### PR TITLE
Add takeSnapshot support to EngineView

### DIFF
--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -81,7 +81,7 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
 
   const onSnapshot = useCallback(async () => {
     if (engineViewCallbacks) {
-      setSnapshotData("data:image/jpeg;base64," + await engineViewCallbacks?.takeSnapshot());
+      setSnapshotData("data:image/jpeg;base64," + await engineViewCallbacks.takeSnapshot());
     }
   }, [engineViewCallbacks]);
 

--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -14,6 +14,7 @@ import Slider from '@react-native-community/slider';
 
 const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
   const defaultScale = 1;
+  const enableSnapshots = false;
 
   const engine = useEngine();
   const [toggleView, setToggleView] = useState(false);
@@ -22,8 +23,7 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
   const [scene, setScene] = useState<Scene>();
   const [xrSession, setXrSession] = useState<WebXRSessionManager>();
   const [scale, setScale] = useState<number>(defaultScale);
-  const [screenshotData, setScreenshotData] = useState<string>();
-  let screenshotDataString: string = "";
+  const [snapshotData, setSnapshotData] = useState<string>();
   let engineViewHooks: EngineViewHooks | undefined;
 
   useEffect(() => {
@@ -75,14 +75,9 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
     })();
   }, [box, scene, xrSession]);
 
