### PR TITLE
Add NativeInput to the interop layer

### DIFF
--- a/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
+++ b/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
@@ -50,5 +50,5 @@ target_link_libraries(BabylonNative
     JsRuntime
     NativeWindow
     NativeEngine
-    Window
-    DeviceInputSystem)
+    NativeInput
+    Window)

--- a/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
+++ b/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
@@ -50,4 +50,5 @@ target_link_libraries(BabylonNative
     JsRuntime
     NativeWindow
     NativeEngine
-    Window)
+    Window
+    DeviceInputSystem)

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -3,7 +3,7 @@
 #include <Babylon/JsRuntime.h>
 #include <Babylon/Plugins/NativeWindow.h>
 #include <Babylon/Plugins/NativeEngine.h>
-#include <Babylon/Plugins/DeviceInputSystem.h>
+#include <Babylon/Plugins/NativeInput.h>
 #include <Babylon/Polyfills/Window.h>
 
 #include <arcana/threading/task_schedulers.h>
@@ -55,7 +55,7 @@ namespace Babylon
 
             Polyfills::Window::Initialize(m_env);
 
-            m_deviceInputSystem = &Babylon::Plugins::DeviceInputSystem::CreateForJavaScript(m_env);
+            m_nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(m_env);
 
             // TODO: This shouldn't be necessary, but for some reason results in a significant increase in frame rate. Need to figure this out.
             Plugins::NativeEngine::Reinitialize(m_env, windowPtr, width, height);
@@ -77,24 +77,24 @@ namespace Babylon
         {
             if (isDown)
             {
-                m_deviceInputSystem->PointerDown(pointerId, buttonId, x, y);
+                m_nativeInput->PointerDown(pointerId, buttonId, x, y);
             }
             else
             {
-                m_deviceInputSystem->PointerUp(pointerId, buttonId, x, y);
+                m_nativeInput->PointerUp(pointerId, buttonId, x, y);
             }
         }
 
         void SetPointerPosition(uint32_t pointerId, uint32_t x, uint32_t y)
         {
-            m_deviceInputSystem->PointerMove(pointerId, x, y);
+            m_nativeInput->PointerMove(pointerId, x, y);
         }
 
     private:
         using looper_scheduler_t = arcana::looper_scheduler<sizeof(std::weak_ptr<Napi::Env>) + sizeof(std::function<void(Napi::Env)>)>;
         Napi::Env m_env;
         JsRuntime* m_runtime;
-        Plugins::DeviceInputSystem* m_deviceInputSystem;
+        Plugins::NativeInput* m_nativeInput;
     };
 }
 

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -3,6 +3,7 @@
 #include <Babylon/JsRuntime.h>
 #include <Babylon/Plugins/NativeWindow.h>
 #include <Babylon/Plugins/NativeEngine.h>
+#include <Babylon/Plugins/DeviceInputSystem.h>
 #include <Babylon/Polyfills/Window.h>
 
 #include <arcana/threading/task_schedulers.h>
@@ -12,6 +13,7 @@
 #include <android/log.h>
 #include <android/native_window.h>
 #include <android/native_window_jni.h>
+#include <android/input.h>
 
 #include <optional>
 #include <sstream>
@@ -43,36 +45,78 @@ namespace Babylon
                 });
             }};
 
-            JsRuntime::CreateForJavaScript(m_env, dispatchFunction);
+            m_runtime = &JsRuntime::CreateForJavaScript(m_env, dispatchFunction);
 
             auto width = static_cast<size_t>(ANativeWindow_getWidth(windowPtr));
             auto height = static_cast<size_t>(ANativeWindow_getHeight(windowPtr));
 
-            Babylon::Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
-            Babylon::Plugins::NativeEngine::Initialize(m_env);
-            Babylon::Plugins::NativeWindow::Initialize(m_env, windowPtr, width, height);
+            Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
+            Plugins::NativeEngine::Initialize(m_env);
+            Plugins::NativeWindow::Initialize(m_env, windowPtr, width, height);
 
