### PR TITLE
Update Babylon.js and Babylon Native to the latest

### DIFF
--- a/Apps/PackageTest/android/app/proguard-rules.pro
+++ b/Apps/PackageTest/android/app/proguard-rules.pro
@@ -8,3 +8,5 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+-keep class com.facebook.hermes.unicode.** { *; }
+-keep class com.facebook.jni.** { *; }

--- a/Apps/PackageTest/package-lock.json
+++ b/Apps/PackageTest/package-lock.json
@@ -917,7 +917,10 @@
     },
     "@babylonjs/react-native": {
       "version": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-RvTxF2QORndrlnINWKjgsejFD6OhsgHN3Obhv1SKtq9W23HTaSVltljkODWP0XQWYHKZUed4F9OIRYs5L8hBKQ=="
+      "integrity": "sha512-4jX1t/2fNiqmJoor/0OE8NG4WRcpvcWSfeZ0hpH3OG84MBUIs3f1rcqqwK47WChRThAjuqtBJbqBs2xdKBLGoA==",
+      "requires": {
+        "base-64": "^0.1.0"
+      }
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -2103,6 +2106,11 @@
           }
         }
       }
+    },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
     },
     "base64-js": {
       "version": "1.3.1",

--- a/Apps/PackageTest/package-lock.json
+++ b/Apps/PackageTest/package-lock.json
@@ -908,9 +908,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-alpha.30.tgz",
-      "integrity": "sha512-8OZJS8zCIPkPPAhlDf0o5E9neVqSEC76+WDxMJY+oWUvZ3x7A8Tq8jd1rpic3gyPtqyUE8wDpzgy0QgBta9L1g==",
+      "version": "4.2.0-alpha.31",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-alpha.31.tgz",
+      "integrity": "sha512-QK3vf37vkF+R2SIbiPak67o5B8GSWSrt6lcToxaAq8N2NWeGsdoqx+8m0Zf6q0QzCfXmKRky7myooZF/FUVbJQ==",
       "requires": {
         "tslib": ">=1.10.0"
       }

--- a/Apps/PackageTest/package.json
+++ b/Apps/PackageTest/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "4.2.0-alpha.30",
+    "@babylonjs/core": "4.2.0-alpha.31",
     "@babylonjs/react-native": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/Playground/android/app/proguard-rules.pro
+++ b/Apps/Playground/android/app/proguard-rules.pro
@@ -8,3 +8,5 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+-keep class com.facebook.hermes.unicode.** { *; }
+-keep class com.facebook.jni.** { *; }

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -864,20 +864,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-alpha.30.tgz",
-      "integrity": "sha512-8OZJS8zCIPkPPAhlDf0o5E9neVqSEC76+WDxMJY+oWUvZ3x7A8Tq8jd1rpic3gyPtqyUE8wDpzgy0QgBta9L1g==",
+      "version": "4.2.0-alpha.31",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-alpha.31.tgz",
+      "integrity": "sha512-QK3vf37vkF+R2SIbiPak67o5B8GSWSrt6lcToxaAq8N2NWeGsdoqx+8m0Zf6q0QzCfXmKRky7myooZF/FUVbJQ==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "4.2.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-alpha.30.tgz",
-      "integrity": "sha512-V6g48p3ffrTtJ2vfmqqMHhBFS56j09v+IuoCySDHElCLAaM8Dj3WsjwEq8AjT83Hv7pBPjteUlJ6XH+rsDK5CQ==",
+      "version": "4.2.0-alpha.31",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-alpha.31.tgz",
+      "integrity": "sha512-us1f7C5Q9u4ecXRwGKVseWosDiSFM/EClacr7Cn5XgEm6RLUxDB3C9Mabg7RTQL7CyoJ21zcZcHtorMc9YfUiw==",
       "requires": {
-        "@babylonjs/core": "4.2.0-alpha.30",
-        "babylonjs-gltf2interface": "4.2.0-alpha.30",
+        "@babylonjs/core": "4.2.0-alpha.31",
+        "babylonjs-gltf2interface": "4.2.0-alpha.31",
         "tslib": ">=1.10.0"
       }
     },
@@ -3053,9 +3053,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "4.2.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-alpha.30.tgz",
-      "integrity": "sha512-FPxo3XcexccYSgJIhI2M18MvB2qlDlDKIlKCF1ZqL+KdblRhYv3IZ3Y5RuzJm2LKLJzUJMHCsX2MR7F4/XH8VQ=="
+      "version": "4.2.0-alpha.31",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-alpha.31.tgz",
+      "integrity": "sha512-IwL3tTkD0zci/sGYcDYUz169/lvI36ltZXoYe55A8AwcOiFl0lOXlPUPOoo7FYuHgqrI430enepQJXrgw6Jchg=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "4.2.0-alpha.30",
-    "@babylonjs/loaders": "4.2.0-alpha.30",
+    "@babylonjs/core": "4.2.0-alpha.31",
+    "@babylonjs/loaders": "4.2.0-alpha.31",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "logkitty": "^0.7.1",

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -27,7 +27,7 @@
     "base-64": "^0.1.0"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^4.2.0-alpha.30",
+    "@babylonjs/core": "^4.2.0-alpha.31",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
     "react-native-permissions": "^2.1.4"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ This project provides Babylon Native integration into React Native.
 Babylon React Native is in the early phase of its development, and has the following limitations:
 
 1. Android and iOS support only - support for Windows is planned, but the timeline is currently unknown.
-1. JavaScriptCore (JSC) only - the published @babylonjs/react-native package is configured specifically for JSC, though it is possible to rebuild it and target other JavaScript engines supported by React Native. In the future, the published package will directly support all JavaScript engines that can be used with React Native.
+1. Touch input only - mouse, keyboard, and controllers are not yet supported.
+1. Single view only - multiple views are not yet supported (only a single view can be displayed).
+
+It is also worth noting that Babylon React Native relies heavily on newer React Native constructs including JSI to get the performance characteristics required for real time rendering. JSI allows for direct synchronous communication between native code and JavaScript code, but is incompatible with "remote debugging." If you need to debug your JavaScript code that uses Babylon React Native, you should enable Hermes and use "direct debugging" (e.g. chrome://inspect or edge://inspect). See the [React Native documentation](https://reactnative.dev/docs/hermes) for more info.
 
 ## Usage
 


### PR DESCRIPTION
And sneak in a couple additional changes:
- Update the `proguard-rules.pro` files to work correctly with Hermes.
- Update the `README.md` to indicate support for Hermes.
- Update PackageTests's npm modules (`package.json.lock` specifically) to reflect dependency on `base-64` (missed this in a previous change).