### PR TITLE
Publish to npmjs.com

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Version & Publish Package
         run: |
           npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-          npm publish
+          npm publish --access public
         working-directory: ./Apps/Playground/node_modules/@babylonjs/react-native
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,12 @@ jobs:
         uses: actions/setup-node@v1.4.2
         with:
           node-version: '12.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@babylonjs'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@ryantrem'
       - name: Version & Publish Package
         run: |
           npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
           npm publish
         working-directory: ./Apps/Playground/node_modules/@babylonjs/react-native
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@ryantrem'
+          scope: '@babylonjs'
       - name: Version & Publish Package
         run: |
           npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}

--- a/Apps/Playground/node_modules/@babylonjs/react-native/package.json
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@babylonjs/react-native",
+  "name": "@ryantrem/react-native",
   "title": "React Native Babylon",
   "version": "0.0.0",
   "description": "Babylon Native integration into React Native",

--- a/Apps/Playground/node_modules/@babylonjs/react-native/package.json
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ryantrem/react-native",
+  "name": "@babylonjs/react-native",
   "title": "React Native Babylon",
   "version": "0.0.0",
   "description": "Babylon Native integration into React Native",


### PR DESCRIPTION
These changes update the release workflow to publish the package to npmjs instead of github. By default when publishing to npmjs packages are private, so I had to add an explicit argument to tell it to publish with public access. The `NPM_TOKEN` was added to the secrets of the repo by @sebavan.