-            Babylon::Polyfills::Window::Initialize(m_env);
+            Polyfills::Window::Initialize(m_env);
+
+            m_deviceInputSystem = &Babylon::Plugins::DeviceInputSystem::CreateForJavaScript(m_env);
 
             // TODO: This shouldn't be necessary, but for some reason results in a significant increase in frame rate. Need to figure this out.
-            Babylon::Plugins::NativeEngine::Reinitialize(m_env, windowPtr, width, height);
+            Plugins::NativeEngine::Reinitialize(m_env, windowPtr, width, height);
         }
 
         ~Native()
         {
-            Babylon::Plugins::NativeEngine::DeinitializeGraphics();
+            Plugins::NativeEngine::DeinitializeGraphics();
         }
 
         void Refresh(ANativeWindow* windowPtr)
         {
             auto width = static_cast<size_t>(ANativeWindow_getWidth(windowPtr));
             auto height = static_cast<size_t>(ANativeWindow_getHeight(windowPtr));
-            Babylon::Plugins::NativeEngine::Reinitialize(m_env, windowPtr, width, height);
+            Plugins::NativeEngine::Reinitialize(m_env, windowPtr, width, height);
+        }
+
+        void SetPointerButtonState(uint32_t pointerId, uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
+        {
+            if (isDown)
+            {
+                m_deviceInputSystem->PointerDown(pointerId, buttonId, x, y);
+            }
+            else
+            {
+                m_deviceInputSystem->PointerUp(pointerId, buttonId, x, y);
+            }
+        }
+
+        void SetPointerPosition(uint32_t pointerId, uint32_t x, uint32_t y)
+        {
+            m_deviceInputSystem->PointerMove(pointerId, x, y);
+        }
+
+        void ReportPointerEvent(uint32_t pointerId, uint32_t maskedAction, uint32_t buttonId, uint32_t x, uint32_t y)
+        {
+            switch(maskedAction)
+            {
+                case AMOTION_EVENT_ACTION_DOWN:
+                case AMOTION_EVENT_ACTION_POINTER_DOWN:
+                    m_deviceInputSystem->PointerDown(pointerId, buttonId, x, y);
+                    break;
+                case AMOTION_EVENT_ACTION_UP:
+                case AMOTION_EVENT_ACTION_POINTER_UP:
+                    m_deviceInputSystem->PointerUp(pointerId, buttonId, x, y);
+                    break;
+                case AMOTION_EVENT_ACTION_MOVE:
+                    m_deviceInputSystem->PointerMove(pointerId, x, y);
+                    break;
+                default:
+                    // Ignore other pointer input.
+                    break;
+            }
         }
 
     private:
         using looper_scheduler_t = arcana::looper_scheduler<sizeof(std::weak_ptr<Napi::Env>) + sizeof(std::function<void(Napi::Env)>)>;
         Napi::Env m_env;
+        JsRuntime* m_runtime;
+        Plugins::DeviceInputSystem* m_deviceInputSystem;
     };
 }
 
@@ -89,6 +133,24 @@ extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_ref
     auto native = reinterpret_cast<Babylon::Native*>(instanceRef);
     ANativeWindow* windowPtr = ANativeWindow_fromSurface(env, surface);
     native->Refresh(windowPtr);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_reportPointerEvent(JNIEnv* env, jclass obj, jlong instanceRef, jint pointerId, jint maskedAction, jint buttonId, jint x, jint y)
