### PR TITLE
Simplify linking for iOS

### DIFF
--- a/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
+++ b/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* PlaygroundTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* PlaygroundTests.m */; };
 		76A5C9314E69F53B9308D45C /* libPods-PlaygroundTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A27E99BCBBA16817330523FA /* libPods-PlaygroundTests.a */; };
+		8A6C9D9224A17E51004260D1 /* libbgfx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6C9D9124A17E51004260D1 /* libbgfx.a */; };
+		8A6C9D9424A17E51004260D1 /* libbx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6C9D9324A17E51004260D1 /* libbx.a */; };
+		8A6C9D9624A17EB8004260D1 /* libbimg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6C9D9524A17EB8004260D1 /* libbimg.a */; };
 		8A992A76249035EB000ACD23 /* libBabylonNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A75249035EB000ACD23 /* libBabylonNative.a */; };
 		8A992A7824903631000ACD23 /* libnapi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A7724903631000ACD23 /* libnapi.a */; };
 		8A992A7E2491A0F3000ACD23 /* libJsRuntime.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A7D2491A0F3000ACD23 /* libJsRuntime.a */; };
@@ -25,7 +28,6 @@
 		8A992A822491A29E000ACD23 /* libNativeEngine.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A812491A29E000ACD23 /* libNativeEngine.a */; };
 		8A992A842491A2A8000ACD23 /* libNativeWindow.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A832491A2A8000ACD23 /* libNativeWindow.a */; };
 		8A992A862491A2B3000ACD23 /* libWindow.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A852491A2B3000ACD23 /* libWindow.a */; };
-		8A992A9E2491A348000ACD23 /* libbimgd.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A9D2491A348000ACD23 /* libbimgd.a */; };
 		8A992AA62491A52A000ACD23 /* libastc-codec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AA52491A52A000ACD23 /* libastc-codec.a */; };
 		8A992AA82491A52A000ACD23 /* libastc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AA72491A52A000ACD23 /* libastc.a */; };
 		8A992AB02491AF28000ACD23 /* libglslang.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AAF2491AF28000ACD23 /* libglslang.a */; };
@@ -76,6 +78,9 @@
 		5BF3DEA5030AD445D3CF62D1 /* Pods-Playground-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Playground-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Playground-tvOS/Pods-Playground-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		68FACB011E63361C5C3BD1B4 /* Pods-Playground-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Playground-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Playground-tvOS/Pods-Playground-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		6BCB9591CE7C52AE32A2296E /* Pods-PlaygroundTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PlaygroundTests.release.xcconfig"; path = "Target Support Files/Pods-PlaygroundTests/Pods-PlaygroundTests.release.xcconfig"; sourceTree = "<group>"; };
+		8A6C9D9124A17E51004260D1 /* libbgfx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbgfx.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A6C9D9324A17E51004260D1 /* libbx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbx.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A6C9D9524A17EB8004260D1 /* libbimg.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbimg.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992A75249035EB000ACD23 /* libBabylonNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libBabylonNative.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992A7724903631000ACD23 /* libnapi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libnapi.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992A7D2491A0F3000ACD23 /* libJsRuntime.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libJsRuntime.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -135,6 +140,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A6C9D9624A17EB8004260D1 /* libbimg.a in Frameworks */,
+				8A6C9D9224A17E51004260D1 /* libbgfx.a in Frameworks */,
+				8A6C9D9424A17E51004260D1 /* libbx.a in Frameworks */,
 				8A992AD42491B155000ACD23 /* libspirv-cross-core.a in Frameworks */,
 				8A992AD22491B13B000ACD23 /* libspirv-cross-glsl.a in Frameworks */,
 				8A992AD02491B132000ACD23 /* libspirv-cross-hlsl.a in Frameworks */,
@@ -145,7 +153,6 @@
 				8A992AB02491AF28000ACD23 /* libglslang.a in Frameworks */,
 				8A992AA62491A52A000ACD23 /* libastc-codec.a in Frameworks */,
 				8A992AA82491A52A000ACD23 /* libastc.a in Frameworks */,
