### PR TITLE
Update to latest Babylon Native (submodule)

### DIFF
--- a/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
+++ b/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
@@ -33,11 +33,7 @@ target_include_directories(javascript_engine INTERFACE "${ANDROID_JSC_INCPATH}")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/")
 
 set(BABYLON_NATIVE_DIR "${CMAKE_CURRENT_LIST_DIR}/../submodules/BabylonNative")
-add_subdirectory(${BABYLON_NATIVE_DIR}/Dependencies/ ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/Dependencies/)
-add_subdirectory(${BABYLON_NATIVE_DIR}/Core/ ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/Core/)
-add_subdirectory(${BABYLON_NATIVE_DIR}/Plugins/ ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/Plugins/)
-add_subdirectory(${BABYLON_NATIVE_DIR}/Polyfills/ ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/Polyfills/)
-#add_subdirectory(${BABYLON_NATIVE_DIR} ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/) # TODO: We can probably switch to just adding the Babylon Native top level dir instead of the individual folders.
+add_subdirectory(${BABYLON_NATIVE_DIR} ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/)
 
 add_library(BabylonNative SHARED
     src/main/cpp/BabylonNativeInterop.cpp)

--- a/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
+++ b/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
@@ -36,6 +36,7 @@ set(BABYLON_NATIVE_DIR "${CMAKE_CURRENT_LIST_DIR}/../submodules/BabylonNative")
 add_subdirectory(${BABYLON_NATIVE_DIR}/Dependencies/ ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/Dependencies/)
 add_subdirectory(${BABYLON_NATIVE_DIR}/Core/ ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/Core/)
 add_subdirectory(${BABYLON_NATIVE_DIR}/Plugins/ ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/Plugins/)
+add_subdirectory(${BABYLON_NATIVE_DIR}/Polyfills/ ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/Polyfills/)
 #add_subdirectory(${BABYLON_NATIVE_DIR} ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/) # TODO: We can probably switch to just adding the Babylon Native top level dir instead of the individual folders.
 
 add_library(BabylonNative SHARED
@@ -52,4 +53,5 @@ target_link_libraries(BabylonNative
     arcana
     JsRuntime
     NativeWindow
-    NativeEngine)
+    NativeEngine
+    Window)

--- a/Apps/Playground/node_modules/react-native-babylon/android/build.gradle
+++ b/Apps/Playground/node_modules/react-native-babylon/android/build.gradle
@@ -23,9 +23,8 @@ def safeExtGet(prop, fallback) {
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
-def jscBaseDir = "${buildDir}/JSC"
-def jscIncDir = "${jscBaseDir}/include"
-def jscLibDir = "${jscBaseDir}/lib"
+def jscIncDir = "${buildDir}/JSC/include"
+def extractedLibDir = "${buildDir}/lib"
 
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
@@ -61,28 +60,15 @@ android {
             cmake {
                 abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
                 arguments '-DANDROID_STL=c++_static',
-                        '-DHTTP_ONLY=OFF',
-                        '-DCMAKE_USE_OPENSSL=ON',
-                        '-DBUILD_CURL_EXE=OFF',
-                        '-DBUILD_CURL_TESTS=OFF',
-                        '-DCURL_STATICLIB=ON',
-                        '-DUSE_UNIX_SOCKETS=0',
-                        '-DHAVE_FSETXATTR=0',
-                        '-DHAVE_LIBSOCKET=0',
-                        '-DCURL_DISABLE_FTP=OFF',
-                        '-DCURL_DISABLE_LDAP=ON',
-                        '-DCURL_DISABLE_TELNET=ON',
-                        '-DCURL_DISABLE_DICT=ON',
-                        '-DCURL_DISABLE_TFTP=ON',
-                        '-DCURL_DISABLE_IMAP=ON',
-                        '-DCURL_DISABLE_POP3=ON',
-                        '-DCURL_DISABLE_SMTP=ON',
                         '-DENABLE_GLSLANG_BINARIES=OFF',
                         '-DSPIRV_CROSS_CLI=OFF',
-                        '-DHAVE_LIBIDN2=OFF',
-                        "-DANDROID_JSC_LIBPATH=${jscLibDir}/jni",
-                        "-DANDROID_JSC_INCPATH=${jscIncDir}"
+                        "-DANDROID_JSC_LIBPATH=${extractedLibDir}/jni",
+                        "-DANDROID_JSC_INCPATH=${jscIncDir}",
+                        "-DARCORE_LIBPATH=${extractedLibDir}/jni"
             }
+        }
+        ndk {
+            abiFilters "arm64-v8a", "armeabi-v7a", "x86"
         }
     }
     lintOptions {
@@ -119,8 +105,10 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    //natives jscFlavor
+    implementation 'com.google.ar:core:1.14.0'
+
     natives 'org.webkit:android-jsc:+'
+    natives 'com.google.ar:core:1.14.0'
 }
 
 def configureReactNativePom(def pom) {
@@ -205,7 +193,7 @@ task extractNativeLibraries() {
         configurations.natives.files.each { f ->
             copy {
                 from zipTree(f)
-                into jscLibDir
+                into extractedLibDir
                 include "jni/**/*"
             }
         }

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -1,8 +1,9 @@
 #include <jni.h>
 
 #include <Babylon/JsRuntime.h>
-#include <Babylon/NativeWindow.h>
-#include <Babylon/NativeEngine.h>
+#include <Babylon/Plugins/NativeWindow.h>
+#include <Babylon/Plugins/NativeEngine.h>
+#include <Babylon/Polyfills/Window.h>
 
 #include <arcana/threading/task_schedulers.h>
 
@@ -47,24 +48,26 @@ namespace Babylon
             auto width = static_cast<size_t>(ANativeWindow_getWidth(windowPtr));
             auto height = static_cast<size_t>(ANativeWindow_getHeight(windowPtr));
 
-            InitializeGraphics(windowPtr, width, height);
-            InitializeNativeEngine(m_env);
-            NativeWindow::Initialize(m_env, windowPtr, width, height);
+            Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
+            Babylon::Plugins::NativeEngine::Initialize(m_env);
+            Babylon::Plugins::NativeWindow::Initialize(m_env, windowPtr, width, height);
+
+            Babylon::Polyfills::Window::Initialize(m_env);
 
             // TODO: This shouldn't be necessary, but for some reason results in a significant increase in frame rate. Need to figure this out.
-            ReinitializeNativeEngine(m_env, windowPtr, width, height);
+            Babylon::Plugins::NativeEngine::Reinitialize(m_env, windowPtr, width, height);
         }
 
         ~Native()
         {
-            DeinitializeGraphics();
+            Babylon::Plugins::NativeEngine::DeinitializeGraphics();
         }
 
         void Refresh(ANativeWindow* windowPtr)
         {
             auto width = static_cast<size_t>(ANativeWindow_getWidth(windowPtr));
             auto height = static_cast<size_t>(ANativeWindow_getHeight(windowPtr));
-            ReinitializeNativeEngine(m_env, windowPtr, width, height);
+            Babylon::Plugins::NativeEngine::Reinitialize(m_env, windowPtr, width, height);
         }
 
     private:


### PR DESCRIPTION
- Update the submodule to the latest commit in master.
- Include ARCore in the list of dependencies and native libs to extract.
- Update native lib extraction to be to a generic folder since it includes ARCore in addition to JSC now.
- Remove all the old curl/openssl related defines.
- Just include the top level CMakeLists.txt of Babylon Native instead of individual directories so we don't have to keep it in sync (e.g. in this case adding the new Polyfills directory).
- Minor updates to BabylonNativeInterop.cpp to account for Plugins/Polyfills refactor.