### PR TITLE
MtkViewDelegate and rendering function

### DIFF
--- a/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -1,3 +1,4 @@
+#include <CoreFoundation/CFRunLoop.h>
 #include "BabylonNative.h"
 #include "../JSCRuntime.h"
 
@@ -11,8 +12,6 @@
 #include <arcana/threading/task_schedulers.h>
 
 #include <JavaScriptCore/JavaScript.h>
-
-#include <CoreFoundation/CFRunLoop.h>
 
 #include <optional>
 #include <sstream>
@@ -35,15 +34,12 @@ namespace Babylon
         Plugins::NativeInput* nativeInput{};
     };
 
-    Native::Native(facebook::jsi::Runtime* jsiRuntime, void* windowPtr, size_t width, size_t height)
+    Native::Native(facebook::jsi::Runtime* jsiRuntime, void* windowPtr, size_t width, size_t height, CFRunLoopRef runloop)
         : m_impl{ std::make_unique<Native::Impl>(jsiRuntime) }
     {
-        // TODO: We should initialize graphics on the UI thread, but for some reason this causes the app to crash
-//        dispatch_sync(dispatch_get_main_queue(), ^{
-//            Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);            
-//        });
-        
-        auto run_loop_scheduler = std::make_shared<arcana::run_loop_scheduler>(arcana::run_loop_scheduler::get_for_current_thread());
+        Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
+
+        auto run_loop_scheduler = std::make_shared<arcana::run_loop_scheduler>(runloop/*get_for_current_thread()*/);
 
         JsRuntime::DispatchFunctionT dispatchFunction{[env = m_impl->env, run_loop_scheduler = std::move(run_loop_scheduler)](std::function<void(Napi::Env)> func)
         {
@@ -55,14 +51,16 @@ namespace Babylon
 
         m_impl->runtime = &JsRuntime::CreateForJavaScript(m_impl->env, std::move(dispatchFunction));
 
-        Polyfills::Window::Initialize(m_impl->env);
+        m_impl->runtime->Dispatch([width, height, windowPtr, this](Napi::Env env)
+        {
+            Polyfills::Window::Initialize(env);
 
-        Plugins::NativeEngine::InitializeGraphics(windowPtr, width, height);
-        Plugins::NativeWindow::Initialize(m_impl->env, windowPtr, width, height);
-        Plugins::NativeEngine::Initialize(m_impl->env);
-        Plugins::NativeXr::Initialize(m_impl->env);
+            Plugins::NativeWindow::Initialize(env, windowPtr, width, height);
+            Plugins::NativeEngine::Initialize(env);
+            Plugins::NativeXr::Initialize(env);
 
-        m_impl->nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(m_impl->env);
+            m_impl->nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(env);
+        });
     }
 
     Native::~Native()
@@ -77,10 +75,15 @@ namespace Babylon
 
     void Native::Resize(size_t width, size_t height)
     {
-        m_impl->runtime->Dispatch([width, height](Napi::Env env)
+        if (m_impl->runtime)
         {
-            Plugins::NativeWindow::UpdateSize(env, width, height);
-        });
+            Plugins::NativeEngine::UpdateSize(width, height);
+            m_impl->runtime->Dispatch([width, height](Napi::Env env)
+            {
+                Plugins::NativeWindow::UpdateSize(env, static_cast<size_t>(width), static_cast<size_t>(height));
+            });
+        }
+
     }
 
     void Native::SetPointerButtonState(uint32_t pointerId, uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
@@ -98,5 +101,10 @@ namespace Babylon
     void Native::SetPointerPosition(uint32_t pointerId, uint32_t x, uint32_t y)
     {
         m_impl->nativeInput->PointerMove(pointerId, x, y);
+    }
+
+    void Native::Render()
+    {
+        Plugins::NativeEngine::Render();
     }
 }

--- a/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNative.h
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNative.h
@@ -8,13 +8,13 @@ namespace Babylon
     {
     public:
         // This class must be constructed from the JavaScript thread
-        Native(facebook::jsi::Runtime* jsiRuntime, void* windowPtr, size_t width, size_t height);
+        Native(facebook::jsi::Runtime* jsiRuntime, void* windowPtr, size_t width, size_t height, CFRunLoopRef runloop);
         ~Native();
         void Refresh(void* windowPtr, size_t width, size_t height);
         void Resize(size_t width, size_t height);
         void SetPointerButtonState(uint32_t pointerId, uint32_t buttonId, bool isDown, uint32_t x, uint32_t y);
         void SetPointerPosition(uint32_t pointerId, uint32_t x, uint32_t y);
-
+        void Render();
     private:
         class Impl;
         std::unique_ptr<Impl> m_impl{};

--- a/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNativeInterop.h
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNativeInterop.h
@@ -5,6 +5,8 @@
 
 @interface BabylonNativeInterop : NSObject
 + (void)setView:(RCTBridge*)bridge jsRunLoop:(NSRunLoop*)jsRunLoop mktView:(MTKView*)mtkView;
++ (void)render:(RCTBridge*)bridge mktView:(MTKView*)mtkView;
 + (void)reportTouchEvent:(NSSet<UITouch*>*)touches withEvent:(UIEvent*)event;
 + (void)whenInitialized:(RCTBridge*)bridge resolve:(RCTPromiseResolveBlock)resolve;
++ (void)resize:(CGSize)size;
 @end

--- a/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
@@ -1,10 +1,11 @@
 #import "BabylonNativeInterop.h"
-#import "BabylonNative.h"
+
 
 #import <React/RCTBridge+Private.h>
 #import <jsi/jsi.h>
 
 #import <Foundation/Foundation.h>
+#import "BabylonNative.h"
 
 #import <functional>
 #import <memory>
@@ -41,20 +42,29 @@ static NSMutableArray* activeTouches;
             jsRunLoop = NSRunLoop.mainRunLoop;
         }
 
-        [jsRunLoop performBlock:^{
-            if (bridge != currentBridge) {
-                currentBridge = bridge;
-                [BabylonNativeInterop setCurrentNativeInstance:mtkView width:width height:height];
-            } else if (currentNativeInstance) {
-                if (mtkView != currentView) {
-                    [BabylonNativeInterop setCurrentView:mtkView];
-                    currentNativeInstance->Refresh((__bridge void*)currentView, width, height);
-                } else {
-                    // TODO: Figure out why resizing causes the app to crash
-                    //currentNativeInstance->Resize(width, height);
-                }
+        if (bridge != currentBridge) {
+            currentBridge = bridge;
+            [BabylonNativeInterop setCurrentNativeInstance:mtkView width:width height:height runLoop:[jsRunLoop getCFRunLoop]];
+        } else if (currentNativeInstance) {
+            if (mtkView != currentView) {
+                [BabylonNativeInterop setCurrentView:mtkView];
+                currentNativeInstance->Refresh((__bridge void*)currentView, width, height);
             }
-        }];
+        }
+    }
+}
+
++ (void)resize:(CGSize)size
+{
+    if (currentNativeInstance) {
+        currentNativeInstance->Resize(size.width, size.height);
+    }
+}
+
++ (void)render:(RCTBridge*)bridge mktView:(MTKView*)mtkView
+{
+    if (currentNativeInstance) {
+        currentNativeInstance->Render();
     }
 }
 
