### PR TITLE
Minor fixes in preparation for packaging

### DIFF
--- a/Apps/Playground/node_modules/react-native-babylon/.npmignore
+++ b/Apps/Playground/node_modules/react-native-babylon/.npmignore
@@ -1,0 +1,50 @@
+# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+
+# Package-specific ignores
+#submodules/BabylonNative/Dependencies/bgfx.cmake/bgfx/examples
+submodules/BabylonNative/Dependencies/glslang/Test
+submodules/BabylonNative/Dependencies/xr/Dependencies/arcore-android-sdk/media
+submodules/BabylonNative/Dependencies/xr/Dependencies/arcore-android-sdk/tools
+submodules/BabylonNative/Dependencies/xr/Dependencies/arcore-android-sdk/assets
+submodules/BabylonNative/Dependencies/xr/Dependencies/arcore-android-sdk/samples

--- a/Apps/Playground/node_modules/react-native-babylon/.npmignore
+++ b/Apps/Playground/node_modules/react-native-babylon/.npmignore
@@ -42,7 +42,9 @@ buck-out/
 *.keystore
 
 # Package-specific ignores
-#submodules/BabylonNative/Dependencies/bgfx.cmake/bgfx/examples
+#submodules/BabylonNative/Apps
+submodules/BabylonNative/Dependencies/bgfx.cmake/bgfx/examples/*
+!submodules/BabylonNative/Dependencies/bgfx.cmake/bgfx/examples/common
 submodules/BabylonNative/Dependencies/glslang/Test
 submodules/BabylonNative/Dependencies/xr/Dependencies/arcore-android-sdk/media
 submodules/BabylonNative/Dependencies/xr/Dependencies/arcore-android-sdk/tools

--- a/Apps/Playground/node_modules/react-native-babylon/android/build.gradle
+++ b/Apps/Playground/node_modules/react-native-babylon/android/build.gradle
@@ -215,4 +215,11 @@ task copyFiles {
     }
 }
 
+task validateSdk {
+    def minSdkVersion = safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+    if (minSdkVersion < DEFAULT_MIN_SDK_VERSION) {
+        throw new GradleException("minSdkVersion must be at least ${DEFAULT_MIN_SDK_VERSION} but is currently ${minSdkVersion}")
+    }
+}
+
 preBuild.dependsOn(copyFiles)

--- a/Apps/Playground/node_modules/react-native-babylon/package.json
+++ b/Apps/Playground/node_modules/react-native-babylon/package.json
@@ -23,7 +23,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^4.2.0-alpha.9",
+    "@babylonjs/core": "^4.2.0-alpha.17",
     "react": "^16.8.1",
     "react-native": ">=0.60.0-rc.0 <1.0.x",
     "react-native-permissions": "^2.1.4"

--- a/Apps/Playground/node_modules/react-native-babylon/package.json
+++ b/Apps/Playground/node_modules/react-native-babylon/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-babylon",
   "title": "React Native Babylon",
   "version": "1.0.0",
-  "description": "TODO",
+  "description": "Babylon Native integration into React Native",
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/README.md
+++ b/README.md
@@ -13,19 +13,29 @@ Babylon React Native is in the early phase of its development, and has the follo
 
 This quick overview will help you understand the constructs provided by Babylon React Native and how to use them in a React Native application. See the Playground app's [App.tsx](Apps/Playground/App.tsx) for example usage.
 
+Note that this package has several **peer dependencies**. If these dependencies are unmet, `react-native` will emit warnings. Be sure to add these dependencies to your project.
+
+### Additional Android Requirements
+
+The minimum Android SDK version is 24. This must be set as `minSdkVersion` in the consuming project's `build.gradle` file. 
+
 ### `useEngine`
 
-`useEngine` is a **custom React hook** that manages the lifecycle of a Babylon engine instance in the context of an owning React component. A callback is passed to `useEngine` that receives an engine instance which is used to create and configure scenes. For example:
+`useEngine` is a **custom React hook** that manages the lifecycle of a Babylon engine instance in the context of an owning React component. `useEngine` creates an engine instance **asynchronously** which is used to create and configure scenes. Typically scene initialization code should exist in a `useEffect` triggered by an `engine` state change. For example:
 
 ```tsx
 import { useEngine } from 'react-native-babylon';
 import { Engine, Scene } from '@babylonjs/core';
 
 const MyComponent: FunctionComponent<MyComponentProps> = (props: MyComponentProps) => {
-    useEngine((engine: Engine) => {
-        const scene = new Scene(engine);
-        // Setup the scene!
-    });
+    const engine = useEngine();
+
+    useEffect(() => {
+        if (engine) {
+            const scene = new Scene(engine);
+            // Setup the scene!
+        }
+    }, [engine]);
 
     return (
         <>
@@ -43,16 +53,19 @@ import { useEngine, EngineView } from 'react-native-babylon';
 import { Engine, Scene, Camera } from '@babylonjs/core';
 
 const MyComponent: FunctionComponent<MyComponentProps> = (props: MyComponentProps) => {
+    const engine = useEngine();
     const [camera, setCamera] = useState<Camera>();
 
-    useEngine((engine: Engine) => {
-        const scene = new Scene(engine);
-        scene.createDefaultCamera(true);
-        if (scene.activeCamera) {
-            setCamera(scene.activeCamera);
+    useEffect(() => {
+        if (engine) {
+            const scene = new Scene(engine);
+            scene.createDefaultCamera(true);
+            if (scene.activeCamera) {
+                setCamera(scene.activeCamera);
+            }
+            // Setup the scene!
         }
-        // Setup the scene!
-    });
+    }, [engine]);
 
     return (
         <>

--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ Babylon React Native is in the early phase of its development, and has the follo
 
 This quick overview will help you understand the constructs provided by Babylon React Native and how to use them in a React Native application. See the Playground app's [App.tsx](Apps/Playground/App.tsx) for example usage.
 
-Note that this package has several **peer dependencies**. If these dependencies are unmet, `react-native` will emit warnings. Be sure to add these dependencies to your project.
+### Dependencies
 
-### Additional Android Requirements
+This package has several **peer dependencies**. If these dependencies are unmet, `react-native` will emit warnings. Be sure to add these dependencies to your project.
 
-The minimum Android SDK version is 24. This must be set as `minSdkVersion` in the consuming project's `build.gradle` file. 
+### C++ Build Requirements
+
+This package includes C++ source, so platform specific tooling to build C++ code must be installed.
+
+### Android Requirements
+
+The minimum Android SDK version is 24. This must be set as `minSdkVersion` in the consuming project's `build.gradle` file.
 
 ### `useEngine`
 


### PR DESCRIPTION
This change includes a handful of fixes that prepare the repo for packaging and publishing `react-native-babylon`. In its initial form, this will be as source, where the consuming project compiles the linked projects. This is standard in the React Native world, though the Babylon Native code is a bit heavier than what is typically included in a react native package, and since it includes native code this requires a bit of extra setup to be able to successfully build. While it is non-standard, we should consider a second iteration on this later where we prebuild the binaries and just include those in the package. I'm not sure if this will create other problems around binary compatibility. In any case, the changes in this PR are:

- Add a `.npmignore` with additional exclusions to reduce the package size. Without this, the package is about 150mb. With this, the package is about 22mb. When no `.npmignore` is present (or it is empty), NPM will fall back to `.gitignore`, but as soon you add a `.npmignore` then NPM ignores `.gitignore`, which means I have to duplicate `.gitignore` into `.npmignore` and then add my extra stuff. This seems pretty terrible, but I couldn't find any way around it.
- Added a pre-build validation check for Android that ensures the consuming project is specifying a minimum SDK version of 24. If not, it tells you you need to use at least 24. Without this, it would just fail during the build saying it couldn't find `-lGLESv3` which obviously is much harder to understand what the problem is.
- Added a package description.
- Updated the Babylon.js peer dependency to the right version (we need to remember to update this when we update the test app to a newer version).
- Updated some out-of-date documentation on usage.

I tested this all out in a new React Native project and the only thing I needed to do was to update the minSdkVersion from 16 to 24. I also tested it with a JavaScript based React Native project and magically everything still works (I can import types defined in TypeScript files into JavaScript files and intellisense works as expected, the build works, and it works at runtime). Maybe Babel or some other tooling is taking care of this. But the point is, I don't think we need to manually compile the TypeScript to JavaScript - the package can just contain the TypeScript directly. Next steps will be setting up an ADO build pipeline that just publishes the package.