-				8A992A9E2491A348000ACD23 /* libbimgd.a in Frameworks */,
 				8A992A862491A2B3000ACD23 /* libWindow.a in Frameworks */,
 				8A992A842491A2A8000ACD23 /* libNativeWindow.a in Frameworks */,
 				8A992A822491A29E000ACD23 /* libNativeEngine.a in Frameworks */,
@@ -210,20 +217,16 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8A6C9D9524A17EB8004260D1 /* libbimg.a */,
+				8A6C9D9124A17E51004260D1 /* libbgfx.a */,
+				8A6C9D9324A17E51004260D1 /* libbx.a */,
 				8A992AD62493FE5E000ACD23 /* Metal.framework */,
 				8A992AD52493FE5D000ACD23 /* MetalKit.framework */,
 				8A992AD32491B155000ACD23 /* libspirv-cross-core.a */,
 				8A992AD12491B13B000ACD23 /* libspirv-cross-glsl.a */,
 				8A992ACF2491B132000ACD23 /* libspirv-cross-hlsl.a */,
-				8A992ACD2491B10E000ACD23 /* libedtaa3.a */,
 				8A992AC52491B0A7000ACD23 /* libastc-codec.a */,
 				8A992AC72491B0A7000ACD23 /* libastc.a */,
-				8A992AC12491B09A000ACD23 /* libetc1.a */,
-				8A992AC32491B09A000ACD23 /* libetc2.a */,
-				8A992ABF2491B08E000ACD23 /* libiqa.a */,
-				8A992ABD2491B088000ACD23 /* libsquish.a */,
-				8A992ABB2491B07E000ACD23 /* libnvtt.a */,
-				8A992AB92491B074000ACD23 /* libpvrtc.a */,
 				8A992AB72491B020000ACD23 /* libspirv-cross-msl.a */,
 				8A992AB52491B00C000ACD23 /* libSPIRV.a */,
 				8A992AB32491AF71000ACD23 /* libOGLCompiler.a */,
@@ -747,8 +750,6 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
-					"-lbgfxd",
-					"-lbxd",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Playground;
@@ -768,8 +769,6 @@
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
-					"-lbgfx",
-					"-lbx",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Playground;

--- a/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
+++ b/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
@@ -18,26 +18,6 @@
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2DCD954D1E0B4F2C00145EB5 /* PlaygroundTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* PlaygroundTests.m */; };
 		76A5C9314E69F53B9308D45C /* libPods-PlaygroundTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A27E99BCBBA16817330523FA /* libPods-PlaygroundTests.a */; };
