### PR TITLE
Update to latest Babylon Native and call NativeWindow::Reinitialize

### DIFF
--- a/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -79,6 +79,7 @@ namespace Babylon
             auto width = static_cast<size_t>(ANativeWindow_getWidth(windowPtr));
             auto height = static_cast<size_t>(ANativeWindow_getHeight(windowPtr));
             m_graphics->ReinitializeFromWindow<void*>(windowPtr, width, height);
+            Plugins::NativeWindow::Reinitialize(m_env, windowPtr, width, height);
         }
 
         void SetPointerButtonState(uint32_t pointerId, uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -73,6 +73,7 @@ namespace Babylon
     void Native::Refresh(void* windowPtr, size_t width, size_t height)
     {
         m_impl->m_graphics->ReinitializeFromWindow<void*>(windowPtr, width, height);
+        Plugins::NativeWindow::Reinitialize(m_impl->env, windowPtr, width, height);
     }
 
     void Native::Resize(size_t width, size_t height)


### PR DESCRIPTION
This updates to the latest Babylon Native which pulls in a few bug fixes and adds `NativeWindow::Reinitialize`. We call this when the underlying `windowPtr` changes so that `NativeWindow::GetWindowPtr()` returns the correct/current `windowPtr`. This is how the `windowPtr` is passed down to the XR layer, so without this XR does not work on iOS after the window has been replaced with a new one (related to #57).