### PR TITLE
Add SnapshotDataReturnedEvent.java to expected build output

### DIFF
--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -133,6 +133,7 @@ Assembled/android/src/main/java
 Assembled/android/src/main/java/com
 Assembled/android/src/main/java/com/reactlibrary
 Assembled/android/src/main/java/com/reactlibrary/BabylonNativeInterop.java
+Assembled/android/src/main/java/com/reactlibrary/SnapshotDataReturnedEvent.java
 Assembled/android/src/main/java/com/reactlibrary/BabylonModule.java
 Assembled/android/src/main/java/com/reactlibrary/BabylonPackage.java
 Assembled/android/src/main/java/com/reactlibrary/EngineViewManager.java


### PR DESCRIPTION
My last change #77 added a new file SnapshotDataReturnedEvent.java, but did not update the expected Gulp build output for the package.  This change adds that file to the output to unblock new release builds.