-		8A6C9D9224A17E51004260D1 /* libbgfx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6C9D9124A17E51004260D1 /* libbgfx.a */; };
-		8A6C9D9424A17E51004260D1 /* libbx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6C9D9324A17E51004260D1 /* libbx.a */; };
-		8A6C9D9624A17EB8004260D1 /* libbimg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A6C9D9524A17EB8004260D1 /* libbimg.a */; };
-		8A992A76249035EB000ACD23 /* libBabylonNative.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A75249035EB000ACD23 /* libBabylonNative.a */; };
-		8A992A7824903631000ACD23 /* libnapi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A7724903631000ACD23 /* libnapi.a */; };
-		8A992A7E2491A0F3000ACD23 /* libJsRuntime.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A7D2491A0F3000ACD23 /* libJsRuntime.a */; };
-		8A992A802491A296000ACD23 /* libNativeInput.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A7F2491A296000ACD23 /* libNativeInput.a */; };
-		8A992A822491A29E000ACD23 /* libNativeEngine.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A812491A29E000ACD23 /* libNativeEngine.a */; };
-		8A992A842491A2A8000ACD23 /* libNativeWindow.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A832491A2A8000ACD23 /* libNativeWindow.a */; };
-		8A992A862491A2B3000ACD23 /* libWindow.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992A852491A2B3000ACD23 /* libWindow.a */; };
-		8A992AA62491A52A000ACD23 /* libastc-codec.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AA52491A52A000ACD23 /* libastc-codec.a */; };
-		8A992AA82491A52A000ACD23 /* libastc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AA72491A52A000ACD23 /* libastc.a */; };
-		8A992AB02491AF28000ACD23 /* libglslang.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AAF2491AF28000ACD23 /* libglslang.a */; };
-		8A992AB22491AF4D000ACD23 /* libOSDependent.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AB12491AF4D000ACD23 /* libOSDependent.a */; };
-		8A992AB42491AF71000ACD23 /* libOGLCompiler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AB32491AF71000ACD23 /* libOGLCompiler.a */; };
-		8A992AB62491B00C000ACD23 /* libSPIRV.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AB52491B00C000ACD23 /* libSPIRV.a */; };
-		8A992AB82491B020000ACD23 /* libspirv-cross-msl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AB72491B020000ACD23 /* libspirv-cross-msl.a */; };
-		8A992AD02491B132000ACD23 /* libspirv-cross-hlsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992ACF2491B132000ACD23 /* libspirv-cross-hlsl.a */; };
-		8A992AD22491B13B000ACD23 /* libspirv-cross-glsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AD12491B13B000ACD23 /* libspirv-cross-glsl.a */; };
-		8A992AD42491B155000ACD23 /* libspirv-cross-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AD32491B155000ACD23 /* libspirv-cross-core.a */; };
 		BC17671D40F4DD48338295AB /* libPods-Playground.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6BC394028D7BAE8A003F7EF /* libPods-Playground.a */; };
 		DC0E086EEC7F13FF7B7A6ACC /* libPods-Playground-tvOSTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EFE1A6A1208FCAF679B3028D /* libPods-Playground-tvOSTests.a */; };
 /* End PBXBuildFile section */
@@ -140,26 +120,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A6C9D9624A17EB8004260D1 /* libbimg.a in Frameworks */,
-				8A6C9D9224A17E51004260D1 /* libbgfx.a in Frameworks */,
-				8A6C9D9424A17E51004260D1 /* libbx.a in Frameworks */,
-				8A992AD42491B155000ACD23 /* libspirv-cross-core.a in Frameworks */,
-				8A992AD22491B13B000ACD23 /* libspirv-cross-glsl.a in Frameworks */,
-				8A992AD02491B132000ACD23 /* libspirv-cross-hlsl.a in Frameworks */,
-				8A992AB82491B020000ACD23 /* libspirv-cross-msl.a in Frameworks */,
-				8A992AB62491B00C000ACD23 /* libSPIRV.a in Frameworks */,
-				8A992AB42491AF71000ACD23 /* libOGLCompiler.a in Frameworks */,
-				8A992AB22491AF4D000ACD23 /* libOSDependent.a in Frameworks */,
-				8A992AB02491AF28000ACD23 /* libglslang.a in Frameworks */,
-				8A992AA62491A52A000ACD23 /* libastc-codec.a in Frameworks */,
-				8A992AA82491A52A000ACD23 /* libastc.a in Frameworks */,
-				8A992A862491A2B3000ACD23 /* libWindow.a in Frameworks */,
-				8A992A842491A2A8000ACD23 /* libNativeWindow.a in Frameworks */,
-				8A992A822491A29E000ACD23 /* libNativeEngine.a in Frameworks */,
-				8A992A802491A296000ACD23 /* libNativeInput.a in Frameworks */,
-				8A992A7E2491A0F3000ACD23 /* libJsRuntime.a in Frameworks */,
-				8A992A7824903631000ACD23 /* libnapi.a in Frameworks */,
-				8A992A76249035EB000ACD23 /* libBabylonNative.a in Frameworks */,
 				BC17671D40F4DD48338295AB /* libPods-Playground.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
+++ b/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
@@ -33,13 +33,6 @@
 		8A992AB42491AF71000ACD23 /* libOGLCompiler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AB32491AF71000ACD23 /* libOGLCompiler.a */; };
 		8A992AB62491B00C000ACD23 /* libSPIRV.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AB52491B00C000ACD23 /* libSPIRV.a */; };
 		8A992AB82491B020000ACD23 /* libspirv-cross-msl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AB72491B020000ACD23 /* libspirv-cross-msl.a */; };
