### PR TITLE
JSI/JSC fixes

### DIFF
--- a/Apps/Playground/node_modules/@babylonjs/react-native/JSCRuntime.h
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/JSCRuntime.h
@@ -16,7 +16,7 @@
 #include <JavaScriptCore/JavaScript.h>
 
 namespace facebook {
-namespace jsc {
+namespace jsc2 {
 
 std::unique_ptr<jsi::Runtime> makeJSCRuntime(JSGlobalContextRef ctx);
 

--- a/Apps/Playground/node_modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -39,7 +39,7 @@ namespace Babylon
     public:
         // This class must be constructed from the JavaScript thread
         Native(facebook::jsi::Runtime* jsiRuntime, ANativeWindow* windowPtr)
-            : m_jsiRuntime{ facebook::jsc::makeJSCRuntime(facebook::jsc::getJSGlobalContextRefFromJSCRuntime(*jsiRuntime)) }
+            : m_jsiRuntime{ facebook::jsc2::makeJSCRuntime(facebook::jsc2::getJSGlobalContextRefFromJSCRuntime(*jsiRuntime)) }
             , m_env{ Napi::Attach<facebook::jsi::Runtime&>(*m_jsiRuntime) }
         {
             auto looper_scheduler = std::make_shared<looper_scheduler_t>(looper_scheduler_t::get_for_current_thread());

--- a/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Apps/Playground/node_modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -27,14 +27,16 @@ namespace Babylon
     {
     public:
         Impl(facebook::jsi::Runtime* jsiRuntime)
-            : jsiRuntime{ facebook::jsc::makeJSCRuntime(facebook::jsc::getJSGlobalContextRefFromJSCRuntime(*jsiRuntime)) }
-            , env{ Napi::Attach<facebook::jsi::Runtime&>(*jsiRuntime) }
+            : m_jsiRuntime{ facebook::jsc2::makeJSCRuntime(facebook::jsc2::getJSGlobalContextRefFromJSCRuntime(*jsiRuntime)) }
+            , env{ Napi::Attach<facebook::jsi::Runtime&>(*m_jsiRuntime) }
         {
         }
 
+    private:
         // custom jsi runtime based on custom jsc runtime
-        std::unique_ptr<facebook::jsi::Runtime> jsiRuntime;
+        std::unique_ptr<facebook::jsi::Runtime> m_jsiRuntime;
 
+    public:
         Napi::Env env;
         JsRuntime* runtime{};
         Plugins::NativeInput* nativeInput{};


### PR DESCRIPTION
There are some naming collisions with the custom version of JSCRuntime, so this change puts it in a separate namespace.

Also include updated Babylon Native submodules for various fixes.