### PR TITLE
Integrate the new Babylon Native Graphics object

### DIFF
--- a/Apps/PackageTest/package-lock.json
+++ b/Apps/PackageTest/package-lock.json
@@ -908,16 +908,16 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.2.tgz",
-      "integrity": "sha512-QPyroV1oHFQ0eKa+TrU2DhtLtleSGN2GbAvLU+ly+8NOVGMZvmKwm+8S/Nvb503+odnV7YgZdKpl5/3WligAYg==",
+      "version": "4.2.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.6.tgz",
+      "integrity": "sha512-oLAgv37Gjept9yMjyJ2EuTYWe96JAYTfdJdW3MAbcafg4TmMv/gOLBqP6a62pOmxZyEJ35bX9A8NNvTb/5R/Xg==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/react-native": {
       "version": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-P9tJSJJbC7g0kYgci6VmnmUmJmdbb9Ml0Gy/y5nZz8QS2X1AIymVNFDuArPhLvu8hkbpv/hEA5WgZBc5oRh7vw==",
+      "integrity": "sha512-Nge4uZHH382TPwEyqpVPFSKsKsIO6rgZi+qGgfy9FCajWvgEC8ItOgD7+v1X4OwBWw1KpCgdG+VIX6nEuYO76w==",
       "requires": {
         "base-64": "^0.1.0"
       }

--- a/Apps/PackageTest/package.json
+++ b/Apps/PackageTest/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0-beta.2",
+    "@babylonjs/core": "^4.2.0-beta.6",
     "@babylonjs/react-native": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/Playground/ios/Podfile.lock
+++ b/Apps/Playground/ios/Podfile.lock
@@ -466,7 +466,7 @@ SPEC CHECKSUMS:
   React-jsi: b32a31da32e030f30bbf9a8d3a9c8325df9e793f
   React-jsiexecutor: 7ab9cdcdd18d57652fb041f8a147fe9658d4e00a
   React-jsinspector: 2e28bb487e42dda6c94dbfa0c648d1343767a0fb
-  react-native-babylon: 004630b2838450727c093bfcc30e05d5b08206c1
+  react-native-babylon: 704a0f409074182d47b917877c3ef70512a18ac5
   react-native-slider: b34d943dc60deb96d952ba6b6b249aa8091e86da
   React-RCTActionSheet: 1702a1a85e550b5c36e2e03cb2bd3adea053de95
   React-RCTAnimation: ddda576010a878865a4eab83a78acd92176ef6a1

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -864,20 +864,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.2.tgz",
-      "integrity": "sha512-QPyroV1oHFQ0eKa+TrU2DhtLtleSGN2GbAvLU+ly+8NOVGMZvmKwm+8S/Nvb503+odnV7YgZdKpl5/3WligAYg==",
+      "version": "4.2.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.6.tgz",
+      "integrity": "sha512-oLAgv37Gjept9yMjyJ2EuTYWe96JAYTfdJdW3MAbcafg4TmMv/gOLBqP6a62pOmxZyEJ35bX9A8NNvTb/5R/Xg==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "4.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.2.tgz",
-      "integrity": "sha512-qYNfU2bXUVxxiCEQwNZ2ANaC7RVothg54foCV2OKBMbqns4hp8DnPx0Cd44II7qpFEP6eSpznAfSKwlVPlDLwA==",
+      "version": "4.2.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.6.tgz",
+      "integrity": "sha512-3n4TD9FgZIyJ6PFhqi6HFm2GlDLAhgszm1lGAb+CCXqiqgHqfApvNO4Q0d+sm+emK820LQukTgowWWlJKwgJZw==",
       "requires": {
-        "@babylonjs/core": "4.2.0-beta.2",
-        "babylonjs-gltf2interface": "4.2.0-beta.2",
+        "@babylonjs/core": "4.2.0-beta.6",
+        "babylonjs-gltf2interface": "4.2.0-beta.6",
         "tslib": ">=1.10.0"
       }
     },