-		8A992ABA2491B074000ACD23 /* libpvrtc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AB92491B074000ACD23 /* libpvrtc.a */; };
-		8A992ABC2491B07E000ACD23 /* libnvtt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992ABB2491B07E000ACD23 /* libnvtt.a */; };
-		8A992ABE2491B088000ACD23 /* libsquish.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992ABD2491B088000ACD23 /* libsquish.a */; };
-		8A992AC02491B08E000ACD23 /* libiqa.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992ABF2491B08E000ACD23 /* libiqa.a */; };
-		8A992AC22491B09A000ACD23 /* libetc1.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AC12491B09A000ACD23 /* libetc1.a */; };
-		8A992AC42491B09A000ACD23 /* libetc2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AC32491B09A000ACD23 /* libetc2.a */; };
-		8A992ACE2491B10E000ACD23 /* libedtaa3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992ACD2491B10E000ACD23 /* libedtaa3.a */; };
 		8A992AD02491B132000ACD23 /* libspirv-cross-hlsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992ACF2491B132000ACD23 /* libspirv-cross-hlsl.a */; };
 		8A992AD22491B13B000ACD23 /* libspirv-cross-glsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AD12491B13B000ACD23 /* libspirv-cross-glsl.a */; };
 		8A992AD42491B155000ACD23 /* libspirv-cross-core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A992AD32491B155000ACD23 /* libspirv-cross-core.a */; };
@@ -111,15 +104,8 @@
 		8A992AB32491AF71000ACD23 /* libOGLCompiler.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libOGLCompiler.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992AB52491B00C000ACD23 /* libSPIRV.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libSPIRV.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992AB72491B020000ACD23 /* libspirv-cross-msl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-msl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AB92491B074000ACD23 /* libpvrtc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libpvrtc.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992ABB2491B07E000ACD23 /* libnvtt.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libnvtt.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992ABD2491B088000ACD23 /* libsquish.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libsquish.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992ABF2491B08E000ACD23 /* libiqa.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libiqa.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AC12491B09A000ACD23 /* libetc1.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libetc1.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AC32491B09A000ACD23 /* libetc2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libetc2.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992AC52491B0A7000ACD23 /* libastc-codec.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libastc-codec.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992AC72491B0A7000ACD23 /* libastc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libastc.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992ACD2491B10E000ACD23 /* libedtaa3.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libedtaa3.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992ACF2491B132000ACD23 /* libspirv-cross-hlsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-hlsl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992AD12491B13B000ACD23 /* libspirv-cross-glsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-glsl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A992AD32491B155000ACD23 /* libspirv-cross-core.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-core.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -152,13 +138,6 @@
 				8A992AD42491B155000ACD23 /* libspirv-cross-core.a in Frameworks */,
 				8A992AD22491B13B000ACD23 /* libspirv-cross-glsl.a in Frameworks */,
 				8A992AD02491B132000ACD23 /* libspirv-cross-hlsl.a in Frameworks */,
-				8A992ACE2491B10E000ACD23 /* libedtaa3.a in Frameworks */,
-				8A992AC22491B09A000ACD23 /* libetc1.a in Frameworks */,
-				8A992AC42491B09A000ACD23 /* libetc2.a in Frameworks */,
-				8A992AC02491B08E000ACD23 /* libiqa.a in Frameworks */,
-				8A992ABE2491B088000ACD23 /* libsquish.a in Frameworks */,
-				8A992ABC2491B07E000ACD23 /* libnvtt.a in Frameworks */,
-				8A992ABA2491B074000ACD23 /* libpvrtc.a in Frameworks */,
 				8A992AB82491B020000ACD23 /* libspirv-cross-msl.a in Frameworks */,
 				8A992AB62491B00C000ACD23 /* libSPIRV.a in Frameworks */,
 				8A992AB42491AF71000ACD23 /* libOGLCompiler.a in Frameworks */,

