### PR TITLE
Fix race condition in iOS React Native module init

### DIFF
--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -117,7 +117,7 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
                             snapshotPromise.current = { promise: promise, resolve: resolveFunction };
                         }
                         else {
-                            throw "Resolution functions not initialized after snapshot promise creation.";
+                            throw new Error("Resolution functions not initialized after snapshot promise creation.");
                         }
 
                         UIManager.dispatchViewManagerCommand(
@@ -151,7 +151,7 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
     } else {
         const message = "Could not initialize Babylon Native.";
         if (!__DEV__) {
-            throw Error(message)
+            throw new Error(message);
         }
 
         return (

--- a/Modules/@babylonjs/react-native/EngineView.tsx
+++ b/Modules/@babylonjs/react-native/EngineView.tsx
@@ -149,9 +149,14 @@ export const EngineView: FunctionComponent<EngineViewProps> = (props: EngineView
             </View>
         );
     } else {
+        const message = "Could not initialize Babylon Native.";
+        if (!__DEV__) {
+            throw Error(message)
+        }
+
         return (
             <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
-                <Text style={{fontSize: 24}}>Could not initialize Babylon Native.</Text>
+                <Text style={{fontSize: 24}}>{message}</Text>
                 { isRemoteDebuggingEnabled && <Text style={{fontSize: 12}}>React Native remote debugging does not work with Babylon Native.</Text> }
             </View>
         );

--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
@@ -43,8 +43,7 @@ static NSMutableArray* activeTouches;
 
         [jsRunLoop performBlock:^{
             if (bridge != currentBridge) {
-                currentBridge = bridge;
-                [BabylonNativeInterop setCurrentNativeInstance:mtkView width:width height:height];
+                [BabylonNativeInterop setCurrentNativeInstance:bridge mtkView:mtkView width:width height:height];
             } else if (currentNativeInstance) {
                 if (mtkView != currentView) {
                     [BabylonNativeInterop setCurrentView:mtkView];
@@ -104,6 +103,7 @@ static NSMutableArray* activeTouches;
 }
 
 + (void)whenInitialized:(RCTBridge*)bridge resolve:(RCTPromiseResolveBlock)resolve {
+    const std::lock_guard<std::mutex> lock(mapMutex);
     if (bridge == currentBridge) {
         resolve([NSNumber numberWithUnsignedLong:reinterpret_cast<uintptr_t>(currentNativeInstance.get())]);
     } else {
@@ -116,16 +116,20 @@ static NSMutableArray* activeTouches;
     activeTouches = [NSMutableArray new];
 }
 
-+ (void)setCurrentNativeInstance:(MTKView*)mtkView width:(int)width height:(int)height {
-    [BabylonNativeInterop setCurrentView:mtkView];
++ (void)setCurrentNativeInstance:(RCTBridge*)bridge mtkView:(MTKView*)mtkView width:(int)width height:(int)height {
+    {
+        const std::lock_guard<std::mutex> lock(mapMutex);
 
-    const std::lock_guard<std::mutex> lock(mapMutex);
+        currentBridge = bridge;
 
-    currentNativeInstance.reset();
+        [BabylonNativeInterop setCurrentView:mtkView];
 
-    jsi::Runtime* jsiRuntime = GetJSIRuntime(currentBridge);
-    if (jsiRuntime) {
-        currentNativeInstance = std::make_unique<Babylon::Native>(GetJSIRuntime(currentBridge), (__bridge void*)mtkView, width, height);
+        currentNativeInstance.reset();
+
+        jsi::Runtime* jsiRuntime = GetJSIRuntime(currentBridge);
+        if (jsiRuntime) {
+            currentNativeInstance = std::make_unique<Babylon::Native>(GetJSIRuntime(currentBridge), (__bridge void*)mtkView, width, height);
+        }
     }
 
     auto initializationPromisesIterator = initializationPromises.find((__bridge void*)currentBridge);

--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
@@ -117,12 +117,12 @@ static NSMutableArray* activeTouches;
 }
 
 + (void)setCurrentNativeInstance:(RCTBridge*)bridge mtkView:(MTKView*)mtkView width:(int)width height:(int)height {
+    [BabylonNativeInterop setCurrentView:mtkView];
+
     {
         const std::lock_guard<std::mutex> lock(mapMutex);
 
         currentBridge = bridge;
-
-        [BabylonNativeInterop setCurrentView:mtkView];
 
         currentNativeInstance.reset();
 


### PR DESCRIPTION
`whenInitialized` runs on the React Native bridging thread, which is different from the JS thread. This resulted in a race condition between `whenInitialized` and `setCurrentNativeInstance` (both are called at different points inside `EngineView`). It seems to depend on how much work is happening on the bridging thread, and how much work is happening on the main thread (since `setCurrentNativeInstance` constructs a `Babylon::Native` instance which dispatches synchronously to the main thread and therefore can be slow), but I found one way to get into this state easily. In that case, `whenInitialized` can execute after `currentBridge` has been set but before `currentNativeInstance` has been set, in which case `whenInitialized` effectively returns with an error state.

The fix is the use the same lock in `whenInitialized` that we use in `setCurrentNativeInstance`. However, `setCurrentNativeInstance` needs to release the lock before trying to invoke the `resolve` callbacks on calls to `whenInitialized` that are pending because this `resolve` is also dispatched to the bridging thread, so if we don't release the lock it would deadlock with any current calls to `whenInitialized` that are waiting on the lock. It is safe to release the lock early because once `currentNativeInstance` has been set, `whenInitialized` will not try to write to the initialization promise map.

I also changed `EngineView` to only display an error view for dev builds (this makes diagnosing an initialization error easier). For release builds, it throws, so a consuming app doesn't show unexpected UI to the user in an error case (instead it throws an exception).