### PR TITLE
Fix issue where EngineView causes other UI to render black

### DIFF
--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -92,7 +92,7 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
 
     if (!failedInitialization) {
         return (
-            <View style={props.style}>
+            <View style={[props.style, {overflow: "hidden"}]}>
                 <NativeEngineView style={{flex: 1}} />
                 { fps && <Text style={{color: 'yellow', position: 'absolute', margin: 10, right: 0, top: 0}}>FPS: {Math.round(fps)}</Text> }
             </View>


### PR DESCRIPTION
I found that on Android, if you have any `<View>`s that are siblings of `EngineView`, the sibling `<View>`s just render black. I still don't fully understand this behavior, but I saw other people hitting the same issue when doing any kind of OpenGL rendering to a `SurfaceView`/`GLSurfaceView` (e.g. https://stackoverflow.com/questions/56728120/react-native-android-resizing-native-ui-component-causes-black-out). This seems to be some kind of issue with the control drawing outside of its bounds, and setting the `overflow` style attribute to `hidden` fixes the issue. Therefore, I am forcefully setting this in the `<View>` wrapping the native view (overrides anything the consumer might set).