--- a/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
+++ b/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
@@ -58,44 +58,6 @@
 		5BF3DEA5030AD445D3CF62D1 /* Pods-Playground-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Playground-tvOS.debug.xcconfig"; path = "Target Support Files/Pods-Playground-tvOS/Pods-Playground-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		68FACB011E63361C5C3BD1B4 /* Pods-Playground-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Playground-tvOS.release.xcconfig"; path = "Target Support Files/Pods-Playground-tvOS/Pods-Playground-tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		6BCB9591CE7C52AE32A2296E /* Pods-PlaygroundTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PlaygroundTests.release.xcconfig"; path = "Target Support Files/Pods-PlaygroundTests/Pods-PlaygroundTests.release.xcconfig"; sourceTree = "<group>"; };
-		8A6C9D9124A17E51004260D1 /* libbgfx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbgfx.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A6C9D9324A17E51004260D1 /* libbx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbx.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A6C9D9524A17EB8004260D1 /* libbimg.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbimg.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A75249035EB000ACD23 /* libBabylonNative.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libBabylonNative.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A7724903631000ACD23 /* libnapi.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libnapi.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A7D2491A0F3000ACD23 /* libJsRuntime.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libJsRuntime.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A7F2491A296000ACD23 /* libNativeInput.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libNativeInput.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A812491A29E000ACD23 /* libNativeEngine.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libNativeEngine.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A832491A2A8000ACD23 /* libNativeWindow.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libNativeWindow.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A852491A2B3000ACD23 /* libWindow.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libWindow.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A872491A319000ACD23 /* libspirv-cross-c.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-c.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A892491A319000ACD23 /* libspirv-cross-core.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-core.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A8B2491A319000ACD23 /* libspirv-cross-cpp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-cpp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A8D2491A319000ACD23 /* libspirv-cross-glsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-glsl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A8F2491A319000ACD23 /* libspirv-cross-hlsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-hlsl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A912491A319000ACD23 /* libspirv-cross-msl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-msl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A932491A319000ACD23 /* libspirv-cross-reflect.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-reflect.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A952491A319000ACD23 /* libspirv-cross-util.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-util.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A972491A319000ACD23 /* libSPIRV.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libSPIRV.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A9D2491A348000ACD23 /* libbimgd.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libbimgd.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992A9F2491A35F000ACD23 /* libglslang.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libglslang.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AA12491A3DB000ACD23 /* libOSDependent.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libOSDependent.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AA32491A435000ACD23 /* libOGLCompiler.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libOGLCompiler.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AA52491A52A000ACD23 /* libastc-codec.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libastc-codec.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AA72491A52A000ACD23 /* libastc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libastc.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AAB2491AE93000ACD23 /* libOGLCompiler.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libOGLCompiler.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AAF2491AF28000ACD23 /* libglslang.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libglslang.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AB12491AF4D000ACD23 /* libOSDependent.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libOSDependent.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AB32491AF71000ACD23 /* libOGLCompiler.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libOGLCompiler.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AB52491B00C000ACD23 /* libSPIRV.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libSPIRV.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AB72491B020000ACD23 /* libspirv-cross-msl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-msl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AC52491B0A7000ACD23 /* libastc-codec.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libastc-codec.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AC72491B0A7000ACD23 /* libastc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libastc.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992ACF2491B132000ACD23 /* libspirv-cross-hlsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-hlsl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AD12491B13B000ACD23 /* libspirv-cross-glsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-glsl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AD32491B155000ACD23 /* libspirv-cross-core.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libspirv-cross-core.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A992AD52493FE5D000ACD23 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
-		8A992AD62493FE5E000ACD23 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		99C45ADF56518ABFCCFCB01B /* Pods-Playground-tvOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Playground-tvOSTests.debug.xcconfig"; path = "Target Support Files/Pods-Playground-tvOSTests/Pods-Playground-tvOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A27E99BCBBA16817330523FA /* libPods-PlaygroundTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PlaygroundTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C876831BED593CF1A1FCBD19 /* Pods-Playground.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Playground.release.xcconfig"; path = "Target Support Files/Pods-Playground/Pods-Playground.release.xcconfig"; sourceTree = "<group>"; };
@@ -177,44 +139,6 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				8A6C9D9524A17EB8004260D1 /* libbimg.a */,
-				8A6C9D9124A17E51004260D1 /* libbgfx.a */,
-				8A6C9D9324A17E51004260D1 /* libbx.a */,
-				8A992AD62493FE5E000ACD23 /* Metal.framework */,
-				8A992AD52493FE5D000ACD23 /* MetalKit.framework */,
-				8A992AD32491B155000ACD23 /* libspirv-cross-core.a */,
-				8A992AD12491B13B000ACD23 /* libspirv-cross-glsl.a */,
-				8A992ACF2491B132000ACD23 /* libspirv-cross-hlsl.a */,
-				8A992AC52491B0A7000ACD23 /* libastc-codec.a */,
-				8A992AC72491B0A7000ACD23 /* libastc.a */,
-				8A992AB72491B020000ACD23 /* libspirv-cross-msl.a */,
-				8A992AB52491B00C000ACD23 /* libSPIRV.a */,
-				8A992AB32491AF71000ACD23 /* libOGLCompiler.a */,
-				8A992AB12491AF4D000ACD23 /* libOSDependent.a */,
-				8A992AAF2491AF28000ACD23 /* libglslang.a */,
-				8A992AAB2491AE93000ACD23 /* libOGLCompiler.a */,
-				8A992AA52491A52A000ACD23 /* libastc-codec.a */,
-				8A992AA72491A52A000ACD23 /* libastc.a */,
-				8A992AA32491A435000ACD23 /* libOGLCompiler.a */,
-				8A992AA12491A3DB000ACD23 /* libOSDependent.a */,
-				8A992A9F2491A35F000ACD23 /* libglslang.a */,
-				8A992A9D2491A348000ACD23 /* libbimgd.a */,
-				8A992A872491A319000ACD23 /* libspirv-cross-c.a */,
-				8A992A892491A319000ACD23 /* libspirv-cross-core.a */,
-				8A992A8B2491A319000ACD23 /* libspirv-cross-cpp.a */,
-				8A992A8D2491A319000ACD23 /* libspirv-cross-glsl.a */,
-				8A992A8F2491A319000ACD23 /* libspirv-cross-hlsl.a */,
-				8A992A912491A319000ACD23 /* libspirv-cross-msl.a */,
-				8A992A932491A319000ACD23 /* libspirv-cross-reflect.a */,
-				8A992A952491A319000ACD23 /* libspirv-cross-util.a */,
-				8A992A972491A319000ACD23 /* libSPIRV.a */,
-				8A992A852491A2B3000ACD23 /* libWindow.a */,
-				8A992A832491A2A8000ACD23 /* libNativeWindow.a */,
-				8A992A812491A29E000ACD23 /* libNativeEngine.a */,
-				8A992A7F2491A296000ACD23 /* libNativeInput.a */,
-				8A992A7D2491A0F3000ACD23 /* libJsRuntime.a */,
-				8A992A7724903631000ACD23 /* libnapi.a */,
-				8A992A75249035EB000ACD23 /* libBabylonNative.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
 				F6BC394028D7BAE8A003F7EF /* libPods-Playground.a */,

