### PR TITLE
Integrate XR support

### DIFF
--- a/Apps/Playground/android/app/src/main/AndroidManifest.xml
+++ b/Apps/Playground/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   package="com.playground">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA"/>
 
     <application
       android:name=".MainApplication"
@@ -21,6 +22,7 @@
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+      <meta-data android:name="com.google.ar.core" android:value="optional" />
     </application>
 
 </manifest>

--- a/Apps/Playground/node_modules/react-native-babylon/EngineHook.ts
+++ b/Apps/Playground/node_modules/react-native-babylon/EngineHook.ts
@@ -3,6 +3,8 @@ import { Engine, NativeEngine } from '@babylonjs/core';
 import { BabylonModule } from './BabylonModule';
 import { DisposeEngine } from './EngineHelpers';
 
+declare const window: any;
+
 export function useEngine(): Engine | undefined {
     const [engine, setEngine] = useState<Engine>();
 
@@ -15,7 +17,11 @@ export function useEngine(): Engine | undefined {
             {
                 // TEMP HACK: Override this because Babylon Native uses the presence of window.requestAnimationFrame to decide whether to run the native or JS code path, but React Native polyfills window.requestAnimationFrame.
                 (NativeEngine.prototype as any)._queueNewFrame = function (bindedRenderFunction: any, requester: any) {
-                    this._native.requestAnimationFrame(bindedRenderFunction);
+                    if (requester.requestAnimationFrame && requester !== window) {
+                        requester.requestAnimationFrame(bindedRenderFunction);
+                    } else {
+                        this._native.requestAnimationFrame(bindedRenderFunction);
+                    }
                     return 0;
                 };
 

--- a/Apps/Playground/node_modules/react-native-babylon/EngineHook.ts
+++ b/Apps/Playground/node_modules/react-native-babylon/EngineHook.ts
@@ -42,6 +42,9 @@ export function useEngine(): Engine | undefined {
                     return 0;
                 };
 
+                // Override the WebXRSessionManager.initializeSessionAsync to insert a camera permissions request. It would be cleaner to do this directly in the native XR implementation, but there are a couple problems with that:
+                // 1. React Native does not provide a way to hook into the permissions request result (at least on Android).
+                // 2. If it is done on the native side, then we need one implementation per platform.
                 const originalInitializeSessionAsync: (...args: any[]) => Promise<any> = WebXRSessionManager.prototype.initializeSessionAsync;
                 WebXRSessionManager.prototype.initializeSessionAsync = async function (...args: any[]): Promise<any> {
                     const cameraPermission = Platform.select({
@@ -49,16 +52,19 @@ export function useEngine(): Engine | undefined {
                         ios: PERMISSIONS.IOS.CAMERA,
                     });
 
+                    // Only Android and iOS are supported.
                     if (cameraPermission === undefined) {
                         throw new DOMException(DOMError.NotSupportedError);
                     }
 
+                    // If the permission has not been granted yet, but also not been blocked, then request permission.
                     let permissionStatus = await check(cameraPermission);
                     if (permissionStatus == "denied")
                     {
                         permissionStatus = await request(cameraPermission);
                     }
 
+                    // If the permission has still not been granted, then throw an appropriate exception, otherwise continue with the actual XR session initialization.
                     switch(permissionStatus) {
                         case "unavailable":
                             throw new DOMException(DOMError.NotSupportedError);

--- a/Apps/Playground/node_modules/react-native-babylon/EngineHook.ts
+++ b/Apps/Playground/node_modules/react-native-babylon/EngineHook.ts
@@ -1,9 +1,26 @@
 import { useEffect, useState } from 'react';
-import { Engine, NativeEngine } from '@babylonjs/core';
+import { Platform } from 'react-native';
+import { PERMISSIONS, check, request } from 'react-native-permissions';
+import { Engine, NativeEngine, WebXRSessionManager } from '@babylonjs/core';
 import { BabylonModule } from './BabylonModule';
 import { DisposeEngine } from './EngineHelpers';
 
 declare const window: any;
+
+// These are errors that are normally thrown by WebXR's requestSession, so we should throw the same errors under similar circumstances so app code can be written the same for browser or native.
+// https://developer.mozilla.org/en-US/docs/Web/API/XRSystem/requestSession
+// https://developer.mozilla.org/en-US/docs/Web/API/DOMException#Error_names
+enum DOMError {
+    NotSupportedError = 9,
+    InvalidStateError = 11,
+    SecurityError = 18,
+}
+
+class DOMException {
+    public constructor(private readonly error: DOMError) { }
+    get code(): number { return this.error; }
+    get name(): string { return DOMError[this.error]; }
+}
 
 export function useEngine(): Engine | undefined {
     const [engine, setEngine] = useState<Engine>();
@@ -24,6 +41,34 @@ export function useEngine(): Engine | undefined {
                     }
                     return 0;
                 };
+
+                const originalInitializeSessionAsync: (...args: any[]) => Promise<any> = WebXRSessionManager.prototype.initializeSessionAsync;
+                WebXRSessionManager.prototype.initializeSessionAsync = async function (...args: any[]): Promise<any> {
+                    const cameraPermission = Platform.select({
+                        android: PERMISSIONS.ANDROID.CAMERA,
+                        ios: PERMISSIONS.IOS.CAMERA,
+                    });
+
+                    if (cameraPermission === undefined) {
+                        throw new DOMException(DOMError.NotSupportedError);
+                    }
+
+                    let permissionStatus = await check(cameraPermission);
+                    if (permissionStatus == "denied")
+                    {
+                        permissionStatus = await request(cameraPermission);
+                    }
+
+                    switch(permissionStatus) {
+                        case "unavailable":
+                            throw new DOMException(DOMError.NotSupportedError);
+                        case "denied":
+                        case "blocked":
+                            throw new DOMException(DOMError.SecurityError);
+                        case "granted":
+                            return originalInitializeSessionAsync.apply(this, args);
+                    }
+                }
 
                 setEngine(engine = new NativeEngine());
             }

--- a/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
+++ b/Apps/Playground/node_modules/react-native-babylon/android/CMakeLists.txt
@@ -47,8 +47,10 @@ target_link_libraries(BabylonNative
     log
     -lz
     arcana
+    AndroidExtensions
     JsRuntime
     NativeWindow
     NativeEngine
     NativeInput
+    NativeXr
     Window)

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -36,7 +36,7 @@ namespace Babylon
     public:
         // This class must be constructed from the JavaScript thread
         Native(JSGlobalContextRef jsContext, ANativeWindow* windowPtr)
-        : m_env{ Napi::Attach<JSContextRef>(jsContext) }
+        : m_env{ Napi::Attach(jsContext) }
         {
             auto looper_scheduler = std::make_shared<looper_scheduler_t>(looper_scheduler_t::get_for_current_thread());
 
@@ -68,6 +68,7 @@ namespace Babylon
         ~Native()
         {
             Plugins::NativeEngine::DeinitializeGraphics();
+            Napi::Detach(m_env);
         }
 
         void Refresh(ANativeWindow* windowPtr)

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -68,7 +68,8 @@ namespace Babylon
         ~Native()
         {
             Plugins::NativeEngine::DeinitializeGraphics();
-            Napi::Detach(m_env);
+            // TODO: Figure out why this causes the app to crash
+            //Napi::Detach(m_env);
         }
 
         void Refresh(ANativeWindow* windowPtr)

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -102,7 +102,7 @@ namespace Babylon
     };
 }
 
-extern "C" JNIEXPORT jlong JNICALL Java_com_reactlibrary_BabylonNativeInterop_create(JNIEnv* env, jclass obj, jobject appContext, jlong jsContextRef, jobject surface)
+extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_initialize(JNIEnv* env, jclass obj, jobject context)
 {
     JavaVM* javaVM{};
     if (env->GetJavaVM(&javaVM) != JNI_OK)
@@ -110,12 +110,11 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_reactlibrary_BabylonNativeInterop_cr
         throw std::runtime_error("Failed to get Java VM");
     }
 
-    // TODO: This should be cleaned up via env->DeleteGlobalRef
-    auto globalAppContext = env->NewGlobalRef(appContext);
+    android::global::Initialize(javaVM, context);
+}
 
-    android::global::Initialize(javaVM, globalAppContext);
-
-
+extern "C" JNIEXPORT jlong JNICALL Java_com_reactlibrary_BabylonNativeInterop_create(JNIEnv* env, jclass obj, jlong jsContextRef, jobject surface)
+{
     auto jsContext = reinterpret_cast<JSGlobalContextRef>(jsContextRef);
     ANativeWindow* windowPtr = ANativeWindow_fromSurface(env, surface);
     auto native = new Babylon::Native(jsContext, windowPtr);

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -113,6 +113,16 @@ extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_ini
     android::global::Initialize(javaVM, context);
 }
 
+extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_pause(JNIEnv* env, jclass obj)
+{
+    android::global::Pause();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_resume(JNIEnv* env, jclass obj)
+{
+    android::global::Resume();
+}
+
 extern "C" JNIEXPORT jlong JNICALL Java_com_reactlibrary_BabylonNativeInterop_create(JNIEnv* env, jclass obj, jlong jsContextRef, jobject surface)
 {
     auto jsContext = reinterpret_cast<JSGlobalContextRef>(jsContextRef);

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -4,7 +4,10 @@
 #include <Babylon/Plugins/NativeWindow.h>
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/NativeInput.h>
+#include <Babylon/Plugins/NativeXr.h>
 #include <Babylon/Polyfills/Window.h>
+
+#include <AndroidExtensions/Globals.h>
 
 #include <arcana/threading/task_schedulers.h>
 
@@ -33,7 +36,7 @@ namespace Babylon
     public:
         // This class must be constructed from the JavaScript thread
         Native(JSGlobalContextRef jsContext, ANativeWindow* windowPtr)
-        : m_env{ Napi::Attach(jsContext) }
+        : m_env{ Napi::Attach<JSContextRef>(jsContext) }
         {
             auto looper_scheduler = std::make_shared<looper_scheduler_t>(looper_scheduler_t::get_for_current_thread());
 
@@ -52,6 +55,7 @@ namespace Babylon
             Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
             Plugins::NativeEngine::Initialize(m_env);
             Plugins::NativeWindow::Initialize(m_env, windowPtr, width, height);
+            Plugins::NativeXr::Initialize(m_env);
 
             Polyfills::Window::Initialize(m_env);
 
@@ -98,8 +102,20 @@ namespace Babylon
     };
 }
 
-extern "C" JNIEXPORT jlong JNICALL Java_com_reactlibrary_BabylonNativeInterop_create(JNIEnv* env, jclass obj, jlong jsContextRef, jobject surface)
+extern "C" JNIEXPORT jlong JNICALL Java_com_reactlibrary_BabylonNativeInterop_create(JNIEnv* env, jclass obj, jobject appContext, jlong jsContextRef, jobject surface)
 {
+    JavaVM* javaVM{};
+    if (env->GetJavaVM(&javaVM) != JNI_OK)
+    {
+        throw std::runtime_error("Failed to get Java VM");
+    }
+
+    // TODO: This should be cleaned up via env->DeleteGlobalRef
+    auto globalAppContext = env->NewGlobalRef(appContext);
+
+    android::global::Initialize(javaVM, globalAppContext);
+
+
     auto jsContext = reinterpret_cast<JSGlobalContextRef>(jsContextRef);
     ANativeWindow* windowPtr = ANativeWindow_fromSurface(env, surface);
     auto native = new Babylon::Native(jsContext, windowPtr);

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonModule.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonModule.java
@@ -1,6 +1,7 @@
 package com.reactlibrary;
 
-import android.util.Log;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.annotation.NonNull;
 
@@ -23,7 +24,7 @@ public final class BabylonModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onCatalystInstanceDestroy() {
-        // TODO: Deinitialize BN
+        new Handler(Looper.getMainLooper()).post(BabylonNativeInterop::deinitialize);
     }
 
     @ReactMethod

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonModule.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonModule.java
@@ -1,5 +1,7 @@
 package com.reactlibrary;
 
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.Promise;
@@ -9,11 +11,8 @@ import com.facebook.react.bridge.ReactMethod;
 
 public final class BabylonModule extends ReactContextBaseJavaModule {
 
-    private final ReactApplicationContext reactContext;
-
     BabylonModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        this.reactContext = reactContext;
     }
 
     @NonNull
@@ -22,15 +21,20 @@ public final class BabylonModule extends ReactContextBaseJavaModule {
         return "BabylonModule";
     }
 
+    @Override
+    public void onCatalystInstanceDestroy() {
+        // TODO: Deinitialize BN
+    }
+
     @ReactMethod
     public void initialize(Promise promise) {
         // Ideally we'd do all the initialization here that is scoped to a javascript engine instance, but this is tied up in the view initialization in Babylon Native currently.
         // For now, just await initialization by the first EngineView that is created.
-        BabylonNativeInterop.whenInitialized(this.reactContext).thenAccept(instanceRef -> promise.resolve(instanceRef != 0));
+        BabylonNativeInterop.whenInitialized(this.getReactApplicationContext()).thenAccept(instanceRef -> promise.resolve(instanceRef != 0));
     }
 
     @ReactMethod
     public void whenInitialized(Promise promise) {
-        BabylonNativeInterop.whenInitialized(this.reactContext).thenAccept(instanceRef -> promise.resolve(instanceRef != 0));
+        BabylonNativeInterop.whenInitialized(this.getReactApplicationContext()).thenAccept(instanceRef -> promise.resolve(instanceRef != 0));
     }
 }

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -69,8 +69,7 @@ final class BabylonNativeInterop {
                     reactContext.addLifecycleEventListener(new LifecycleEventListener() {
                         @Override
                         public void onHostResume() {
-                            Log.i("BabylonNativeInterop", "onHostResume");
-                            BabylonNativeInterop.pause();
+                            BabylonNativeInterop.resume();
 
                             // TODO: Remove this when "on demand" permissions request is implemented
                             Activity currentActivity = reactContext.getCurrentActivity();
@@ -81,14 +80,12 @@ final class BabylonNativeInterop {
 
                         @Override
                         public void onHostPause() {
-                            Log.i("BabylonNativeInterop", "onHostPause");
-                            BabylonNativeInterop.resume();
+                            BabylonNativeInterop.pause();
                         }
 
                         @Override
                         public void onHostDestroy() {
-                            Log.i("BabylonNativeInterop", "onHostDestroy");
-                            BabylonNativeInterop.destroyOldNativeInstances(null);
+                            BabylonNativeInterop.deinitialize();
                         }
                     });
 
@@ -132,6 +129,11 @@ final class BabylonNativeInterop {
     // Must be called from the Android UI thread
     static CompletionStage<Long> whenInitialized(ReactContext reactContext) {
         return BabylonNativeInterop.getOrCreateFuture(reactContext);
+    }
+
+    // Must be called from the Android UI thread
+    static void deinitialize() {
+        BabylonNativeInterop.destroyOldNativeInstances(null);
     }
 
     private static CompletableFuture<Long> getOrCreateFuture(ReactContext reactContext) {

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -32,6 +32,8 @@ final class BabylonNativeInterop {
     private static final Hashtable<JavaScriptContextHolder, CompletableFuture<Long>> nativeInstances = new Hashtable<>();
 
     private static native void initialize(Context context);
+    private static native void pause();
+    private static native void resume();
     private static native long create(long jsContextRef, Surface surface);
     private static native void refresh(long instanceRef, Surface surface);
     private static native void setPointerButtonState(long instanceRef, int pointerId, int buttonId, boolean isDown, int x, int y);
@@ -67,8 +69,9 @@ final class BabylonNativeInterop {
                         @Override
                         public void onHostResume() {
                             Log.i("BabylonNativeInterop", "onHostResume");
-                            // TODO: Probably call into native interop to resume (e.g. resume XR/ARCore)
-                            // For now, the consuming app will need to check for and request camera permissions
+                            BabylonNativeInterop.pause();
+
+                            // TODO: Remove this when "on demand" permissions request is implemented
                             Activity currentActivity = reactContext.getCurrentActivity();
                             if (!(ContextCompat.checkSelfPermission(currentActivity, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)) {
                                 ActivityCompat.requestPermissions(currentActivity, new String[]{Manifest.permission.CAMERA}, 0);
@@ -78,7 +81,7 @@ final class BabylonNativeInterop {
                         @Override
                         public void onHostPause() {
                             Log.i("BabylonNativeInterop", "onHostPause");
-                            // TODO: Probably call into native interop to pause (e.g. resume XR/ARCore)
+                            BabylonNativeInterop.resume();
                         }
 
                         @Override

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -1,15 +1,8 @@
 package com.reactlibrary;
 
-import android.Manifest;
-import android.app.Activity;
 import android.content.Context;
-import android.content.pm.PackageManager;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.Surface;
-
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 
 import com.babylon.GetJsGlobalContextRef;
 import com.facebook.react.bridge.JavaScriptContextHolder;

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -1,8 +1,15 @@
 package com.reactlibrary;
 
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.Surface;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 import com.babylon.GetJsGlobalContextRef;
 import com.facebook.react.bridge.JavaScriptContextHolder;
@@ -23,7 +30,7 @@ final class BabylonNativeInterop {
 
     private static final Hashtable<JavaScriptContextHolder, CompletableFuture<Long>> nativeInstances = new Hashtable<>();
 
-    private static native long create(long jsContextRef, Surface surface);
+    private static native long create(Context appContext, long jsContextRef, Surface surface);
     private static native void refresh(long instanceRef, Surface surface);
     private static native void setPointerButtonState(long instanceRef, int pointerId, int buttonId, boolean isDown, int x, int y);
     private static native void setPointerPosition(long instanceRef, int pointerId, int x, int y);
@@ -46,7 +53,7 @@ final class BabylonNativeInterop {
                     GetJsGlobalContextRef getJsGlobalContextRef = new GetJsGlobalContextRef();
                     long jsContextRef = getJsGlobalContextRef.GetJsGlobalContextRef(jsContextHandle);
 
-                    instanceRef = BabylonNativeInterop.create(jsContextRef, surface);
+                    instanceRef = BabylonNativeInterop.create(reactContext, jsContextRef, surface);
                     final long finalInstanceRef = instanceRef;
 
                     reactContext.addLifecycleEventListener(new LifecycleEventListener() {
@@ -54,6 +61,11 @@ final class BabylonNativeInterop {
                         public void onHostResume() {
                             Log.i("BabylonNativeInterop", "onHostResume");
                             // TODO: Probably call into native interop to resume (e.g. resume XR/ARCore)
+                            // For now, the consuming app will need to check for and request camera permissions
+                            Activity currentActivity = reactContext.getCurrentActivity();
+                            if (!(ContextCompat.checkSelfPermission(currentActivity, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)) {
+                                ActivityCompat.requestPermissions(currentActivity, new String[]{Manifest.permission.CAMERA}, 0);
+                            }
                         }
 
                         @Override

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -70,12 +70,6 @@ final class BabylonNativeInterop {
                         @Override
                         public void onHostResume() {
                             BabylonNativeInterop.resume();
-
-                            // TODO: Remove this when "on demand" permissions request is implemented
-                            Activity currentActivity = reactContext.getCurrentActivity();
-                            if (!(ContextCompat.checkSelfPermission(currentActivity, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED)) {
-                                ActivityCompat.requestPermissions(currentActivity, new String[]{Manifest.permission.CAMERA}, 0);
-                            }
                         }
 
                         @Override

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -28,9 +28,11 @@ final class BabylonNativeInterop {
         System.loadLibrary("BabylonNative");
     }
 
+    private static boolean isInitialized;
     private static final Hashtable<JavaScriptContextHolder, CompletableFuture<Long>> nativeInstances = new Hashtable<>();
 
-    private static native long create(Context appContext, long jsContextRef, Surface surface);
+    private static native void initialize(Context context);
+    private static native long create(long jsContextRef, Surface surface);
     private static native void refresh(long instanceRef, Surface surface);
     private static native void setPointerButtonState(long instanceRef, int pointerId, int buttonId, boolean isDown, int x, int y);
     private static native void setPointerPosition(long instanceRef, int pointerId, int x, int y);
@@ -38,6 +40,11 @@ final class BabylonNativeInterop {
 
     // Must be called from the Android UI thread
     static void setView(ReactContext reactContext, Surface surface) {
+        if (!BabylonNativeInterop.isInitialized) {
+            BabylonNativeInterop.initialize(reactContext);
+            BabylonNativeInterop.isInitialized = true;
+        }
+
         BabylonNativeInterop.destroyOldNativeInstances(reactContext);
 
         CompletableFuture<Long> instanceRefFuture = BabylonNativeInterop.getOrCreateFuture(reactContext);
@@ -53,7 +60,7 @@ final class BabylonNativeInterop {
                     GetJsGlobalContextRef getJsGlobalContextRef = new GetJsGlobalContextRef();
                     long jsContextRef = getJsGlobalContextRef.GetJsGlobalContextRef(jsContextHandle);
 
-                    instanceRef = BabylonNativeInterop.create(reactContext, jsContextRef, surface);
+                    instanceRef = BabylonNativeInterop.create(jsContextRef, surface);
                     final long finalInstanceRef = instanceRef;
 
                     reactContext.addLifecycleEventListener(new LifecycleEventListener() {

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -42,6 +42,7 @@ final class BabylonNativeInterop {
 
     // Must be called from the Android UI thread
     static void setView(ReactContext reactContext, Surface surface) {
+        // This is global initialization that only needs to happen once
         if (!BabylonNativeInterop.isInitialized) {
             BabylonNativeInterop.initialize(reactContext);
             BabylonNativeInterop.isInitialized = true;

--- a/Apps/Playground/node_modules/react-native-babylon/package.json
+++ b/Apps/Playground/node_modules/react-native-babylon/package.json
@@ -25,7 +25,8 @@
   "peerDependencies": {
     "@babylonjs/core": "^4.2.0-alpha.9",
     "react": "^16.8.1",
-    "react-native": ">=0.60.0-rc.0 <1.0.x"
+    "react-native": ">=0.60.0-rc.0 <1.0.x",
+    "react-native-permissions": "^2.1.4"
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -14,7 +14,8 @@
     "@react-native-community/slider": "^2.0.9",
     "react": "16.9.0",
     "react-native": "0.62.1",
-    "react-native-babylon": "./node_modules/react-native-babylon"
+    "react-native-babylon": "./node_modules/react-native-babylon",
+    "react-native-permissions": "^2.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/Apps/Playground/yarn.lock
+++ b/Apps/Playground/yarn.lock
@@ -5125,6 +5125,11 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
 react-native-babylon@./node_modules/react-native-babylon:
   version "1.0.0"
 
+react-native-permissions@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-2.1.4.tgz#b0663839d28444d8ea6b5302303b2151ea70d2da"
+  integrity sha512-R1mVPGctEJuOlxoeIBlT5270A+DKngP78rWU0dgMxIuETjGYhBRJMKOp1rQUbp6PxcahfU+PjSTSzsbja5FyDw==
+
 react-native@0.62.1:
   version "0.62.1"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.62.1.tgz#fd0324bedf4c3237c928de582c29403f1e46ea80"


### PR DESCRIPTION
This change brings XR support into the react native layer. One notable change here is with the camera permissions request code I added in the JS layer. See the comments for some explanation, and let me know if anyone has thoughts on the way I currently just "inject" the permissions check into the existing XR session initialization function.

NOTE: This PR depends on https://github.com/BabylonJS/BabylonNative/pull/264. Once this PR is completed, I will update the Babylon Native submodule to master.