### PR TITLE
Fix double render on Android release

### DIFF
--- a/Apps/PackageTest/package-lock.json
+++ b/Apps/PackageTest/package-lock.json
@@ -908,9 +908,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.1.tgz",
-      "integrity": "sha512-+obrGFrLriMttGcinqDTSZDyPFU4slZaGxO0zISdAItnhNxS6d+P0k7OvUQySJgvHoThI3e0J3h8BFO6hpKYcg==",
+      "version": "4.2.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.2.tgz",
+      "integrity": "sha512-QPyroV1oHFQ0eKa+TrU2DhtLtleSGN2GbAvLU+ly+8NOVGMZvmKwm+8S/Nvb503+odnV7YgZdKpl5/3WligAYg==",
       "requires": {
         "tslib": ">=1.10.0"
       }

--- a/Apps/PackageTest/package.json
+++ b/Apps/PackageTest/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0-beta.1",
+    "@babylonjs/core": "^4.2.0-beta.2",
     "@babylonjs/react-native": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -864,31 +864,21 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.1.tgz",
-      "integrity": "sha512-+obrGFrLriMttGcinqDTSZDyPFU4slZaGxO0zISdAItnhNxS6d+P0k7OvUQySJgvHoThI3e0J3h8BFO6hpKYcg==",
+      "version": "4.2.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.2.tgz",
+      "integrity": "sha512-QPyroV1oHFQ0eKa+TrU2DhtLtleSGN2GbAvLU+ly+8NOVGMZvmKwm+8S/Nvb503+odnV7YgZdKpl5/3WligAYg==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "4.2.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.1.tgz",
-      "integrity": "sha512-AKmRpLSewet27eijaZ2W567pPc8qMYIqhcwI4u+XLtDtb3bfWhzLgVDpNZDBWW1VL52ZmINPIg+AtG0cZ/+XVQ==",
+      "version": "4.2.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.2.tgz",
+      "integrity": "sha512-qYNfU2bXUVxxiCEQwNZ2ANaC7RVothg54foCV2OKBMbqns4hp8DnPx0Cd44II7qpFEP6eSpznAfSKwlVPlDLwA==",
       "requires": {
-        "@babylonjs/core": "4.2.0-beta.1",
-        "babylonjs-gltf2interface": "4.2.0-beta.1",
+        "@babylonjs/core": "4.2.0-beta.2",
+        "babylonjs-gltf2interface": "4.2.0-beta.2",
         "tslib": ">=1.10.0"
-      },
-      "dependencies": {
-        "@babylonjs/core": {
-          "version": "4.2.0-beta.1",
-          "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.1.tgz",
-          "integrity": "sha512-+obrGFrLriMttGcinqDTSZDyPFU4slZaGxO0zISdAItnhNxS6d+P0k7OvUQySJgvHoThI3e0J3h8BFO6hpKYcg==",
-          "requires": {
-            "tslib": ">=1.10.0"
-          }
-        }
       }
     },
     "@babylonjs/react-native": {
@@ -3063,9 +3053,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "4.2.0-beta.1",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.1.tgz",
-      "integrity": "sha512-7aN5ToP377lBhbfsIJNsLXI3+l6GvUjjE9/wWIzBrWcXZh68JiwSTsxZWX5cZChugMf2rxIUNXCF3BYH5tOixA=="
+      "version": "4.2.0-beta.2",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.2.tgz",
+      "integrity": "sha512-5vnRb7Yv4TZop74/7vaB35Im9MsBngh6ChPUku7AQ0+WPW+5yXXr8JYFHzPz7gz9qWK4WcKXlZgiRsE7tcW2ag=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0-beta.1",
-    "@babylonjs/loaders": "^4.2.0-beta.1",
+    "@babylonjs/core": "^4.2.0-beta.2",
+    "@babylonjs/loaders": "^4.2.0-beta.2",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "logkitty": "^0.7.1",

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -66,13 +66,12 @@ export function useEngine(): Engine | undefined {
     const [engine, setEngine] = useState<Engine>();
 
     useEffect(() => {
-        let engine: Engine | undefined;
         let disposed = false;
 
         (async () => {
             if (await BabylonModule.initialize() && !disposed)
             {
-                engine = new NativeEngine();
+                const engine = new NativeEngine();
 
                 // NOTE: This is a workaround for https://github.com/BabylonJS/BabylonReactNative/issues/60
                 let heartbeat: NodeJS.Timeout | null;
@@ -119,9 +118,12 @@ export function useEngine(): Engine | undefined {
 
         return () => {
             disposed = true;
-            if (engine) {
-                DisposeEngine(engine);
-            }
+            setEngine(engine => {
+                if (engine) {
+                    DisposeEngine(engine);
+                }
+                return undefined;
+            })
         };
     }, []);
 


### PR DESCRIPTION
This is a fix for issue #78. The problem is that for some reason on Android specifically in release builds we get an extra app state changed event from React Native and incorrectly start a second render loop. The fix is to store the app state in react state, update it in the app state changed event, and start/stop the render loop as a side effect of an actual change in app state.

I also updated Babylon.js to the latest, which for some reason removed the dependency from loaders to core, which also fixes the issue where we end up with two definitions of `RegisterPlugin` and break gltf loading. It doesn't look like anything in Babylon.js changed, so the only thing I can think is that this is an issue with NPM itself, maybe if you install the dependencies out of order or something...

I also noticed that the `engine` returned by `useEngine` was not getting cleared when the associated `useEffect` cleans up (e.g. on unmount and fast refresh). I'm not aware of any problems this was causing, but it was not correct, so I fixed it in this PR as well.