### PR TITLE
Update the "heartbeat" workaround for promise continuations

### DIFF
--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -76,9 +76,8 @@ export function useEngine(): Engine | undefined {
         })();
 
         // NOTE: This is a workaround for https://github.com/BabylonJS/BabylonReactNative/issues/60
-        let continueHeartbeat = true;
         function heartbeat() {
-            if (continueHeartbeat) {
+            if (!disposed) {
                 setTimeout(heartbeat, 10);
             }
         }
@@ -92,7 +91,6 @@ export function useEngine(): Engine | undefined {
                 }
                 return undefined;
             });
-            continueHeartbeat = false;
         };
     }, []);
 

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -71,50 +71,18 @@ export function useEngine(): Engine | undefined {
         (async () => {
             if (await BabylonModule.initialize() && !disposed)
             {
-                const engine = new NativeEngine();
-
-                // NOTE: This is a workaround for https://github.com/BabylonJS/BabylonReactNative/issues/60
-                let heartbeat: NodeJS.Timeout | null;
-                const startHeartbeat = () => {
-                    if (!heartbeat) {
-                        heartbeat = setInterval(() => {}, 10);
-                    }
-                };
-                const stopHeartbeat = () => {
-                    if (heartbeat) {
-                        clearInterval(heartbeat);
-                        heartbeat = null;
-                    }
-                }
-                startHeartbeat();
-
-                let renderLoopCount = 0;
-
-                const originalRunRenderLoop: (...args: any[]) => void = engine.runRenderLoop;
-                engine.runRenderLoop = function(...args: any[]): void {
-                    originalRunRenderLoop.apply(this, args);
-                    if (++renderLoopCount == 1) {
-                        stopHeartbeat();
-                    }
-                }
-
-                const originalStopRenderLoop: (...args: any[]) => void = engine.stopRenderLoop;
-                engine.stopRenderLoop = function(...args: any[]): void {
-                    if (--renderLoopCount == 0) {
-                        startHeartbeat();
-                    }
-                    originalStopRenderLoop.apply(this, args);
-                }
-
-                const originalDipose = engine.dispose;
-                engine.dispose = function() {
-                    originalDipose.apply(this);
-                    stopHeartbeat();
-                };
-
-                setEngine(engine);
+                setEngine(new NativeEngine());
             }
         })();
+
+        // NOTE: This is a workaround for https://github.com/BabylonJS/BabylonReactNative/issues/60
+        let continueHeartbeat = true;
+        function heartbeat() {
+            if (continueHeartbeat) {
+                setTimeout(heartbeat, 10);
+            }
+        }
+        heartbeat();
 
         return () => {
             disposed = true;
@@ -123,7 +91,8 @@ export function useEngine(): Engine | undefined {
                     DisposeEngine(engine);
                 }
                 return undefined;
-            })
+            });
+            continueHeartbeat = false;
         };
     }, []);
 


### PR DESCRIPTION
To work around #60 (promise continuations not executing), we have this "heartbeat" mechanism that just calls `setInterval` which seems to have the side effect of causing promise continuations that are ready to run to actually run (we still don't know the root cause). However, this workaround has two problems specifically on Android release builds:
1. Stopping the heartbeat timer after the render loop starts running is not good enough - promise continuations still get hung up.
1. Using `setInterval` somehow interferes with UI responsiveness. It seems like there is some work queue somewhere that is getting filled up, but at the same time tapping the screen (for touch interactions) *is* still responsive (but tapping UI buttons is not).

There is definitely still more investigation that needs to be done here, but I'm updating the work around to work on Android release builds as well by:
1. Continuing the heartbeat for the lifetime of the engine.
1. Switching from `setInterval` to `setTimeout` to prevent the possibility of interval callbacks piling up.