+{
+    auto native = reinterpret_cast<Babylon::Native*>(instanceRef);
+    native->ReportPointerEvent(static_cast<uint32_t>(pointerId), static_cast<uint32_t>(maskedAction), static_cast<uint32_t>(buttonId), static_cast<uint32_t>(x), static_cast<uint32_t>(y));
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_setPointerButtonState(JNIEnv* env, jclass obj, jlong instanceRef, jint pointerId, jint buttonId, jboolean isDown, jint x, jint y)
+{
+    auto native = reinterpret_cast<Babylon::Native*>(instanceRef);
+    native->SetPointerButtonState(static_cast<uint32_t>(pointerId), static_cast<uint32_t>(buttonId), isDown, static_cast<uint32_t>(x), static_cast<uint32_t>(y));
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_setPointerPosition(JNIEnv* env, jclass obj, jlong instanceRef, jint pointerId, jint x, jint y)
+{
+    auto native = reinterpret_cast<Babylon::Native*>(instanceRef);
+    native->SetPointerPosition(static_cast<uint32_t>(pointerId), static_cast<uint32_t>(x), static_cast<uint32_t>(y));
 }
 
 extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_destroy(JNIEnv* env, jclass obj, jlong instanceRef)

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -13,7 +13,6 @@
 #include <android/log.h>
 #include <android/native_window.h>
 #include <android/native_window_jni.h>
-#include <android/input.h>
 
 #include <optional>
 #include <sstream>
@@ -91,27 +90,6 @@ namespace Babylon
             m_deviceInputSystem->PointerMove(pointerId, x, y);
         }
 
-        void ReportPointerEvent(uint32_t pointerId, uint32_t maskedAction, uint32_t buttonId, uint32_t x, uint32_t y)
-        {
-            switch(maskedAction)
-            {
-                case AMOTION_EVENT_ACTION_DOWN:
-                case AMOTION_EVENT_ACTION_POINTER_DOWN:
-                    m_deviceInputSystem->PointerDown(pointerId, buttonId, x, y);
-                    break;
-                case AMOTION_EVENT_ACTION_UP:
-                case AMOTION_EVENT_ACTION_POINTER_UP:
-                    m_deviceInputSystem->PointerUp(pointerId, buttonId, x, y);
-                    break;
-                case AMOTION_EVENT_ACTION_MOVE:
-                    m_deviceInputSystem->PointerMove(pointerId, x, y);
-                    break;
-                default:
-                    // Ignore other pointer input.
-                    break;
-            }
-        }
-
     private:
         using looper_scheduler_t = arcana::looper_scheduler<sizeof(std::weak_ptr<Napi::Env>) + sizeof(std::function<void(Napi::Env)>)>;
         Napi::Env m_env;
@@ -133,12 +111,6 @@ extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_ref
     auto native = reinterpret_cast<Babylon::Native*>(instanceRef);
     ANativeWindow* windowPtr = ANativeWindow_fromSurface(env, surface);
     native->Refresh(windowPtr);
-}
-
-extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_reportPointerEvent(JNIEnv* env, jclass obj, jlong instanceRef, jint pointerId, jint maskedAction, jint buttonId, jint x, jint y)
-{
-    auto native = reinterpret_cast<Babylon::Native*>(instanceRef);
-    native->ReportPointerEvent(static_cast<uint32_t>(pointerId), static_cast<uint32_t>(maskedAction), static_cast<uint32_t>(buttonId), static_cast<uint32_t>(x), static_cast<uint32_t>(y));
 }
 
 extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_setPointerButtonState(JNIEnv* env, jclass obj, jlong instanceRef, jint pointerId, jint buttonId, jboolean isDown, jint x, jint y)

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -1,6 +1,7 @@
 package com.reactlibrary;
 
 import android.util.Log;
+import android.view.MotionEvent;
 import android.view.Surface;
 
 import com.babylon.GetJsGlobalContextRef;
@@ -24,6 +25,9 @@ final class BabylonNativeInterop {
 
     private static native long create(long jsContextRef, Surface surface);
     private static native void refresh(long instanceRef, Surface surface);
+    private static native void reportPointerEvent(long instanceRef, int pointerId, int maskedAction, int buttonId, int x, int y);
+    private static native void setPointerButtonState(long instanceRef, int pointerId, int buttonId, boolean isDown, int x, int y);
+    private static native void setPointerPosition(long instanceRef, int pointerId, int x, int y);
     private static native void destroy(long instanceRef);
 
     // Must be called from the Android UI thread
@@ -72,6 +76,57 @@ final class BabylonNativeInterop {
                 BabylonNativeInterop.refresh(instanceRef, surface);
             }
         });