--- a/Apps/Playground/ios/Podfile.lock
+++ b/Apps/Playground/ios/Podfile.lock
@@ -366,7 +366,7 @@ SPEC CHECKSUMS:
   React-jsi: 600d8e42510c3254fd2abd702f4b9d3f598d8f52
   React-jsiexecutor: e9698dee4fd43ceb44832baf15d5745f455b0157
   React-jsinspector: f74a62727e5604119abd4a1eda52c0a12144bcd5
-  react-native-babylon: 6b5dc8756db819f969601d3e20c082b239d5a7f3
+  react-native-babylon: b11dbc4e865e266b34f21483834342d8aba442de
   react-native-slider: e51492f1264d882a8815b71c5870f8978e52887d
   React-RCTActionSheet: af8f28dd82fec89b8fe29637b8c779829e016a88
   React-RCTAnimation: 0d21fff7c20fb8ee41de5f2ebb63221127febd96

--- a/Apps/Playground/node_modules/@babylonjs/react-native/package.json
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^4.2.0-alpha.17",
+    "@babylonjs/core": "^4.2.0-alpha.21",
     "react": "^16.8.1",
     "react-native": ">=0.60.0-rc.0 <1.0.x",
     "react-native-permissions": "^2.1.4"

--- a/Apps/Playground/node_modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -17,6 +17,27 @@ Pod::Spec.new do |s|
   s.exclude_files = "ios/BabylonNative.h"
   s.requires_arc = true
 