@@ -115,7 +125,7 @@ static NSMutableArray* activeTouches;
     activeTouches = [NSMutableArray new];
 }
 
-+ (void)setCurrentNativeInstance:(MTKView*)mtkView width:(int)width height:(int)height {
++ (void)setCurrentNativeInstance:(MTKView*)mtkView width:(int)width height:(int)height runLoop:(CFRunLoopRef)runLoop {
     [BabylonNativeInterop setCurrentView:mtkView];
 
     const std::lock_guard<std::mutex> lock(mapMutex);
@@ -124,7 +134,7 @@ static NSMutableArray* activeTouches;
 
     jsi::Runtime* jsiRuntime = GetJSIRuntime(currentBridge);
     if (jsiRuntime) {
-        currentNativeInstance = std::make_unique<Babylon::Native>(GetJSIRuntime(currentBridge), (__bridge void*)mtkView, width, height);
+        currentNativeInstance = std::make_unique<Babylon::Native>(GetJSIRuntime(currentBridge), (__bridge void*)mtkView, width, height, runLoop);
     }
 
     auto initializationPromisesIterator = initializationPromises.find((__bridge void*)currentBridge);

--- a/Apps/Playground/node_modules/@babylonjs/react-native/ios/EngineViewManager.mm
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/ios/EngineViewManager.mm
@@ -6,7 +6,8 @@
 #import <UIKit/UIKit.h>
 #import <MetalKit/MetalKit.h>
 
-@interface EngineView : MTKView
+
+@interface EngineView : MTKView <MTKViewDelegate>
 @end
 
 @implementation EngineView {
@@ -14,10 +15,21 @@
     NSRunLoop* runLoop;
 }
 
+- (void)mtkView:(MTKView *)view drawableSizeWillChange:(CGSize)size
+{
+    [BabylonNativeInterop resize:size];
+}
+
+- (void)drawInMTKView:(MTKView *)view
+{
+    [BabylonNativeInterop render:bridge mktView:self];
+}
+
 - (instancetype)init:(RCTBridge*)_bridge runLoop:(NSRunLoop*)_runLoop {
     if (self = [super initWithFrame:CGRectZero device:MTLCreateSystemDefaultDevice()]) {
         bridge = _bridge;
         runLoop = _runLoop;
+        self.delegate = self;
 
         super.translatesAutoresizingMaskIntoConstraints = false;
         super.colorPixelFormat = MTLPixelFormatBGRA8Unorm_sRGB;


### PR DESCRIPTION
These changes need this PR on BabylonNative : https://github.com/BabylonJS/BabylonNative/pull/322

What's changed?
- Graphics Init, resize and Rendering happen on the Main UI thread
- Delegate for the MTKView that allows resize and rendering. The framerate is now in sync with the UI compositor locked at 60Hz
- No more crash when resizing!