+    }
+
+    static void reportMotionEvent(ReactContext reactContext, MotionEvent motionEvent) {
+        double callId = Math.random();
+        {
+            int maskedAction = motionEvent.getActionMasked();
+            boolean isPointerDown = maskedAction == MotionEvent.ACTION_DOWN || maskedAction == MotionEvent.ACTION_POINTER_DOWN;
+            boolean isPointerUp = maskedAction == MotionEvent.ACTION_UP || maskedAction == MotionEvent.ACTION_POINTER_UP;
+            if (isPointerDown || isPointerUp) {
+                Log.i("CallId", "Outer call id: " + callId);
+            }
+        }
+
+//        reactContext.runOnJSQueueThread(() -> {
+            CompletableFuture<Long> instanceRefFuture = BabylonNativeInterop.nativeInstances.get(reactContext.getJavaScriptContextHolder());
+            if (instanceRefFuture != null) {
+                Long instanceRef = instanceRefFuture.getNow(null);
+                if (instanceRef != null) {
+                    int maskedAction = motionEvent.getActionMasked();
+
+//                    int count = motionEvent.getPointerCount();
+//
+//                    Log.i("TAG", "pointerIndex: " + pointerIndex);
+//                    Log.i("TAG", "pointerCount: " + count);
+//                    BabylonNativeInterop.reportPointerEvent(instanceRef, pointerId, maskedAction, buttonId, x, y);
+
+                    boolean isPointerDown = maskedAction == MotionEvent.ACTION_DOWN || maskedAction == MotionEvent.ACTION_POINTER_DOWN;
+                    boolean isPointerUp = maskedAction == MotionEvent.ACTION_UP || maskedAction == MotionEvent.ACTION_POINTER_UP;
+                    boolean isPointerMove = maskedAction == MotionEvent.ACTION_MOVE;
+
+                    if (isPointerDown || isPointerUp) {
+                        Log.i("CallId", "Inner call id: " + callId);
+                        int pointerIndex = motionEvent.getActionIndex();
+                        int pointerId = motionEvent.getPointerId(pointerIndex);
+                        int buttonId = motionEvent.getActionButton();
+                        int x = (int)motionEvent.getX(pointerIndex);
+                        int y = (int)motionEvent.getY(pointerIndex);
+                        Log.i("TAG", "Set button state: " + pointerId + "|" + buttonId + "|" + isPointerDown);
+                        BabylonNativeInterop.setPointerButtonState(instanceRef, pointerId, buttonId, isPointerDown, x, y);
+                    } else if (isPointerMove) {
+                        for (int pointerIndex = 0; pointerIndex < motionEvent.getPointerCount(); pointerIndex++) {
+                            int pointerId = motionEvent.getPointerId(pointerIndex);
+                            int x = (int)motionEvent.getX(pointerIndex);
+                            int y = (int)motionEvent.getY(pointerIndex);
+                            //Log.i("TAG", "Set pointer position: " + pointerId);
+                            BabylonNativeInterop.setPointerPosition(instanceRef, pointerId, x, y);
+                        }
+                    }
+                }
+            }
+//        });
     }
 
     // Must be called from the Android UI thread

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -25,7 +25,6 @@ final class BabylonNativeInterop {
 
     private static native long create(long jsContextRef, Surface surface);
     private static native void refresh(long instanceRef, Surface surface);
-    private static native void reportPointerEvent(long instanceRef, int pointerId, int maskedAction, int buttonId, int x, int y);
     private static native void setPointerButtonState(long instanceRef, int pointerId, int buttonId, boolean isDown, int x, int y);
     private static native void setPointerPosition(long instanceRef, int pointerId, int x, int y);
     private static native void destroy(long instanceRef);
@@ -79,54 +78,32 @@ final class BabylonNativeInterop {
     }
 
     static void reportMotionEvent(ReactContext reactContext, MotionEvent motionEvent) {
-        double callId = Math.random();
-        {
-            int maskedAction = motionEvent.getActionMasked();
-            boolean isPointerDown = maskedAction == MotionEvent.ACTION_DOWN || maskedAction == MotionEvent.ACTION_POINTER_DOWN;
-            boolean isPointerUp = maskedAction == MotionEvent.ACTION_UP || maskedAction == MotionEvent.ACTION_POINTER_UP;
-            if (isPointerDown || isPointerUp) {
-                Log.i("CallId", "Outer call id: " + callId);
-            }
-        }
+        CompletableFuture<Long> instanceRefFuture = BabylonNativeInterop.nativeInstances.get(reactContext.getJavaScriptContextHolder());
+        if (instanceRefFuture != null) {
+            Long instanceRef = instanceRefFuture.getNow(null);
+            if (instanceRef != null) {
+                int maskedAction = motionEvent.getActionMasked();
+                boolean isPointerDown = maskedAction == MotionEvent.ACTION_DOWN || maskedAction == MotionEvent.ACTION_POINTER_DOWN;
+                boolean isPointerUp = maskedAction == MotionEvent.ACTION_UP || maskedAction == MotionEvent.ACTION_POINTER_UP;
+                boolean isPointerMove = maskedAction == MotionEvent.ACTION_MOVE;
 
-//        reactContext.runOnJSQueueThread(() -> {
-            CompletableFuture<Long> instanceRefFuture = BabylonNativeInterop.nativeInstances.get(reactContext.getJavaScriptContextHolder());
-            if (instanceRefFuture != null) {
-                Long instanceRef = instanceRefFuture.getNow(null);
-                if (instanceRef != null) {
-                    int maskedAction = motionEvent.getActionMasked();
-
-//                    int count = motionEvent.getPointerCount();
-//
-//                    Log.i("TAG", "pointerIndex: " + pointerIndex);
-//                    Log.i("TAG", "pointerCount: " + count);
-//                    BabylonNativeInterop.reportPointerEvent(instanceRef, pointerId, maskedAction, buttonId, x, y);
-
-                    boolean isPointerDown = maskedAction == MotionEvent.ACTION_DOWN || maskedAction == MotionEvent.ACTION_POINTER_DOWN;
-                    boolean isPointerUp = maskedAction == MotionEvent.ACTION_UP || maskedAction == MotionEvent.ACTION_POINTER_UP;
-                    boolean isPointerMove = maskedAction == MotionEvent.ACTION_MOVE;
-
-                    if (isPointerDown || isPointerUp) {
-                        Log.i("CallId", "Inner call id: " + callId);
-                        int pointerIndex = motionEvent.getActionIndex();
+                if (isPointerDown || isPointerUp) {
+                    int pointerIndex = motionEvent.getActionIndex();
+                    int pointerId = motionEvent.getPointerId(pointerIndex);
+                    int buttonId = motionEvent.getActionButton();
+                    int x = (int)motionEvent.getX(pointerIndex);
+                    int y = (int)motionEvent.getY(pointerIndex);
+                    BabylonNativeInterop.setPointerButtonState(instanceRef, pointerId, buttonId, isPointerDown, x, y);
+                } else if (isPointerMove) {
+                    for (int pointerIndex = 0; pointerIndex < motionEvent.getPointerCount(); pointerIndex++) {
                         int pointerId = motionEvent.getPointerId(pointerIndex);
-                        int buttonId = motionEvent.getActionButton();
                         int x = (int)motionEvent.getX(pointerIndex);
                         int y = (int)motionEvent.getY(pointerIndex);
-                        Log.i("TAG", "Set button state: " + pointerId + "|" + buttonId + "|" + isPointerDown);
-                        BabylonNativeInterop.setPointerButtonState(instanceRef, pointerId, buttonId, isPointerDown, x, y);
-                    } else if (isPointerMove) {
-                        for (int pointerIndex = 0; pointerIndex < motionEvent.getPointerCount(); pointerIndex++) {
-                            int pointerId = motionEvent.getPointerId(pointerIndex);
-                            int x = (int)motionEvent.getX(pointerIndex);
-                            int y = (int)motionEvent.getY(pointerIndex);
-                            //Log.i("TAG", "Set pointer position: " + pointerId);
-                            BabylonNativeInterop.setPointerPosition(instanceRef, pointerId, x, y);
-                        }
+                        BabylonNativeInterop.setPointerPosition(instanceRef, pointerId, x, y);
                     }
                 }
             }
-//        });
+        }
     }
 
     // Must be called from the Android UI thread

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/EngineView.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/EngineView.java
@@ -1,7 +1,5 @@
 package com.reactlibrary;
 
-import android.util.Log;
-import android.view.InputDevice;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -36,9 +34,6 @@ public final class EngineView extends SurfaceView implements SurfaceHolder.Callb
 
     @Override
     public boolean onTouch(View view, MotionEvent motionEvent) {
-        if (motionEvent.getAction() != MotionEvent.ACTION_MOVE) {
-            Log.i("Sync MotionEvent", "PointerId: " + motionEvent.getPointerId(motionEvent.getActionIndex()) + " " + motionEvent.getActionMasked() + " " + motionEvent.isFromSource(InputDevice.SOURCE_TOUCHSCREEN) + " " + motionEvent.getActionButton());
-        }
         BabylonNativeInterop.reportMotionEvent(this.reactContext, motionEvent);
         return true;
     }

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/EngineView.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/EngineView.java
@@ -1,22 +1,22 @@
 package com.reactlibrary;
 
+import android.util.Log;
+import android.view.InputDevice;
+import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.View;
 
 import com.facebook.react.bridge.ReactContext;
 
-public final class EngineView extends SurfaceView implements SurfaceHolder.Callback2 {
+public final class EngineView extends SurfaceView implements SurfaceHolder.Callback, View.OnTouchListener {
     private final ReactContext reactContext;
 
     public EngineView(ReactContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         this.getHolder().addCallback(this);
-    }
-
-    @Override
-    public void surfaceRedrawNeeded(SurfaceHolder surfaceHolder) {
-
+        this.setOnTouchListener(this);
     }
 
     @Override
@@ -32,5 +32,14 @@ public final class EngineView extends SurfaceView implements SurfaceHolder.Callb
     @Override
     public void surfaceDestroyed(SurfaceHolder surfaceHolder) {
 
+    }
+
+    @Override
+    public boolean onTouch(View view, MotionEvent motionEvent) {
+        if (motionEvent.getAction() != MotionEvent.ACTION_MOVE) {
+            Log.i("Sync MotionEvent", "PointerId: " + motionEvent.getPointerId(motionEvent.getActionIndex()) + " " + motionEvent.getActionMasked() + " " + motionEvent.isFromSource(InputDevice.SOURCE_TOUCHSCREEN) + " " + motionEvent.getActionButton());
+        }
+        BabylonNativeInterop.reportMotionEvent(this.reactContext, motionEvent);
+        return true;
     }
 }


### PR DESCRIPTION
These changes depend on the changes in https://github.com/BabylonJS/BabylonNative/pull/234, which will be included as a submodule update in this PR once the dependent PR is completed.

With these changes, the interop layer in the React Native module now consumes `NativeInput` and forwards input events from the native `SurfaceView` to `NativeInput`.  Ideally we'd find a better way to share more of this interop code through Babylon Native itself (rather than being way up here in the React Native layer), but I think we should wait and figure this out in the future.