### PR TITLE
Update to latest Babylon Native submodule

### DIFF
--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -60,7 +60,7 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
       } else {
         if (box !== undefined && scene !== undefined) {
           const xr = await scene.createDefaultXRExperienceAsync({ disableDefaultUI: true, disableTeleportation: true })
-          const session = await xr.baseExperience.enterXRAsync("immersive-vr", "unbounded", xr.renderTarget);
+          const session = await xr.baseExperience.enterXRAsync("immersive-ar", "unbounded", xr.renderTarget);
           setXrSession(session);
           box.position = (scene.activeCamera as TargetCamera).getFrontPosition(2);
           box.rotate(Vector3.Up(), 3.14159);

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -115,6 +115,11 @@ extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_ini
     android::global::Initialize(javaVM, context);
 }
 
+extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_setCurrentActivity(JNIEnv* env, jclass obj, jobject activity)
+{
+    android::global::SetCurrentActivity(activity);
+}
+
 extern "C" JNIEXPORT void JNICALL Java_com_reactlibrary_BabylonNativeInterop_pause(JNIEnv* env, jclass obj)
 {
     android::global::Pause();

--- a/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+++ b/Apps/Playground/node_modules/react-native-babylon/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
@@ -1,10 +1,13 @@
 package com.reactlibrary;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.view.MotionEvent;
 import android.view.Surface;
 
 import com.babylon.GetJsGlobalContextRef;
+import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
@@ -25,6 +28,7 @@ final class BabylonNativeInterop {
     private static final Hashtable<JavaScriptContextHolder, CompletableFuture<Long>> nativeInstances = new Hashtable<>();
 
     private static native void initialize(Context context);
+    private static native void setCurrentActivity(Activity activity);
     private static native void pause();
     private static native void resume();
     private static native long create(long jsContextRef, Surface surface);
@@ -62,6 +66,7 @@ final class BabylonNativeInterop {
                     reactContext.addLifecycleEventListener(new LifecycleEventListener() {
                         @Override
                         public void onHostResume() {
+                            BabylonNativeInterop.setCurrentActivity(reactContext.getCurrentActivity());
                             BabylonNativeInterop.resume();
                         }
 
@@ -73,6 +78,18 @@ final class BabylonNativeInterop {
                         @Override
                         public void onHostDestroy() {
                             BabylonNativeInterop.deinitialize();
+                        }
+                    });
+
+                    reactContext.addActivityEventListener(new ActivityEventListener() {
+                        @Override
+                        public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+                            // Nothing to do here
+                        }
+
+                        @Override
+                        public void onNewIntent(Intent intent) {
+                            BabylonNativeInterop.setCurrentActivity(reactContext.getCurrentActivity());
                         }
                     });
 


### PR DESCRIPTION
The main changes here are to ensure we are setting the current Android `Activity` since the Android XR code path now requires it (to check for ARCore package installation).