### PR TITLE
Enable logbox for unhandled exceptions that go from JS back to native

### DIFF
--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -34,6 +34,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/")
 set(BABYLON_NATIVE_DIR "${CMAKE_CURRENT_LIST_DIR}/../submodules/BabylonNative")
 add_subdirectory(${BABYLON_NATIVE_DIR} ${BABYLON_NATIVE_DIR}/build/Android_${CMAKE_ANDROID_ARCH_ABI}/)
 
+set(BABYLON_REACT_NATIVE_SHARED_DIR "${CMAKE_CURRENT_LIST_DIR}/../shared")
+add_subdirectory(${BABYLON_REACT_NATIVE_SHARED_DIR} ${CMAKE_CURRENT_BINARY_DIR}/shared)
+
 add_library(fbjni SHARED IMPORTED)
 set_target_properties(fbjni PROPERTIES
     IMPORTED_LOCATION ${FBJNI_LIBPATH}/${ANDROID_ABI}/libfbjni.so
@@ -63,6 +66,7 @@ target_link_libraries(BabylonNative
     fbjni
     jsi
     turbomodulejsijni
+    BabylonReactNativeShared
     AndroidExtensions
     Graphics
     JsRuntime

--- a/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -22,7 +22,7 @@
 #include <jsi/jsi.h>
 #include <ReactCommon/CallInvokerHolder.h>
 
-#include "../../../../shared/DispatchFunction.h"
+#include <DispatchFunction.h>
 
 using namespace facebook;
 

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -19,7 +19,7 @@
 #include <sstream>
 #include <unistd.h>
 
-#include "../shared/DispatchFunction.h"
+#include <DispatchFunction.h>
 
 namespace Babylon
 {

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -19,6 +19,8 @@
 #include <sstream>
 #include <unistd.h>
 
+#include "../shared/DispatchFunction.h"
+
 namespace Babylon
 {
     using namespace facebook;
@@ -26,8 +28,8 @@ namespace Babylon
     class Native::Impl
     {
     public:
-        Impl(facebook::jsi::Runtime* jsiRuntime, std::shared_ptr<facebook::react::CallInvoker> callInvoker)
-            : env{ Napi::Attach<facebook::jsi::Runtime&>(*jsiRuntime) }
+        Impl(facebook::jsi::Runtime& jsiRuntime, std::shared_ptr<facebook::react::CallInvoker> callInvoker)
+            : env{ Napi::Attach<facebook::jsi::Runtime&>(jsiRuntime) }
             , jsCallInvoker{ callInvoker }
         {
         }
@@ -39,23 +41,14 @@ namespace Babylon
         Plugins::NativeInput* nativeInput{};
     };
 
-    Native::Native(facebook::jsi::Runtime* jsiRuntime, std::shared_ptr<facebook::react::CallInvoker> callInvoker, void* windowPtr, size_t width, size_t height)
+    Native::Native(facebook::jsi::Runtime& jsiRuntime, std::shared_ptr<facebook::react::CallInvoker> callInvoker, void* windowPtr, size_t width, size_t height)
         : m_impl{ std::make_unique<Native::Impl>(jsiRuntime, callInvoker) }
     {
         dispatch_sync(dispatch_get_main_queue(), ^{
             m_impl->m_graphics = Graphics::InitializeFromWindow<void*>(windowPtr, width, height);
         });
 
-        JsRuntime::DispatchFunctionT dispatchFunction =
-            [env = m_impl->env, callInvoker = m_impl->jsCallInvoker](std::function<void(Napi::Env)> func)
-            {
-                callInvoker->invokeAsync([env, func = std::move(func)]
-                {
-                    func(env);
-                });
-            };
-
-        m_impl->runtime = &JsRuntime::CreateForJavaScript(m_impl->env, std::move(dispatchFunction));
+        m_impl->runtime = &JsRuntime::CreateForJavaScript(m_impl->env, CreateJsRuntimeDispatcher(m_impl->env, jsiRuntime, callInvoker));
         
         m_impl->m_graphics->AddToJavaScript(m_impl->env);
 

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.h
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.h
@@ -9,7 +9,7 @@ namespace Babylon
     {
     public:
         // This class must be constructed from the JavaScript thread
-        Native(facebook::jsi::Runtime* jsiRuntime, std::shared_ptr<facebook::react::CallInvoker> callInvoker, void* windowPtr, size_t width, size_t height);
+        Native(facebook::jsi::Runtime& jsiRuntime, std::shared_ptr<facebook::react::CallInvoker> callInvoker, void* windowPtr, size_t width, size_t height);
         ~Native();
         void Refresh(void* windowPtr, size_t width, size_t height);
         void Resize(size_t width, size_t height);

--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
@@ -132,7 +132,7 @@ static NSMutableArray* activeTouches;
 
         jsi::Runtime* jsiRuntime = GetJSIRuntime(currentBridge);
         if (jsiRuntime) {
-            currentNativeInstance = std::make_unique<Babylon::Native>(GetJSIRuntime(currentBridge), currentBridge.jsCallInvoker, (__bridge void*)mtkView, width, height);
+            currentNativeInstance = std::make_unique<Babylon::Native>(*jsiRuntime, currentBridge.jsCallInvoker, (__bridge void*)mtkView, width, height);
         }
     }
 

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -23,6 +23,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/")
 set(BABYLON_NATIVE_DIR "${CMAKE_CURRENT_LIST_DIR}/../submodules/BabylonNative")
 add_subdirectory(${BABYLON_NATIVE_DIR} ${BABYLON_NATIVE_DIR}/build/ios/)
 
+set(BABYLON_REACT_NATIVE_SHARED_DIR "${CMAKE_CURRENT_LIST_DIR}/../shared")
+add_subdirectory(${BABYLON_REACT_NATIVE_SHARED_DIR} ${CMAKE_CURRENT_BINARY_DIR}/shared)
+
 add_library(BabylonNative
     ${CMAKE_CURRENT_LIST_DIR}/BabylonNative.h
     ${CMAKE_CURRENT_LIST_DIR}/BabylonNative.cpp)
@@ -38,6 +41,7 @@ target_link_libraries(BabylonNative
     Graphics
     jsi
     reactnative
+    BabylonReactNativeShared
     JsRuntime
     NativeWindow
     NativeEngine

--- a/Modules/@babylonjs/react-native/shared/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/shared/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(BabylonReactNativeShared INTERFACE)
+target_include_directories(BabylonReactNativeShared INTERFACE ".")

--- a/Modules/@babylonjs/react-native/shared/DispatchFunction.h
+++ b/Modules/@babylonjs/react-native/shared/DispatchFunction.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <Babylon/JsRuntime.h>
+
+#include <jsi/jsi.h>
+#include <ReactCommon/CallInvoker.h>
+
+namespace Babylon
+{
+    using namespace facebook;
+
+    inline JsRuntime::DispatchFunctionT CreateJsRuntimeDispatcher(Napi::Env env, jsi::Runtime& jsiRuntime, std::shared_ptr<react::CallInvoker> callInvoker)
+    {
+        return [env, &jsiRuntime, callInvoker](std::function<void(Napi::Env)> func)
+        {
+            callInvoker->invokeAsync([env, &jsiRuntime, func{std::move(func)}]
+            {
+                try
+                {
+                    func(env);
+                }
+                catch (...)
+                {
+                    auto ex{std::current_exception()};
+                    auto setImmediate{jsiRuntime.global().getPropertyAsFunction(jsiRuntime, "setImmediate")};
+                    auto throwFunc{jsi::Function::createFromHostFunction(jsiRuntime, jsi::PropNameID::forAscii(jsiRuntime, "throwFunc"), 0,
+                        [ex](jsi::Runtime &, const jsi::Value &, const jsi::Value *, size_t) -> jsi::Value
+                        {
+                            std::rethrow_exception(ex);
+                        })};
+                    setImmediate.call(jsiRuntime, {std::move(throwFunc)});
+                }
+            });
+        };
+    }
+}

--- a/Modules/@babylonjs/react-native/shared/DispatchFunction.h
+++ b/Modules/@babylonjs/react-native/shared/DispatchFunction.h
@@ -9,10 +9,20 @@ namespace Babylon
 {
     using namespace facebook;
 
+    // Creates a JsRuntime::DispatchFunctionT that integrates with the React Native execution environment.
     inline JsRuntime::DispatchFunctionT CreateJsRuntimeDispatcher(Napi::Env env, jsi::Runtime& jsiRuntime, std::shared_ptr<react::CallInvoker> callInvoker)
     {
         return [env, &jsiRuntime, callInvoker](std::function<void(Napi::Env)> func)
         {
+            // Ideally we would just use CallInvoker::invokeAsync directly, but currently it does not seem to integrate well with the React Native logbox.
+            // To work around this, we wrap all functions in a try/catch, and when there is an exception, we do the following:
+            // 1. Call the JavaScript setImmediate function.
+            // 2. Have the setImmediate callback call back into native code (throwFunc).
+            // 3. Re-throw the exception from throwFunc.
+            // This works because:
+            // 1. setImmediate queues the callback, and that queue is drained immediately following the invocation of the function passed to CallInvoker::invokeAsync.
+            // 2. The immediates queue is drained as part of the class bridge, which knows how to display the logbox for unhandled exceptions.
+            // In the future, CallInvoker::invokeAsync likely will properly integrate with logbox, at which point we can remove the try/catch and just call func directly.
             callInvoker->invokeAsync([env, &jsiRuntime, func{std::move(func)}]
             {
                 try


### PR DESCRIPTION
In a nutshell, this change makes unhandled JS errors that bubble back up to native code (through our JSI related code paths) display correctly in the React Native logbox/redbox so you can see what error happened and where. See the big comment in `DispatchFunction.h` for more details.

- Add a new BabylonReactNativeShared lib, since we will likely share more code going forward.
- Add DispatchFunction.h containing the `CreateJsRuntimeDispatcher` function. This is where the work is done to re-expose the unhandled error in a way that it is displayed in the React Native logbox.
- Add a library dependency on BabylonReactNativeShared for both the iOS and Android Babylon React Native CMakeLists.txt files.
- Use `CreateJsRuntimeDispatcher` in both the iOS and Android Babylon React Native interop layers.

With these changes, when an unhandled exception occurs in JavaScript that is called from our native code, it now shows correctly in logbox:
![image](https://user-images.githubusercontent.com/5084643/96521528-58096500-1226-11eb-80b4-fb139cc1745c.png)

NOTE: This still doesn't work quite right when an unhandled exception comes from JavaScript code that executes as part of `Scene.beforeRender`. It seems like something in bgfx goes wrong, so I will log a bug for this separately.
