### PR TITLE
Update Babylon Native and Babylon.js to latest

### DIFF
--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -864,9 +864,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-alpha.21.tgz",
-      "integrity": "sha512-cQx8SjY/UZFBMflU0XPHUDw1fD1hwrXtB9bWaGANzwpY2FS4l23v8kWcZG2e9r71CXC7cinQb7t/jesPJvNUqA==",
+      "version": "4.2.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-alpha.26.tgz",
+      "integrity": "sha512-TBoUh0orGtZp32cSr9yGrGsJaeNTX9qHo9oqTE0Ntv0vqkdLMX+cokuroH4BYPV1WZRvOZsiEBUzXoAiCeRIlw==",
       "requires": {
         "tslib": ">=1.10.0"
       }

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "4.2.0-alpha.21",
+    "@babylonjs/core": "4.2.0-alpha.26",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "logkitty": "^0.7.1",

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^4.2.0-alpha.21",
+    "@babylonjs/core": "^4.2.0-alpha.26",
     "react": "^16.8.1",
     "react-native": ">=0.60.0-rc.0 <1.0.x",
     "react-native-permissions": "^2.1.4"


### PR DESCRIPTION
- Updating Babylon Native to get the BGFX fix for re-instantiating the EngineView on iOS (as described in #15) (and verified this is fixed).
- Updating Babylon.js to get the 32-bit index buffer fix (as described in https://github.com/babylonjs/babylonnative/issues/321) (did not verify this fix, but I think @RonnieAshlock did).