### PR TITLE
Update to latest Babylon JS/Native and fix iOS flushedQueue issue

### DIFF
--- a/Apps/PackageTest/package-lock.json
+++ b/Apps/PackageTest/package-lock.json
@@ -908,9 +908,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.6.tgz",
-      "integrity": "sha512-oLAgv37Gjept9yMjyJ2EuTYWe96JAYTfdJdW3MAbcafg4TmMv/gOLBqP6a62pOmxZyEJ35bX9A8NNvTb/5R/Xg==",
+      "version": "4.2.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.10.tgz",
+      "integrity": "sha512-OnfQQfhbUrGYEOKSEgmvgqQ5ZHockWUXyn0F488HTvUHB1/iaPlh9UAAsNYCEphIT0exlg3bFmJ1ZGfZyxAhmw==",
       "requires": {
         "tslib": ">=1.10.0"
       }

--- a/Apps/PackageTest/package.json
+++ b/Apps/PackageTest/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0-beta.6",
+    "@babylonjs/core": "^4.2.0-beta.10",
     "@babylonjs/react-native": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -864,20 +864,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.6.tgz",
-      "integrity": "sha512-oLAgv37Gjept9yMjyJ2EuTYWe96JAYTfdJdW3MAbcafg4TmMv/gOLBqP6a62pOmxZyEJ35bX9A8NNvTb/5R/Xg==",
+      "version": "4.2.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.10.tgz",
+      "integrity": "sha512-OnfQQfhbUrGYEOKSEgmvgqQ5ZHockWUXyn0F488HTvUHB1/iaPlh9UAAsNYCEphIT0exlg3bFmJ1ZGfZyxAhmw==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "4.2.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.6.tgz",
-      "integrity": "sha512-3n4TD9FgZIyJ6PFhqi6HFm2GlDLAhgszm1lGAb+CCXqiqgHqfApvNO4Q0d+sm+emK820LQukTgowWWlJKwgJZw==",
+      "version": "4.2.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.10.tgz",
+      "integrity": "sha512-rE0Pe/Ov3LiycXnfyrP2j90USEUOX9rRS7roQoCNCib4DpmN1EebXhJqmdu1dRmpuP9wKUsTXPm0JMgRxz/7RA==",
       "requires": {
-        "@babylonjs/core": "4.2.0-beta.6",
-        "babylonjs-gltf2interface": "4.2.0-beta.6",
+        "@babylonjs/core": "4.2.0-beta.10",
+        "babylonjs-gltf2interface": "4.2.0-beta.10",
         "tslib": ">=1.10.0"
       }
     },
@@ -3053,9 +3053,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "4.2.0-beta.6",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.6.tgz",
-      "integrity": "sha512-ppH5R2SPaZ9EHfVZAdi3Fb/s0n/vtle1XWy4BMiTKsnRuZXNwKtruRkdT9sAO6D5xw2ZJ0S1gSuz0JXaCo3AAw=="
+      "version": "4.2.0-beta.10",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.10.tgz",
+      "integrity": "sha512-Bi0LFfLlBAiP1urxd2PEtyJIESEWg/fiugOLGDIgJAnebXR5++LSpxOuhuDmXC1Gql+bO5Dp8AW8JwQqp+dPTg=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0-beta.6",
-    "@babylonjs/loaders": "^4.2.0-beta.6",
+    "@babylonjs/core": "^4.2.0-beta.10",
+    "@babylonjs/loaders": "^4.2.0-beta.10",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "logkitty": "^0.7.1",

--- a/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -80,9 +80,6 @@ namespace Babylon
             Polyfills::Window::Initialize(m_env);
 
             m_nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(m_env);
-
-            // TODO: This shouldn't be necessary, but for some reason results in a significant increase in frame rate. Need to figure this out.
-            m_graphics->ReinitializeFromWindow<void*>(windowPtr, width, height);
         }
 
         ~Native()

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -27,7 +27,7 @@
     "base-64": "^0.1.0"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^4.2.0-beta.6",
+    "@babylonjs/core": "^4.2.0-beta.10",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
     "react-native-permissions": "^2.1.4"

--- a/Modules/@babylonjs/react-native/shared/Shared.h
+++ b/Modules/@babylonjs/react-native/shared/Shared.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <napi/napi.h>
+#include <jsi/jsi.h>
 
 // See https://github.com/BabylonJS/BabylonReactNative/issues/60 for original issue.
 // This is a work around to poke the React Native message queue to run setImmediate callbacks.
@@ -15,4 +16,15 @@ inline Napi::FunctionReference GetFlushedQueue(Napi::Env env)
     auto batchedBridge{ env.Global().Get("__fbBatchedBridge").As<Napi::Object>() };
     auto flushedQueue{ batchedBridge.Get("flushedQueue").As<Napi::Function>() };
     return Napi::Persistent(flushedQueue);
+}
+
+// On iOS, directly calling flushedQueue breaks some kind of internal UI state and we start getting errors like:
+// *** Assertion failure in -[RCTNativeAnimatedNodesManager disconnectAnimatedNodes:childTag:](), node_modules/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m:138
+// [native] Exception thrown while executing UI block: 'parentNode' is a required parameter
+// However, calling setTimeout eventually also calls flushedQueue, but doesn't result in the above error,
+// so we'll go this route until we (hopefully) get a better resolution from the React Native team at Facebook.
+inline std::shared_ptr<facebook::jsi::Function> GetSetTimeout(facebook::jsi::Runtime& rt)
+{
+    auto code{std::make_shared<const facebook::jsi::StringBuffer>("() => setTimeout(() => {})")};
+    return std::make_shared<facebook::jsi::Function>(rt.evaluateJavaScript(std::move(code), "").asObject(rt).asFunction(rt));
 }


### PR DESCRIPTION
Directly calling `flushedQueue` on iOS has some side effects that I didn't notice in my first test. With some UI transitions, the internal UI state becomes broken. I'm not sure what is going on, but see the comments in the code for more details. We have an active thread on Discord with some Facebook React Native folks, so we'll wait and see if they have a better solution.

I also removed the call to reinitialize graphics right after initialization on Android as this no longer seems to be an issue.

Finally, I'm updating both Babylon.js and Babylon Native to the latest. This brings in Babylon.js changes that expose the XR tracking state, and also bring in the Babylon Native XR render loop fix.