+  s.libraries = 'astc-codec',
+                'astc',
+                'BabylonNative',
+                'bgfx',
+                'bimg',
+                'bx',
+                'glslang',
+                'jsRuntime',
+                'OGLCompiler',
+                'OSDependent',
+                'napi',
+                'NativeEngine',
+                'NativeInput',
+                'NativeWindow',
+                'SPIRV',
+                'spirv-cross-core',
+                'spirv-cross-glsl',
+                'spirv-cross-hlsl',
+                'spirv-cross-msl',
+                'Window'
+
   s.frameworks = "MetalKit"
 
   s.dependency "React"

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,11 +10,11 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "4.2.0-alpha.17",
+    "@babylonjs/core": "4.2.0-alpha.21",
+    "@babylonjs/react-native": "./node_modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "react": "16.9.0",
     "react-native": "0.62.1",
-    "@babylonjs/react-native": "./node_modules/@babylonjs/react-native",
     "react-native-permissions": "^2.1.4"
   },
   "devDependencies": {

--- a/Apps/Playground/yarn.lock
+++ b/Apps/Playground/yarn.lock
@@ -607,14 +607,14 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babylonjs/core@4.2.0-alpha.17":
-  version "4.2.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/@babylonjs/core/-/core-4.2.0-alpha.17.tgz#0ce4202e586a15dc46b30f3fe50c28703ef00f31"
+"@babylonjs/core@4.2.0-alpha.21":
+  version "4.2.0-alpha.21"
+  resolved "https://registry.yarnpkg.com/@babylonjs/core/-/core-4.2.0-alpha.21.tgz#f75fd78eaa322ee30a8a2d625e707f21f5f934c0"
   dependencies:
-    tslib "^1.10.0"
+    tslib ">=1.10.0"
 
 "@babylonjs/react-native@./node_modules/@babylonjs/react-native":
-  version "1.0.0"
+  version "0.0.1"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -5310,7 +5310,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@>=1.10.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
 


### PR DESCRIPTION
Previously, I had manually updated the Playground app to link all the necessary libs. This would have to be repeated for any other project that consumed the current source-based package. So the main change here is to move that list of libs from the consuming pbxproj to the podspec. However, to do this I needed all the lib names to be the same for debug and release, but a few bgfx related libs had a `d` appended to them for debug. This was fixed in the BabylonNative repo, but updating to a newer BabylonNative submodule also pulls in @syntheticmagus's shader compilation changes, which require a newer version of Babylon.js, so I also updated to the latest Babylon.js NPM package.