### PR TITLE
Update Babylon Native and Babylon.js to the latest

### DIFF
--- a/Apps/PackageTest/package-lock.json
+++ b/Apps/PackageTest/package-lock.json
@@ -908,16 +908,16 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-alpha.33.tgz",
-      "integrity": "sha512-pxDdwJsuC0shJADLDxEH48ZsoR3NjyxGRV9Y/mTb9vaIxwTjWouWuhShIKtv+qdoTBfhUT3fRn2Ah9Wq7wwNxA==",
+      "version": "4.2.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.1.tgz",
+      "integrity": "sha512-+obrGFrLriMttGcinqDTSZDyPFU4slZaGxO0zISdAItnhNxS6d+P0k7OvUQySJgvHoThI3e0J3h8BFO6hpKYcg==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/react-native": {
       "version": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-6wYOCDP8Oyx989hEDh8Ow44+8Nd0fGCyL4enbIPTbXJ9vnP4xU2Dx1iumJgF76YljaLxeNzdX7oWhg9F68mnbw==",
+      "integrity": "sha512-P9tJSJJbC7g0kYgci6VmnmUmJmdbb9Ml0Gy/y5nZz8QS2X1AIymVNFDuArPhLvu8hkbpv/hEA5WgZBc5oRh7vw==",
       "requires": {
         "base-64": "^0.1.0"
       }

--- a/Apps/PackageTest/package.json
+++ b/Apps/PackageTest/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "4.2.0-alpha.33",
+    "@babylonjs/core": "^4.2.0-beta.1",
     "@babylonjs/react-native": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/Playground/metro.config.js
+++ b/Apps/Playground/metro.config.js
@@ -26,7 +26,7 @@ function getModuleMappings() {
         if (!path.isAbsolute(linkPath)) {
           linkPath = path.resolve(directory, linkPath);
         }
-        const linkStat = fs.lstatSync(linkPath);
+        const linkStat = fs.statSync(linkPath);
         if (linkStat.isDirectory()) {
           const packagePath = path.resolve(linkPath, "package.json");
           if (fs.existsSync(packagePath)) {

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -864,21 +864,31 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-alpha.33.tgz",
-      "integrity": "sha512-pxDdwJsuC0shJADLDxEH48ZsoR3NjyxGRV9Y/mTb9vaIxwTjWouWuhShIKtv+qdoTBfhUT3fRn2Ah9Wq7wwNxA==",
+      "version": "4.2.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.1.tgz",
+      "integrity": "sha512-+obrGFrLriMttGcinqDTSZDyPFU4slZaGxO0zISdAItnhNxS6d+P0k7OvUQySJgvHoThI3e0J3h8BFO6hpKYcg==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "4.2.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-alpha.33.tgz",
-      "integrity": "sha512-VOPmKOGN85mksDpgfT3tJMjXOsyVf63ZfA/nA7beTAWdNptJcOMXmSSiidkrl28CE+9qzZ6AwUJ7aN9knxbAlg==",
+      "version": "4.2.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.1.tgz",
+      "integrity": "sha512-AKmRpLSewet27eijaZ2W567pPc8qMYIqhcwI4u+XLtDtb3bfWhzLgVDpNZDBWW1VL52ZmINPIg+AtG0cZ/+XVQ==",
       "requires": {
-        "@babylonjs/core": "4.2.0-alpha.33",
-        "babylonjs-gltf2interface": "4.2.0-alpha.33",
+        "@babylonjs/core": "4.2.0-beta.1",
+        "babylonjs-gltf2interface": "4.2.0-beta.1",
         "tslib": ">=1.10.0"
+      },
+      "dependencies": {
+        "@babylonjs/core": {
+          "version": "4.2.0-beta.1",
+          "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.1.tgz",
+          "integrity": "sha512-+obrGFrLriMttGcinqDTSZDyPFU4slZaGxO0zISdAItnhNxS6d+P0k7OvUQySJgvHoThI3e0J3h8BFO6hpKYcg==",
+          "requires": {
+            "tslib": ">=1.10.0"
+          }
+        }
       }
     },
     "@babylonjs/react-native": {
@@ -3053,9 +3063,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "4.2.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-alpha.33.tgz",
-      "integrity": "sha512-xOT4ORQmkXSzfp26Spwrw0HIMd9DpgPkHowDhLc7fF+fZ/io5oSMa5GM+OQ1KWWaENxgD6wFTjdPZztP5NH8Dw=="
+      "version": "4.2.0-beta.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.1.tgz",
+      "integrity": "sha512-7aN5ToP377lBhbfsIJNsLXI3+l6GvUjjE9/wWIzBrWcXZh68JiwSTsxZWX5cZChugMf2rxIUNXCF3BYH5tOixA=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "4.2.0-alpha.33",
-    "@babylonjs/loaders": "4.2.0-alpha.33",
+    "@babylonjs/core": "^4.2.0-beta.1",
+    "@babylonjs/loaders": "^4.2.0-beta.1",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "logkitty": "^0.7.1",

--- a/Modules/@babylonjs/react-native/README.md
+++ b/Modules/@babylonjs/react-native/README.md
@@ -10,10 +10,6 @@ This package has several **peer dependencies**. If these dependencies are unmet,
 
 The `react-native-permissions` dependency is required for XR capabilities of Babylon.js (to request camera permissions automatically). Be sure to follow the `react-native-permissions` [instructions](https://github.com/react-native-community/react-native-permissions#setup) to update your `Podfile` and `Info.plist` (iOS) and/or `AndroidManifest.xml` (Android).
 
-### C++ Build Requirements
-
-This package includes C++ source, so platform specific tooling to build C++ code must be installed.
-
 ### Android Configuration
 
 The minimum Android SDK version is 18. This must be set as `minSdkVersion` in the consuming project's `build.gradle` file.


### PR DESCRIPTION
- Updating Babylon Native to the latest to pull in the iOS XR improvements (less swimmy).
- Updating Babylon.js to the latest (4.2.0-beta.1) just to stay up to date and make sure we don't have any regressions.
- Updating the README.md to remove the old note about needing C++ tooling (now all (most) of the C++ is precompiled).
- Fixing a (potential?) bug in metro.config.js (I [shared our solution with the community](https://github.com/react-native-community/cli/issues/1238) and someone found a bug in it that didn't repro for me, but their solution seems more correct according to docs and also works for us, so I changed it to be sure).