@@ -3053,9 +3053,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "4.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.2.tgz",
-      "integrity": "sha512-5vnRb7Yv4TZop74/7vaB35Im9MsBngh6ChPUku7AQ0+WPW+5yXXr8JYFHzPz7gz9qWK4WcKXlZgiRsE7tcW2ag=="
+      "version": "4.2.0-beta.6",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.6.tgz",
+      "integrity": "sha512-ppH5R2SPaZ9EHfVZAdi3Fb/s0n/vtle1XWy4BMiTKsnRuZXNwKtruRkdT9sAO6D5xw2ZJ0S1gSuz0JXaCo3AAw=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0-beta.2",
-    "@babylonjs/loaders": "^4.2.0-beta.2",
+    "@babylonjs/core": "^4.2.0-beta.6",
+    "@babylonjs/loaders": "^4.2.0-beta.6",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "logkitty": "^0.7.1",

--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(BabylonNative
     arcana
     jsi
     AndroidExtensions
+    Graphics
     JsRuntime
     NativeWindow
     NativeEngine

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(BabylonNative PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(BabylonNative
     z
     arcana
+    Graphics
     jsi
     JsRuntime
     NativeWindow

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -27,7 +27,7 @@
     "base-64": "^0.1.0"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^4.2.0-alpha.33",
+    "@babylonjs/core": "^4.2.0-beta.6",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
     "react-native-permissions": "^2.1.4"

--- a/Modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
                 'bx',
                 'GenericCodeGen',
                 'glslang',
+                'Graphics',
                 'jsRuntime',
                 'OGLCompiler',
                 'OSDependent',

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -31,7 +31,7 @@ const buildIphoneOS = async () => {
 };
 
 const buildIphoneSimulator = async () => {
-  exec('xcodebuild -sdk iphonesimulator -configuration Release -project ReactNativeBabylon.xcodeproj -scheme BabylonNative build CODE_SIGNING_ALLOWED=NO', 'iOS/Build');
+  exec('xcodebuild -sdk iphonesimulator -arch x86_64 -configuration Release -project ReactNativeBabylon.xcodeproj -scheme BabylonNative build CODE_SIGNING_ALLOWED=NO', 'iOS/Build');
 };
 
 const buildIOS = gulp.series(makeXCodeProj, buildIphoneOS, buildIphoneSimulator);
@@ -100,6 +100,7 @@ Assembled/ios/libs/libNativeXr.a
 Assembled/ios/libs/libspirv-cross-glsl.a
 Assembled/ios/libs/libNativeInput.a
 Assembled/ios/libs/libJsRuntime.a
+Assembled/ios/libs/libGraphics.a
 Assembled/ios/libs/libOSDependent.a
 Assembled/ios/libs/libastc-codec.a
 Assembled/ios/libs/libGenericCodeGen.a

--- a/Package/iOS/CMakeLists.txt
+++ b/Package/iOS/CMakeLists.txt
@@ -10,6 +10,7 @@ set(PACKAGED_LIBS
     bx
     GenericCodeGen
     glslang
+    Graphics
     JsRuntime
     OGLCompiler
     OSDependent

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ cd ios
 pod install
 ```
 
-This will create a symbolic link in your `node_modules` directory to the `@babylonjs/react-native` source directory. For iOS the XCode project needs to be generated with `CMake` as described [above](#ios) and added to your `xcworkspace`.
+This will create a symbolic link in your `node_modules` directory to the `@babylonjs/react-native` source directory. However, this also requires a custom `metro.config.js` as the Metro bundler does not support symbolic links by default. See the [GitHub issue](https://github.com/react-native-community/cli/issues/1238#issue-673055870) on this for a solution.
+
+For iOS the XCode project needs to be generated with `CMake` as described [above](#ios) and added to your `xcworkspace`.
 
 ## Security
 


### PR DESCRIPTION
The main change here is to use the new `Graphics` object from Babylon Native:
- Update Babylon Native to the latest, and Babylon.js to 4.2.0-beta.6.
- Bump up the min version of @babylonjs/core to 4.2.0-beta.6 (it has changes tied to changes made to Babylon Native).
- Add dependencies on the `Graphics` lib (CMakeLists.txt and podspec).
- Update gulp package build script to expect to include `libGraphics.a` (iOS).

Also included a couple other minor changes:
- Explicitly specify the architecture when building the simulator libs for iOS (XCode 12 seems to default to arm64 instead of x86_64).
- Add a note to the readme about requiring a custom metro.config.js if you want to install a local version of the package.