-  const onScreenshot = async () => {
-        if (screenshotData) {
-            console.log(screenshotData);
-            setScreenshotData(undefined);
-        }
-        else if (engineViewHooks) {
-            screenshotDataString = "data:image/jpeg;base64," + (await engineViewHooks?.takeScreenshot()).replace(/(\r\n|\n|\r)/gm, "");
-            setScreenshotData(screenshotDataString);
+  const onSnapshot = async () => {
+        if (engineViewHooks) {
+            setSnapshotData("data:image/jpeg;base64," + (await engineViewHooks?.takeSnapshot()).replace(/(\r\n|\n|\r)/gm, ""));
         }
   };
 
@@ -91,10 +86,14 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
       <View style={props.style}>
         <Button title="Toggle EngineView" onPress={() => { setToggleView(!toggleView) }} />
         <Button title={ xrSession ? "Stop XR" : "Start XR"} onPress={onToggleXr} />
-        <Button title={"Take Screenshot"} onPress={onScreenshot}/>
         { !toggleView &&
           <View style={{flex: 1}}>
-            <Image style={{width:100, height:100}} source={{uri: screenshotData }} />
+            { enableSnapshots && 
+                <View style ={{flex: 1}}>
+                    <Button title={"Take Snapshot"} onPress={onSnapshot}/>
+                    <Image style={{flex: 1}} source={{uri: snapshotData }} />
+                </View>
+            }
             <EngineView style={props.style} camera={camera} initialized={(viewHooks: EngineViewHooks) => { engineViewHooks = viewHooks; }} />
             <Slider style={{position: 'absolute', minHeight: 50, margin: 10, left: 0, right: 0, bottom: 0}} minimumValue={0.2} maximumValue={2} value={defaultScale} onValueChange={setScale} />
           </View>

--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -94,12 +94,8 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
         <Button title={"Take Screenshot"} onPress={onScreenshot}/>
         { !toggleView &&
           <View style={{flex: 1}}>
-            { screenshotData &&
-                <Image style={{flex: 1}} source={{uri: screenshotData }} />
-            }
-            {!screenshotData && 
-                <EngineView style={props.style} camera={camera} initialized={(viewHooks: EngineViewHooks) => { engineViewHooks = viewHooks; }} />
-            }
+            <Image style={{width:100, height:100}} source={{uri: screenshotData }} />
+            <EngineView style={props.style} camera={camera} initialized={(viewHooks: EngineViewHooks) => { engineViewHooks = viewHooks; }} />
             <Slider style={{position: 'absolute', minHeight: 50, margin: 10, left: 0, right: 0, bottom: 0}} minimumValue={0.2} maximumValue={2} value={defaultScale} onValueChange={setScale} />
           </View>
         }

--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -94,7 +94,7 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
                     <Image style={{flex: 1}} source={{uri: snapshotData }} />
                 </View>
             }
-            <EngineView style={props.style} camera={camera} initialized={(viewHooks: EngineViewHooks) => { engineViewHooks = viewHooks; }} />
+            <EngineView style={props.style} camera={camera} onInitialized={(viewHooks: EngineViewHooks) => { engineViewHooks = viewHooks; }} />
             <Slider style={{position: 'absolute', minHeight: 50, margin: 10, left: 0, right: 0, bottom: 0}} minimumValue={0.2} maximumValue={2} value={defaultScale} onValueChange={setScale} />
           </View>
         }

--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -100,7 +100,6 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
             {!screenshotData && 
                 <EngineView style={props.style} camera={camera} initialized={(viewHooks: EngineViewHooks) => { engineViewHooks = viewHooks; }} />
             }
-
             <Slider style={{position: 'absolute', minHeight: 50, margin: 10, left: 0, right: 0, bottom: 0}} minimumValue={0.2} maximumValue={2} value={defaultScale} onValueChange={setScale} />
           </View>
         }

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -133,7 +133,7 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
 
     // Handle snapshot data returned.
     const snapshotDataReturnedHandler = useCallback((event: SyntheticEvent) => {
-        let { data } = event.nativeEvent;
+        const { data } = event.nativeEvent;
         if (snapshotPromise) {
             snapshotPromise.resolve(data);
             setSnapshotPromise(undefined);

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -98,34 +98,35 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
         setFps(undefined);
     }, [props.camera, props.displayFrameRate]);
 
-    // Call initialized and include the hook to takeScreeenshot
+    // Call initialized and include the hook to takeScreenshot
     if (props.initialized) {
         props.initialized(
             {
                 takeScreenshot: () => {
                     if (!screenshotPromise) {
-                    let resolutionFunctions: { resolve: (data: string) => void, reject: () => void } | undefined;
-                    const promise = new Promise<string>((resolutionFunc, rejectionFunc) => {
-                        resolutionFunctions = {resolve: resolutionFunc, reject: rejectionFunc};
-                    });
+                        let resolutionFunctions: { resolve: (data: string) => void, reject: () => void } | undefined;
+                        const promise = new Promise<string>((resolutionFunc, rejectionFunc) => {
+                            resolutionFunctions = {resolve: resolutionFunc, reject: rejectionFunc};
+                        });
 
-                    if (resolutionFunctions) {
-                        setScreenshotPromise({ promise: promise, resolve: resolutionFunctions.resolve, reject: resolutionFunctions.reject });
+                        if (resolutionFunctions) {
+                            setScreenshotPromise({ promise: promise, resolve: resolutionFunctions.resolve, reject: resolutionFunctions.reject });
+                        }
+
+                        UIManager.dispatchViewManagerCommand(
+                            findNodeHandle(engineViewRef.current),
+                            UIManager.getViewManagerConfig("EngineView").Commands["takeSnapshot"],
+                            []);
+
+                        return promise;
                     }
 
-                    UIManager.dispatchViewManagerCommand(
-                        findNodeHandle(engineViewRef.current),
-                        UIManager.getViewManagerConfig("EngineView").Commands["takeSnapshot"],
-                        []);
-
-                    return promise;
-                 }
-
-                 return screenshotPromise.promise;
+                    return screenshotPromise.promise;
             }
         });
     }
 
+    // Handle snapshot data returned.
     const snapshotDataReturnedHandler = (event: SyntheticEvent) => {
         let { data } = event.nativeEvent;
         if (screenshotPromise) {

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -113,8 +113,6 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
                         setScreenshotPromise({ promise: promise, resolve: resolutionFunctions.resolve, reject: resolutionFunctions.reject });
                     }
 
-                    let nodeHandle = findNodeHandle(engineViewRef.current)
-                    let commandID = UIManager.getViewManagerConfig("EngineView").Commands["takeSnapshot"]
                     UIManager.dispatchViewManagerCommand(
                         findNodeHandle(engineViewRef.current),
                         UIManager.getViewManagerConfig("EngineView").Commands["takeSnapshot"],

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -17,7 +17,7 @@ if (EngineViewManager && EngineViewManager.setJSThread && !isRemoteDebuggingEnab
 }
 
 interface NativeEngineViewProps extends ViewProps {
-    snapshotDataReturned: (event: SyntheticEvent) => void;
+    onSnapshotDataReturned: (event: SyntheticEvent) => void;
 }
 
 const NativeEngineView: {
@@ -138,7 +138,7 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
     if (!failedInitialization) {
         return (
             <View style={[props.style, {overflow: "hidden"}]}>
-                <NativeEngineView ref={engineViewRef} style={{flex: 1}} snapshotDataReturned={snapshotDataReturnedHandler} />
+                <NativeEngineView ref={engineViewRef} style={{flex: 1}} onSnapshotDataReturned={snapshotDataReturnedHandler} />
                 { fps && <Text style={{color: 'yellow', position: 'absolute', margin: 10, right: 0, top: 0}}>FPS: {Math.round(fps)}</Text> }
             </View>
         );

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -102,16 +102,16 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
     useEffect(() => {
         if (props.onInitialized) {
             props.onInitialized({
-                takeSnapshot: () => {
+                takeSnapshot: (): Promise<string> => {
                     if (!snapshotPromise.current) {
-                        let resolutionFunctions: { resolve: (data: string) => void, reject: () => void } | undefined;
-                        const promise = new Promise<string>((resolutionFunc, rejectionFunc) => {
-                            resolutionFunctions = {resolve: resolutionFunc, reject: rejectionFunc};
+                        let resolveFunction: ((data: string) => void) | undefined;
+                        const promise = new Promise<string>((resolutionFunc) => {
+                            resolveFunction = resolutionFunc;
                         });
 
                         // Resolution functions should always be initialized.
-                        if (resolutionFunctions) {
-                            snapshotPromise.current = { promise: promise, resolve: resolutionFunctions.resolve, reject: resolutionFunctions.reject };
+                        if (resolveFunction) {
+                            snapshotPromise.current = { promise: promise, resolve: resolveFunction };
                         }
                         else {
                             throw "Resolution functions not initialized after snapshot promise creation.";
@@ -121,11 +121,9 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
                             findNodeHandle(engineViewRef.current),
                             "takeSnapshot",
                             []);
-
-                        return promise;
                     }
 
-                    return snapshotPromise.promise;
+                    return snapshotPromise.current.promise;
                 }
             });
         }

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent, Component, useEffect, useState } from 'react';
-import { requireNativeComponent, NativeModules, ViewProps, AppState, AppStateStatus, View, Text } from 'react-native';
+import React, { FunctionComponent, Component, useEffect, useState, useRef, useCallback } from 'react';
+import { requireNativeComponent, NativeModules, ViewProps, AppState, AppStateStatus, View, Text, findNodeHandle, UIManager } from 'react-native';
 import { Camera } from '@babylonjs/core';
 import { IsEngineDisposed } from './EngineHelpers';
 import { BabylonModule } from './BabylonModule';
@@ -32,6 +32,7 @@ export interface EngineViewProps extends ViewProps {
 export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineViewProps) => {
     const [failedInitialization, setFailedInitialization] = useState(false);
     const [fps, setFps] = useState<number>();
+    const engineViewRef = React.createRef();
 
     useEffect(() => {
         (async () => {
@@ -90,10 +91,17 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
         setFps(undefined);
     }, [props.camera, props.displayFrameRate]);
 
+    useCallback(() => {
+        UIManager.dispatchViewManagerCommand(
+            findNodeHandle(engineViewRef),
+            UIManager.getViewManagerConfig("EngineView").Commands.takeSnapshot,
+            []);
+    },[])
+
     if (!failedInitialization) {
         return (
             <View style={[props.style, {overflow: "hidden"}]}>
-                <NativeEngineView style={{flex: 1}} />
+                <NativeEngineView ref={engineViewRef} style={{flex: 1}} />
                 { fps && <Text style={{color: 'yellow', position: 'absolute', margin: 10, right: 0, top: 0}}>FPS: {Math.round(fps)}</Text> }
             </View>
         );

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -27,12 +27,17 @@ const NativeEngineView: {
 export interface EngineViewProps extends ViewProps {
     camera?: Camera;
     displayFrameRate?: boolean;
+    initalized?: (view: EngineViewHooks) => void;
+}
+
+export interface EngineViewHooks {
+    takeScreenshot: () => Promise<string>;
 }
 
 export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineViewProps) => {
     const [failedInitialization, setFailedInitialization] = useState(false);
     const [fps, setFps] = useState<number>();
-    const engineViewRef = useRef<Component<NativeEngineViewProps & ViewProps>>(null);
+    const engineViewRef = useRef<Component<NativeEngineViewProps>>(null);
 
     useEffect(() => {
         (async () => {
@@ -91,12 +96,19 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
         setFps(undefined);
     }, [props.camera, props.displayFrameRate]);
 
-    useCallback(() => {
-        UIManager.dispatchViewManagerCommand(
-            findNodeHandle(engineViewRef.current),
-            UIManager.getViewManagerConfig("EngineView").Commands.takeSnapshot,
-            []);
-    },[])
+    // Call initialized and include the hook to takeScreeenshot
+    if (props.initalized) {
+        props.initalized(
+            {
+                takeScreenshot: () => {
+                    UIManager.dispatchViewManagerCommand(
+                        findNodeHandle(engineViewRef.current),
+                        UIManager.getViewManagerConfig("EngineView").Commands.takeSnapshot,
+                        []);
+                    return Promise.resolve("");
+            }
+        });
+    }
 
     if (!failedInitialization) {
         return (

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -32,7 +32,7 @@ export interface EngineViewProps extends ViewProps {
 export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineViewProps) => {
     const [failedInitialization, setFailedInitialization] = useState(false);
     const [fps, setFps] = useState<number>();
-    const engineViewRef = React.createRef();
+    const engineViewRef = useRef<Component<NativeEngineViewProps & ViewProps>>(null);
 
     useEffect(() => {
         (async () => {
@@ -93,7 +93,7 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
 
     useCallback(() => {
         UIManager.dispatchViewManagerCommand(
-            findNodeHandle(engineViewRef),
+            findNodeHandle(engineViewRef.current),
             UIManager.getViewManagerConfig("EngineView").Commands.takeSnapshot,
             []);
     },[])

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineView.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineView.java
@@ -73,7 +73,7 @@ public final class EngineView extends SurfaceView implements SurfaceHolder.Callb
         // Request the pixel copy.
         PixelCopy.request(this, bitmap, (copyResult) ->  {
             // If the pixel copy was a success then convert the image to a base 64 encoded jpeg and fire the event.
-            String encoded ="";
+            String encoded = "";
             if (copyResult == PixelCopy.SUCCESS) {
                 ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
                 bitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayStream);

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineView.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineView.java
@@ -59,8 +59,8 @@ public final class EngineView extends SurfaceView implements SurfaceHolder.Callb
         final Handler helperThreadHandler = new Handler(helperThread.getLooper());
 
         final Bitmap bitmap = Bitmap.createBitmap(
-                getRootView().getWidth(),
-                getRootView().getHeight(),
+                getWidth(),
+                getHeight(),
                 Bitmap.Config.ARGB_8888);
 
         PixelCopy.request(this, bitmap, (copyResult) ->  {
@@ -76,7 +76,8 @@ public final class EngineView extends SurfaceView implements SurfaceHolder.Callb
                     encoded = Base64.encodeToString(byteArray, Base64.DEFAULT);
                 }
 
-                reactEventDispatcher.dispatchEvent(new SnapshotDataReturnedEvent(encoded));
+                SnapshotDataReturnedEvent snapshotEvent = new SnapshotDataReturnedEvent(this.getId(), encoded);
+                reactEventDispatcher.dispatchEvent(snapshotEvent);
                 helperThread.quitSafely();
             }
         }, helperThreadHandler);

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineView.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineView.java
@@ -1,20 +1,32 @@
 package com.reactlibrary;
 
+import android.annotation.TargetApi;
+import android.graphics.Bitmap;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.util.Base64;
 import android.view.MotionEvent;
+import android.view.PixelCopy;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.EventDispatcher;
+
+import java.io.ByteArrayOutputStream;
 
 public final class EngineView extends SurfaceView implements SurfaceHolder.Callback, View.OnTouchListener {
     private final ReactContext reactContext;
+    private final EventDispatcher reactEventDispatcher;
 
     public EngineView(ReactContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         this.getHolder().addCallback(this);
         this.setOnTouchListener(this);
+        this.reactEventDispatcher = this.reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
     }
 
     @Override
@@ -36,5 +48,37 @@ public final class EngineView extends SurfaceView implements SurfaceHolder.Callb
     public boolean onTouch(View view, MotionEvent motionEvent) {
         BabylonNativeInterop.reportMotionEvent(this.reactContext, motionEvent);
         return true;
+    }
+
+    @TargetApi(24)
+    public void takeSnapshot() {
+        // no-op for now.
+        // Offload the screenshot to a helper thread.
+        final HandlerThread helperThread = new HandlerThread("ScreenCapture",-1);
+        helperThread.start();
+        final Handler helperThreadHandler = new Handler(helperThread.getLooper());
+
+        final Bitmap bitmap = Bitmap.createBitmap(
+                getRootView().getWidth(),
+                getRootView().getHeight(),
+                Bitmap.Config.ARGB_8888);
+
+        PixelCopy.request(this, bitmap, (copyResult) ->  {
+            if (copyResult == PixelCopy.SUCCESS) {
+                // Encode the result to base64.
+                ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayStream);
+                String encoded = "";
+                {
+                    byte[] byteArray = byteArrayStream.toByteArray();
+                    bitmap.recycle();
+
+                    encoded = Base64.encodeToString(byteArray, Base64.DEFAULT);
+                }
+
+                reactEventDispatcher.dispatchEvent(new SnapshotDataReturnedEvent(encoded));
+                helperThread.quitSafely();
+            }
+        }, helperThreadHandler);
     }
 }

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineViewManager.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineViewManager.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 public final class EngineViewManager extends SimpleViewManager<EngineView> {
     public static final int COMMAND_TAKE_SNAPSHOT = 0;
+    public static final String COMMAND_TAKE_SNAPSHOT_NAME = "takeSnapshot";
 
     @NonNull
     @Override
@@ -34,18 +35,26 @@ public final class EngineViewManager extends SimpleViewManager<EngineView> {
     @Override
     public Map<String,Integer> getCommandsMap() {
         return MapBuilder.of(
-            "takeSnapshot",
+            COMMAND_TAKE_SNAPSHOT_NAME,
             COMMAND_TAKE_SNAPSHOT
         );
     }
 
     @Override
     public void receiveCommand(final EngineView view, int commandId, ReadableArray args) {
-    // This will be called whenever a command is sent from react-native.
-    switch (commandId) {
-      case COMMAND_TAKE_SNAPSHOT:
-        view.takeSnapshot();
-        break;
+        // This will be called whenever a command is sent from react-native.
+        switch (commandId) {
+            case COMMAND_TAKE_SNAPSHOT:
+                view.takeSnapshot();
+                break;
+        }
     }
-  }
+
+    @Override
+    public Map getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.builder()
+                .put(SnapshotDataReturnedEvent.EVENT_NAME,
+                    MapBuilder.of("registrationName", SnapshotDataReturnedEvent.EVENT_NAME))
+                .build();
+    }
 }

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineViewManager.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineViewManager.java
@@ -47,6 +47,9 @@ public final class EngineViewManager extends SimpleViewManager<EngineView> {
             case COMMAND_TAKE_SNAPSHOT_NAME:
                 view.takeSnapshot();
                 break;
+            default:
+                throw new IllegalArgumentException(
+                    String.format("Invalid command %s specified for EngineView.  Supported Commands: takeSnapshot", commandId));
         }
     }
 

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineViewManager.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineViewManager.java
@@ -3,6 +3,7 @@ package com.reactlibrary;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -10,6 +11,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import java.util.Map;
 
 public final class EngineViewManager extends SimpleViewManager<EngineView> {
+    public static final int COMMAND_TAKE_SNAPSHOT = 0;
 
     @NonNull
     @Override
@@ -28,4 +30,22 @@ public final class EngineViewManager extends SimpleViewManager<EngineView> {
         super.onDropViewInstance(view);
         // TODO: Native view specific cleanup
     }
+
+    @Override
+    public Map<String,Integer> getCommandsMap() {
+        return MapBuilder.of(
+            "takeSnapshot",
+            COMMAND_TAKE_SNAPSHOT
+        );
+    }
+
+    @Override
+    public void receiveCommand(final EngineView view, int commandId, ReadableArray args) {
+    // This will be called whenever a command is sent from react-native.
+    switch (commandId) {
+      case COMMAND_TAKE_SNAPSHOT:
+        view.takeSnapshot();
+        break;
+    }
+  }
 }

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineViewManager.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/EngineViewManager.java
@@ -41,10 +41,10 @@ public final class EngineViewManager extends SimpleViewManager<EngineView> {
     }
 
     @Override
-    public void receiveCommand(final EngineView view, int commandId, ReadableArray args) {
+    public void receiveCommand(final EngineView view, String commandId, ReadableArray args) {
         // This will be called whenever a command is sent from react-native.
         switch (commandId) {
-            case COMMAND_TAKE_SNAPSHOT:
+            case COMMAND_TAKE_SNAPSHOT_NAME:
                 view.takeSnapshot();
                 break;
         }

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/SnapshotDataReturnedEvent.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/SnapshotDataReturnedEvent.java
@@ -1,0 +1,27 @@
+package com.reactlibrary;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+public class SnapshotDataReturnedEvent extends Event<SnapshotDataReturnedEvent> {
+    public static final String EVENT_NAME = "snapshotDataReturned";
+    public static final String DATA_NAME = "data";
+    private final WritableMap payload;
+
+    public SnapshotDataReturnedEvent(String imageData) {
+        this.payload = Arguments.createMap();
+        this.payload.putString(DATA_NAME, imageData);
+    }
+
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), this.payload);
+    }
+}

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/SnapshotDataReturnedEvent.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/SnapshotDataReturnedEvent.java
@@ -6,7 +6,7 @@ import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 public class SnapshotDataReturnedEvent extends Event<SnapshotDataReturnedEvent> {
-    public static final String EVENT_NAME = "snapshotDataReturned";
+    public static final String EVENT_NAME = "onSnapshotDataReturned";
     public static final String DATA_NAME = "data";
     private final WritableMap payload;
 

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/SnapshotDataReturnedEvent.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/reactlibrary/SnapshotDataReturnedEvent.java
@@ -10,7 +10,8 @@ public class SnapshotDataReturnedEvent extends Event<SnapshotDataReturnedEvent> 
     public static final String DATA_NAME = "data";
     private final WritableMap payload;
 
-    public SnapshotDataReturnedEvent(String imageData) {
+    public SnapshotDataReturnedEvent(int viewId, String imageData) {
+        super(viewId);
         this.payload = Arguments.createMap();
         this.payload.putString(DATA_NAME, imageData);
     }

--- a/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
+++ b/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
@@ -61,10 +61,10 @@
         [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:NO];
         
         // Grab the image from the graphics context, and convert into a base64 encoded JPG.
-        UIImage *capturedImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIImage* capturedImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
-        NSData *jpgData = UIImageJPEGRepresentation(capturedImage, 1.0f);
-        NSString *encodedData = [jpgData base64EncodedStringWithOptions:0];
+        NSData* jpgData = UIImageJPEGRepresentation(capturedImage, 1.0f);
+        NSString* encodedData = [jpgData base64EncodedStringWithOptions:0];
         
         // Fire the onSnapshotDataReturned event if hooked up.
         if (self.onSnapshotDataReturned != nil) {
@@ -89,8 +89,8 @@ RCT_EXPORT_VIEW_PROPERTY(onSnapshotDataReturned, RCTDirectEventBlock)
 
 RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber*) reactTag) {
     // Marshal the takeSnapshot call to the appropriate EngineView.
-    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
-        EngineView *view = (EngineView *)viewRegistry[reactTag];
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber*,UIView*>* viewRegistry) {
+        EngineView* view = (EngineView*)viewRegistry[reactTag];
         if (!view || ![view isKindOfClass:[EngineView class]]) {
             return;
         }

--- a/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
+++ b/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
@@ -1,12 +1,16 @@
 #import "BabylonNativeInterop.h"
 
 #import <React/RCTViewManager.h>
+#import <React/RCTUIManager.h>
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <MetalKit/MetalKit.h>
 
 @interface EngineView : MTKView
+
+@property (nonatomic, copy) RCTDirectEventBlock onSnapshotDataReturned;
+
 @end
 
 @implementation EngineView {
@@ -47,6 +51,47 @@
     [BabylonNativeInterop reportTouchEvent:touches withEvent:event];
 }
 
+- (void)takeSnapshot {
+    // Grab a reference to the currently presented drawable on us or a subview.
+    id<MTLTexture> currentDrawable = nil;
+    while (currentDrawable == nil) {
+        if (self.subviews != nil && self.subviews.count > 0) {
+            MTKView *xrView = (MTKView *)self.subviews[0];
+            currentDrawable = [xrView.currentDrawable texture];
+        }
+        else {
+            currentDrawable = [self.currentDrawable texture];
+        }
+    }
+    
+    int width = (int)[currentDrawable width];
+    int height = (int)[currentDrawable height];
+    int rowBytes = width * 4;
+    int textureSize = width * height * 4;
+    
+    // Allocate the bitmap, and load in the bytes
+    void* bitMap = malloc (textureSize);
+    [currentDrawable getBytes:bitMap bytesPerRow:rowBytes fromRegion:MTLRegionMake2D(0, 0, width, height) mipmapLevel:0];
+    
+    // Create the CGImage representation.
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Little | kCGImageAlphaFirst;
+    CGDataProviderRef provider = CGDataProviderCreateWithData(nil, bitMap, textureSize, nil);
+    CGImageRef cgImageRef = CGImageCreate(width, height, 8, 32, rowBytes, colorSpace, bitmapInfo, provider, nil, true, (CGColorRenderingIntent)kCGRenderingIntentDefault);
+    
+    // Create the UIImage from the CG Image.
+    UIImage *uiImage = [UIImage imageWithCGImage:cgImageRef];
+    
+    NSData *pngData = UIImagePNGRepresentation(uiImage);
+    NSString *encodedData = [pngData base64EncodedStringWithOptions:0];
+    if (self.onSnapshotDataReturned != nil && encodedData != nil) {
+        self.onSnapshotDataReturned(@{ @"data":encodedData});
+    }
+    
+    CFRelease(cgImageRef);
+    free(bitMap);
+}
+
 @end
 
 
@@ -58,6 +103,19 @@
 }
 
 RCT_EXPORT_MODULE(EngineViewManager)
+
+RCT_EXPORT_VIEW_PROPERTY(onSnapshotDataReturned, RCTDirectEventBlock)
+
+RCT_EXPORT_METHOD(takeSnapshot:(nonnull NSNumber*) reactTag) {
+    [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+        EngineView *view = (EngineView *)viewRegistry[reactTag];
+        if (!view || ![view isKindOfClass:[EngineView class]]) {
+            RCTLogError(@"Cannot find EngineView with tag #%@", reactTag);
+            return;
+        }
+        [view takeSnapshot];
+    }];
+}
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(setJSThread) {
     runLoop = [NSRunLoop currentRunLoop];

--- a/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
+++ b/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
@@ -52,18 +52,18 @@
 }
 
 - (void)takeSnapshot {
-    // We must take the screenshot on the main thread otherwise we might fail to get a handle on the view after screen updates.
+    // We must take the screenshot on the main thread otherwise we might fail to get a valid handle on the view's image.
     dispatch_async(dispatch_get_main_queue(), ^{
         // Start the graphics context.
-        UIGraphicsBeginImageContextWithOptions(self.bounds.size, YES, 0.0f);
+        UIGraphicsBeginImageContextWithOptions(self.bounds.size, YES /* opaque */, 0.0f);
         
-        // Draw the current state of the view into the graphics context after screen updates occur.
-        [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:YES];
+        // Draw the current state of the view into the graphics context.
+        [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:NO];
         
         // Grab the image from the graphics context, and convert into a base64 encoded JPG.
         UIImage *capturedImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
-        NSData *jpgData = UIImageJPEGRepresentation(capturedImage, 100.0f);
+        NSData *jpgData = UIImageJPEGRepresentation(capturedImage, 1.0f);
         NSString *encodedData = [jpgData base64EncodedStringWithOptions:0];
         
         // Fire the onSnapshotDataReturned event if hooked up.


### PR DESCRIPTION
This PR adds the ability to take a snapshot of content that is currently rendered for a given EngineView.

Important highlights of the implementation:
- Added a new callback prop "Initialized" to the EngineView which is used to set up a view handle that allows calling methods against the underlying native engine view.  Since EngineView is a FunctionComponent it does not actually support returning an object to make calls against it directly.
- Added takeSnapshot to the native EngineView which takes a direct snapshot of either the underlying SurfaceView or MTKView on iOS and Android respectively, and passes back the data as a Base64 encoded JPEG.
- Updated the sample app to optionally include taking snapshots.