### PR TITLE
Use Babylon Native's XMLHttpRequest

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
       - name: Setup Ninja
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
       - name: NPM Install (Playground)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
       - name: Setup Ninja
@@ -23,7 +23,7 @@ jobs:
         run: npx gulp
         working-directory: ./Package
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.0
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'

--- a/Apps/PackageTest/ios/PackageTest.xcodeproj/project.pbxproj
+++ b/Apps/PackageTest/ios/PackageTest.xcodeproj/project.pbxproj
@@ -178,7 +178,6 @@
 				D5B2C53165757B8DB1E88994 /* Pods-PackageTest-PackageTestTests.debug.xcconfig */,
 				920AE01196CF291853BA329C /* Pods-PackageTest-PackageTestTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -554,7 +553,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = PackageTestTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -574,7 +573,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = PackageTestTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -784,7 +783,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
@@ -837,7 +836,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",

--- a/Apps/PackageTest/package-lock.json
+++ b/Apps/PackageTest/package-lock.json
@@ -908,16 +908,16 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.10.tgz",
-      "integrity": "sha512-OnfQQfhbUrGYEOKSEgmvgqQ5ZHockWUXyn0F488HTvUHB1/iaPlh9UAAsNYCEphIT0exlg3bFmJ1ZGfZyxAhmw==",
+      "version": "4.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.12.tgz",
+      "integrity": "sha512-dBnVXxJYHYoMlrFGXHOwDeF6U1aQE1RqtUVSnenrkKszvzetoWJ4ho0kxTnjLAQxPXMPE2shY3kzsPpCDEhpKw==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/react-native": {
       "version": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-Nge4uZHH382TPwEyqpVPFSKsKsIO6rgZi+qGgfy9FCajWvgEC8ItOgD7+v1X4OwBWw1KpCgdG+VIX6nEuYO76w==",
+      "integrity": "sha512-Oh9hgxDHXGHEB7AQOdcfv1Wr3LVnZXjhqaCunFxeM6YRfwwh18Agq+X9LtoDL4WtJsAf03dE2xCqVvpQWVzZ/A==",
       "requires": {
         "base-64": "^0.1.0"
       }
@@ -1197,12 +1197,371 @@
         "chalk": "^3.0.0"
       }
     },
+    "@react-native-community/cli": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.13.0.tgz",
+      "integrity": "sha512-R+1VehIQ6VTLf+e7YOwzJk0F9tstfeSC4xy7oT6GSgB3FnXbTJGHFUp4siyO68Ae/gzGqt8SiUO145teWkP+ZA==",
+      "dev": true,
+      "requires": {
+        "@hapi/joi": "^15.0.3",
+        "@react-native-community/cli-debugger-ui": "^4.9.0",
+        "@react-native-community/cli-hermes": "^4.13.0",
+        "@react-native-community/cli-server-api": "^4.13.0",
+        "@react-native-community/cli-tools": "^4.13.0",
+        "@react-native-community/cli-types": "^4.10.1",
+        "chalk": "^3.0.0",
+        "command-exists": "^1.2.8",
+        "commander": "^2.19.0",
+        "cosmiconfig": "^5.1.0",
+        "deepmerge": "^3.2.0",
+        "envinfo": "^7.7.2",
+        "execa": "^1.0.0",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.3",
+        "inquirer": "^3.0.6",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "metro": "^0.58.0",
+        "metro-config": "^0.58.0",
+        "metro-core": "^0.58.0",
+        "metro-react-native-babel-transformer": "^0.58.0",
+        "metro-resolver": "^0.58.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-stream-zip": "^1.9.1",
+        "ora": "^3.4.0",
+        "pretty-format": "^25.2.0",
+        "semver": "^6.3.0",
+        "serve-static": "^1.13.1",
+        "strip-ansi": "^5.2.0",
+        "sudo-prompt": "^9.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "@react-native-community/cli-server-api": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-4.13.0.tgz",
+          "integrity": "sha512-ER138ChLc1YYX7j9yE6fDm4DdNdsHThr+pla/B6iZoKje1r7TwymDdKaUvOsYalG7sWG9glW3bofcCq+Yh0Dvw==",
+          "dev": true,
+          "requires": {
+            "@react-native-community/cli-debugger-ui": "^4.9.0",
+            "@react-native-community/cli-tools": "^4.13.0",
+            "compression": "^1.7.1",
+            "connect": "^3.6.5",
+            "errorhandler": "^1.5.0",
+            "pretty-format": "^25.1.0",
+            "serve-static": "^1.13.1",
+            "ws": "^1.1.0"
+          }
+        },
+        "@react-native-community/cli-tools": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-4.13.0.tgz",
+          "integrity": "sha512-s4f489h5+EJksn4CfheLgv5PGOM0CDmK1UEBLw2t/ncWs3cW2VI7vXzndcd/WJHTv3GntJhXDcJMuL+Z2IAOgg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mime": "^2.4.1",
+            "node-fetch": "^2.6.0",
+            "open": "^6.2.0",
+            "shell-quote": "1.6.1"
+          }
+        },
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
+        "cli-width": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+          "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "metro-react-native-babel-preset": {
+          "version": "0.58.0",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz",
+          "integrity": "sha512-MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==",
+          "dev": true,
+          "requires": {
+            "@babel/plugin-proposal-class-properties": "^7.0.0",
+            "@babel/plugin-proposal-export-default-from": "^7.0.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-export-default-from": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.2.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-object-assign": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-runtime": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typescript": "^7.5.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "@babel/template": "^7.0.0",
+            "react-refresh": "^0.4.0"
+          }
+        },
+        "metro-react-native-babel-transformer": {
+          "version": "0.58.0",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.58.0.tgz",
+          "integrity": "sha512-3A73+cRq1eUPQ8g+hPNGgMUMCGmtQjwqHfoG1DwinAoJ/kr4WOXWWbGZo0xHJNBe/zdHGl0uHcDCp2knPglTdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.0.0",
+            "babel-preset-fbjs": "^3.3.0",
+            "metro-babel-transformer": "0.58.0",
+            "metro-react-native-babel-preset": "0.58.0",
+            "metro-source-map": "0.58.0"
+          }
+        },
+        "metro-source-map": {
+          "version": "0.58.0",
+          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
+          "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
+          "dev": true,
+          "requires": {
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "invariant": "^2.2.4",
+            "metro-symbolicate": "0.58.0",
+            "ob1": "0.58.0",
+            "source-map": "^0.5.6",
+            "vlq": "^1.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@react-native-community/cli-debugger-ui": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.9.0.tgz",
       "integrity": "sha512-fBFGamHm4VUrDqkBGnsrwQL8OC6Om7K6EBQb4xj0nWekpXt1HSa3ScylYHTTWwYcpRf9htGMRGiv4dQDY/odAw==",
       "requires": {
         "serve-static": "^1.13.1"
+      }
+    },
+    "@react-native-community/cli-hermes": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-4.13.0.tgz",
+      "integrity": "sha512-oG+w0Uby6rSGsUkJGLvMQctZ5eVRLLfhf84lLyz942OEDxFRa9U19YJxOe9FmgCKtotbYiM3P/XhK+SVCuerPQ==",
+      "dev": true,
+      "requires": {
+        "@react-native-community/cli-platform-android": "^4.13.0",
+        "@react-native-community/cli-tools": "^4.13.0",
+        "chalk": "^3.0.0",
+        "hermes-profile-transformer": "^0.0.6",
+        "ip": "^1.1.5"
+      },
+      "dependencies": {
+        "@react-native-community/cli-platform-android": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-4.13.0.tgz",
+          "integrity": "sha512-3i8sX8GklEytUZwPnojuoFbCjIRzMugCdzDIdZ9UNmi/OhD4/8mLGO0dgXfT4sMWjZwu3qjy45sFfk2zOAgHbA==",
+          "dev": true,
+          "requires": {
+            "@react-native-community/cli-tools": "^4.13.0",
+            "chalk": "^3.0.0",
+            "execa": "^1.0.0",
+            "fs-extra": "^8.1.0",
+            "glob": "^7.1.3",
+            "jetifier": "^1.6.2",
+            "lodash": "^4.17.15",
+            "logkitty": "^0.7.1",
+            "slash": "^3.0.0",
+            "xmldoc": "^1.1.2"
+          }
+        },
+        "@react-native-community/cli-tools": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-4.13.0.tgz",
+          "integrity": "sha512-s4f489h5+EJksn4CfheLgv5PGOM0CDmK1UEBLw2t/ncWs3cW2VI7vXzndcd/WJHTv3GntJhXDcJMuL+Z2IAOgg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mime": "^2.4.1",
+            "node-fetch": "^2.6.0",
+            "open": "^6.2.0",
+            "shell-quote": "1.6.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        }
       }
     },
     "@react-native-community/cli-platform-android": {
@@ -3869,6 +4228,23 @@
       "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.5.1.tgz",
       "integrity": "sha512-hLwqh8dejHayjlpvZY40e1aDCDvyP98cWx/L5DhAjSJLH8g4z9Tp08D7y4+3vErDsncPOdf1bxm+zUWpx0/Fxg=="
     },
+    "hermes-profile-transformer": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz",
+      "integrity": "sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -4087,6 +4463,12 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",

--- a/Apps/PackageTest/package.json
+++ b/Apps/PackageTest/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0-beta.10",
+    "@babylonjs/core": "^4.2.0-beta.12",
     "@babylonjs/react-native": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
+    "@react-native-community/cli": "^4.13.0",
     "@react-native-community/eslint-config": "^1.1.0",
     "@types/jest": "^25.2.3",
     "@types/react-native": "0.63.1",

--- a/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
+++ b/Apps/Playground/ios/Playground.xcodeproj/project.pbxproj
@@ -178,7 +178,6 @@
 				D5B2C53165757B8DB1E88994 /* Pods-Playground-PlaygroundTests.debug.xcconfig */,
 				920AE01196CF291853BA329C /* Pods-Playground-PlaygroundTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -554,7 +553,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = PlaygroundTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -574,7 +573,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = PlaygroundTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -784,7 +783,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
@@ -837,7 +836,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",

--- a/Apps/Playground/ios/Podfile.lock
+++ b/Apps/Playground/ios/Podfile.lock
@@ -466,7 +466,7 @@ SPEC CHECKSUMS:
   React-jsi: b32a31da32e030f30bbf9a8d3a9c8325df9e793f
   React-jsiexecutor: 7ab9cdcdd18d57652fb041f8a147fe9658d4e00a
   React-jsinspector: 2e28bb487e42dda6c94dbfa0c648d1343767a0fb
-  react-native-babylon: 704a0f409074182d47b917877c3ef70512a18ac5
+  react-native-babylon: cbcec38c3e3d9fc1aee538508a1f751619bb335b
   react-native-slider: b34d943dc60deb96d952ba6b6b249aa8091e86da
   React-RCTActionSheet: 1702a1a85e550b5c36e2e03cb2bd3adea053de95
   React-RCTAnimation: ddda576010a878865a4eab83a78acd92176ef6a1

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -864,20 +864,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.10.tgz",
-      "integrity": "sha512-OnfQQfhbUrGYEOKSEgmvgqQ5ZHockWUXyn0F488HTvUHB1/iaPlh9UAAsNYCEphIT0exlg3bFmJ1ZGfZyxAhmw==",
+      "version": "4.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0-beta.12.tgz",
+      "integrity": "sha512-dBnVXxJYHYoMlrFGXHOwDeF6U1aQE1RqtUVSnenrkKszvzetoWJ4ho0kxTnjLAQxPXMPE2shY3kzsPpCDEhpKw==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "4.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.10.tgz",
-      "integrity": "sha512-rE0Pe/Ov3LiycXnfyrP2j90USEUOX9rRS7roQoCNCib4DpmN1EebXhJqmdu1dRmpuP9wKUsTXPm0JMgRxz/7RA==",
+      "version": "4.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0-beta.12.tgz",
+      "integrity": "sha512-3FXFRalA58pX1Q9oO1kV7i6UE0QsqbEFWIXdWRnn1JflIjyPlKmboHePMG49wJDNpiN9jhE++RgxkLUaiBIEXQ==",
       "requires": {
-        "@babylonjs/core": "4.2.0-beta.10",
-        "babylonjs-gltf2interface": "4.2.0-beta.10",
+        "@babylonjs/core": "4.2.0-beta.12",
+        "babylonjs-gltf2interface": "4.2.0-beta.12",
         "tslib": ">=1.10.0"
       }
     },
@@ -2184,12 +2184,265 @@
         "chalk": "^3.0.0"
       }
     },
+    "@react-native-community/cli": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-4.13.0.tgz",
+      "integrity": "sha512-R+1VehIQ6VTLf+e7YOwzJk0F9tstfeSC4xy7oT6GSgB3FnXbTJGHFUp4siyO68Ae/gzGqt8SiUO145teWkP+ZA==",
+      "dev": true,
+      "requires": {
+        "@hapi/joi": "^15.0.3",
+        "@react-native-community/cli-debugger-ui": "^4.9.0",
+        "@react-native-community/cli-hermes": "^4.13.0",
+        "@react-native-community/cli-server-api": "^4.13.0",
+        "@react-native-community/cli-tools": "^4.13.0",
+        "@react-native-community/cli-types": "^4.10.1",
+        "chalk": "^3.0.0",
+        "command-exists": "^1.2.8",
+        "commander": "^2.19.0",
+        "cosmiconfig": "^5.1.0",
+        "deepmerge": "^3.2.0",
+        "envinfo": "^7.7.2",
+        "execa": "^1.0.0",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.3",
+        "inquirer": "^3.0.6",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "metro": "^0.58.0",
+        "metro-config": "^0.58.0",
+        "metro-core": "^0.58.0",
+        "metro-react-native-babel-transformer": "^0.58.0",
+        "metro-resolver": "^0.58.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-stream-zip": "^1.9.1",
+        "ora": "^3.4.0",
+        "pretty-format": "^25.2.0",
+        "semver": "^6.3.0",
+        "serve-static": "^1.13.1",
+        "strip-ansi": "^5.2.0",
+        "sudo-prompt": "^9.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "@react-native-community/cli-server-api": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-4.13.0.tgz",
+          "integrity": "sha512-ER138ChLc1YYX7j9yE6fDm4DdNdsHThr+pla/B6iZoKje1r7TwymDdKaUvOsYalG7sWG9glW3bofcCq+Yh0Dvw==",
+          "dev": true,
+          "requires": {
+            "@react-native-community/cli-debugger-ui": "^4.9.0",
+            "@react-native-community/cli-tools": "^4.13.0",
+            "compression": "^1.7.1",
+            "connect": "^3.6.5",
+            "errorhandler": "^1.5.0",
+            "pretty-format": "^25.1.0",
+            "serve-static": "^1.13.1",
+            "ws": "^1.1.0"
+          }
+        },
+        "@react-native-community/cli-tools": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-4.13.0.tgz",
+          "integrity": "sha512-s4f489h5+EJksn4CfheLgv5PGOM0CDmK1UEBLw2t/ncWs3cW2VI7vXzndcd/WJHTv3GntJhXDcJMuL+Z2IAOgg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mime": "^2.4.1",
+            "node-fetch": "^2.6.0",
+            "open": "^6.2.0",
+            "shell-quote": "1.6.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "metro-react-native-babel-preset": {
+          "version": "0.58.0",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.58.0.tgz",
+          "integrity": "sha512-MRriNW+fF6jxABsgPphocUY6mIhmCm8idcrQZ58fT3Iti2vCdtkaK32TyCGUNUptzhUe2/cbE57j4aC+eaodAA==",
+          "dev": true,
+          "requires": {
+            "@babel/plugin-proposal-class-properties": "^7.0.0",
+            "@babel/plugin-proposal-export-default-from": "^7.0.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-export-default-from": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.2.0",
+            "@babel/plugin-transform-arrow-functions": "^7.0.0",
+            "@babel/plugin-transform-block-scoping": "^7.0.0",
+            "@babel/plugin-transform-classes": "^7.0.0",
+            "@babel/plugin-transform-computed-properties": "^7.0.0",
+            "@babel/plugin-transform-destructuring": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+            "@babel/plugin-transform-for-of": "^7.0.0",
+            "@babel/plugin-transform-function-name": "^7.0.0",
+            "@babel/plugin-transform-literals": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+            "@babel/plugin-transform-object-assign": "^7.0.0",
+            "@babel/plugin-transform-parameters": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-runtime": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+            "@babel/plugin-transform-spread": "^7.0.0",
+            "@babel/plugin-transform-sticky-regex": "^7.0.0",
+            "@babel/plugin-transform-template-literals": "^7.0.0",
+            "@babel/plugin-transform-typescript": "^7.5.0",
+            "@babel/plugin-transform-unicode-regex": "^7.0.0",
+            "@babel/template": "^7.0.0",
+            "react-refresh": "^0.4.0"
+          }
+        },
+        "metro-react-native-babel-transformer": {
+          "version": "0.58.0",
+          "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.58.0.tgz",
+          "integrity": "sha512-3A73+cRq1eUPQ8g+hPNGgMUMCGmtQjwqHfoG1DwinAoJ/kr4WOXWWbGZo0xHJNBe/zdHGl0uHcDCp2knPglTdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.0.0",
+            "babel-preset-fbjs": "^3.3.0",
+            "metro-babel-transformer": "0.58.0",
+            "metro-react-native-babel-preset": "0.58.0",
+            "metro-source-map": "0.58.0"
+          }
+        },
+        "metro-source-map": {
+          "version": "0.58.0",
+          "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.58.0.tgz",
+          "integrity": "sha512-yvN1YPmejmgiiS7T1aKBiiUTHPw2Vcm3r2TZ+DY92z/9PR4alysIywrCs/fTHs8rbDcKM5VfPCKGLpkBrbKeOw==",
+          "dev": true,
+          "requires": {
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "invariant": "^2.2.4",
+            "metro-symbolicate": "0.58.0",
+            "ob1": "0.58.0",
+            "source-map": "^0.5.6",
+            "vlq": "^1.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
+      }
+    },
     "@react-native-community/cli-debugger-ui": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.9.0.tgz",
       "integrity": "sha512-fBFGamHm4VUrDqkBGnsrwQL8OC6Om7K6EBQb4xj0nWekpXt1HSa3ScylYHTTWwYcpRf9htGMRGiv4dQDY/odAw==",
       "requires": {
         "serve-static": "^1.13.1"
+      }
+    },
+    "@react-native-community/cli-hermes": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-4.13.0.tgz",
+      "integrity": "sha512-oG+w0Uby6rSGsUkJGLvMQctZ5eVRLLfhf84lLyz942OEDxFRa9U19YJxOe9FmgCKtotbYiM3P/XhK+SVCuerPQ==",
+      "dev": true,
+      "requires": {
+        "@react-native-community/cli-platform-android": "^4.13.0",
+        "@react-native-community/cli-tools": "^4.13.0",
+        "chalk": "^3.0.0",
+        "hermes-profile-transformer": "^0.0.6",
+        "ip": "^1.1.5"
+      },
+      "dependencies": {
+        "@react-native-community/cli-platform-android": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-4.13.0.tgz",
+          "integrity": "sha512-3i8sX8GklEytUZwPnojuoFbCjIRzMugCdzDIdZ9UNmi/OhD4/8mLGO0dgXfT4sMWjZwu3qjy45sFfk2zOAgHbA==",
+          "dev": true,
+          "requires": {
+            "@react-native-community/cli-tools": "^4.13.0",
+            "chalk": "^3.0.0",
+            "execa": "^1.0.0",
+            "fs-extra": "^8.1.0",
+            "glob": "^7.1.3",
+            "jetifier": "^1.6.2",
+            "lodash": "^4.17.15",
+            "logkitty": "^0.7.1",
+            "slash": "^3.0.0",
+            "xmldoc": "^1.1.2"
+          }
+        },
+        "@react-native-community/cli-tools": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-4.13.0.tgz",
+          "integrity": "sha512-s4f489h5+EJksn4CfheLgv5PGOM0CDmK1UEBLw2t/ncWs3cW2VI7vXzndcd/WJHTv3GntJhXDcJMuL+Z2IAOgg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mime": "^2.4.1",
+            "node-fetch": "^2.6.0",
+            "open": "^6.2.0",
+            "shell-quote": "1.6.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
       }
     },
     "@react-native-community/cli-platform-android": {
@@ -3053,9 +3306,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "4.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.10.tgz",
-      "integrity": "sha512-Bi0LFfLlBAiP1urxd2PEtyJIESEWg/fiugOLGDIgJAnebXR5++LSpxOuhuDmXC1Gql+bO5Dp8AW8JwQqp+dPTg=="
+      "version": "4.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0-beta.12.tgz",
+      "integrity": "sha512-RHEonz9Pvc7c50b0fMGjpygs2/rWo7zqHlZ6SNjSw2WDXWgnqIdrTkwgnclB28QXxQFPFxM59cw0ChnDkOL9Mg=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -5133,6 +5386,23 @@
       "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.5.1.tgz",
       "integrity": "sha512-hLwqh8dejHayjlpvZY40e1aDCDvyP98cWx/L5DhAjSJLH8g4z9Tp08D7y4+3vErDsncPOdf1bxm+zUWpx0/Fxg=="
     },
+    "hermes-profile-transformer": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz",
+      "integrity": "sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -5337,6 +5607,12 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0-beta.10",
-    "@babylonjs/loaders": "^4.2.0-beta.10",
+    "@babylonjs/core": "^4.2.0-beta.12",
+    "@babylonjs/loaders": "^4.2.0-beta.12",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "logkitty": "^0.7.1",
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
+    "@react-native-community/cli": "^4.13.0",
     "@react-native-community/eslint-config": "^1.1.0",
     "@types/jest": "^25.2.3",
     "@types/react-native": "0.63.1",

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -75,6 +75,14 @@ export function useEngine(): Engine | undefined {
             }
         })();
 
+        // NOTE: This is a workaround for https://github.com/BabylonJS/BabylonReactNative/issues/60
+        function heartbeat() {
+            if (!disposed) {
+                setTimeout(heartbeat, 10);
+            }
+        }
+        heartbeat();
+
         return () => {
             disposed = true;
             setEngine(engine => {

--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -52,4 +52,5 @@ target_link_libraries(BabylonNative
     NativeEngine
     NativeInput
     NativeXr
-    Window)
+    Window
+    XMLHttpRequest)

--- a/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -81,6 +81,8 @@ namespace Babylon
             Plugins::NativeXr::Initialize(m_env);
 
             Polyfills::Window::Initialize(m_env);
+            // NOTE: React Native's XMLHttpRequest is slow and allocates a lot of memory. This does not override
+            // React Native's implementation, but rather adds a second one scoped to Babylon and used by WebRequest.ts.
             Polyfills::XMLHttpRequest::Initialize(m_env);
 
             m_nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(m_env);

--- a/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -7,6 +7,7 @@
 #include <Babylon/Plugins/NativeInput.h>
 #include <Babylon/Plugins/NativeXr.h>
 #include <Babylon/Polyfills/Window.h>
+#include <Babylon/Polyfills/XMLHttpRequest.h>
 
 #include <AndroidExtensions/Globals.h>
 
@@ -61,7 +62,9 @@ namespace Babylon
                     (data->scheduler)([env, func = std::move(func), &data]()
                     {
                         func(env);
-                        data->flushedQueue.Call({});
+                        // NOTE: This doesn't work quite right on iOS, so we'll use a different work around until
+                        // we have a better solution (see Shared.h and EngineHook.ts for more details).
+                        //data->flushedQueue.Call({});
                     });
                 };
 
@@ -78,6 +81,7 @@ namespace Babylon
             Plugins::NativeXr::Initialize(m_env);
 
             Polyfills::Window::Initialize(m_env);
+            Polyfills::XMLHttpRequest::Initialize(m_env);
 
             m_nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(m_env);
         }

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -75,6 +75,8 @@ namespace Babylon
         m_impl->m_graphics->AddToJavaScript(m_impl->env);
 
         Polyfills::Window::Initialize(m_impl->env);
+        // NOTE: React Native's XMLHttpRequest is slow and allocates a lot of memory. This does not override
+        // React Native's implementation, but rather adds a second one scoped to Babylon and used by WebRequest.ts.
         Polyfills::XMLHttpRequest::Initialize(m_impl->env);
 
         Plugins::NativeWindow::Initialize(m_impl->env, windowPtr, width, height);

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -7,6 +7,7 @@
 #include <Babylon/Plugins/NativeInput.h>
 #include <Babylon/Plugins/NativeXr.h>
 #include <Babylon/Polyfills/Window.h>
+#include <Babylon/Polyfills/XMLHttpRequest.h>
 
 #include <arcana/threading/task_schedulers.h>
 
@@ -63,7 +64,9 @@ namespace Babylon
                 (data->scheduler)([env, func = std::move(func), &data]()
                 {
                     func(env);
-                    data->setTimeout->call((static_cast<napi_env>(env))->rt, {});
+                    // NOTE: This doesn't work quite right on iOS, so we'll use a different work around until
+                    // we have a better solution (see Shared.h and EngineHook.ts for more details).
+                    //data->setTimeout->call((static_cast<napi_env>(env))->rt, {});
                 });
             };
 
@@ -72,6 +75,7 @@ namespace Babylon
         m_impl->m_graphics->AddToJavaScript(m_impl->env);
 
         Polyfills::Window::Initialize(m_impl->env);
+        Polyfills::XMLHttpRequest::Initialize(m_impl->env);
 
         Plugins::NativeWindow::Initialize(m_impl->env, windowPtr, width, height);
         Plugins::NativeEngine::Initialize(m_impl->env);

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -39,7 +39,8 @@ target_link_libraries(BabylonNative
     NativeEngine
     NativeInput
     NativeXr
-    Window)
+    Window
+    XMLHttpRequest)
 
 # TODO: For some reason these don't work, so we specify these in the CMake command line args.
 set_target_properties(BabylonNative PROPERTIES

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -27,7 +27,7 @@
     "base-64": "^0.1.0"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^4.2.0-beta.10",
+    "@babylonjs/core": "^4.2.0-beta.12",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
     "react-native-permissions": "^2.1.4"

--- a/Modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -40,7 +40,9 @@ Pod::Spec.new do |s|
                 'spirv-cross-glsl',
                 'spirv-cross-hlsl',
                 'spirv-cross-msl',
+                'UrlLib',
                 'Window',
+                'XMLHttpRequest',
                 'xr'
 
   s.frameworks = "MetalKit", "ARKit"

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -102,6 +102,8 @@ Assembled/ios/libs/libNativeInput.a
 Assembled/ios/libs/libJsRuntime.a
 Assembled/ios/libs/libGraphics.a
 Assembled/ios/libs/libOSDependent.a
+Assembled/ios/libs/libXMLHttpRequest.a
+Assembled/ios/libs/libUrlLib.a
 Assembled/ios/libs/libastc-codec.a
 Assembled/ios/libs/libGenericCodeGen.a
 Assembled/ios/libs/libspirv-cross-core.a

--- a/Package/iOS/CMakeLists.txt
+++ b/Package/iOS/CMakeLists.txt
@@ -25,7 +25,9 @@ set(PACKAGED_LIBS
     spirv-cross-glsl
     spirv-cross-hlsl
     spirv-cross-msl
+    UrlLib
     Window
+    XMLHttpRequest
     xr
 )
 


### PR DESCRIPTION
React Native's `XMLHttpRequest` uses too much memory and is too slow for use with Babylon.js. This change brings in Babylon Native's `XMLHttpRequest`, but does not replace the globally scoped one provided by React Native. Instead, it exposes it from the `_native` object, which `WebRequest` will specifically look for in @babylonjs/core@4.2.0-beta.12 or newer.
- Update Babylon.js to 4.2.0-beta.12.
- Update Babylon Native to latest (for corresponding `XMLHttpRequest` related changes).
- Add `XMLHttpRequest` to the Android and iOS build.
- Initialize `XMLHttpRequest` in the Android and iOS interop layers.
- Add `XMLHttpRequest` related libs to the pod file and package build validation.

Other unrelated changes included in this PR:
- Updating some GitHub build tasks to the latest to see if it resolves some confusing build warnings.
- Update iOS test app project files to use iOS 12 to match what the Babylon React Native podspec requires (otherwise I get errors when building Release in XCode 12).
- Revert to the old workaround for the promise continuation issue (it turns out the new approach doesn't work on iOS in Release builds).
- Add `@react-native-community/cli` as a dev dependency to the test apps as it seems we can use it to convert a Hermes profile to CDT profiler format and view it in Chrome (still trying to get this to work).