### PR TITLE
Fix CMake build break on windows

### DIFF
--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -23,11 +23,12 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(BABYLON_NATIVE_PLATFORM "Android")
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+file(TO_CMAKE_PATH "${REACTNATIVE_DIR}" REACTNATIVE_DIR_CMAKE)
 
 # Configure Babylon Native to use JSI
 set(NAPI_JAVASCRIPT_ENGINE "JSI" CACHE STRING "The JavaScript engine to power N-API")
 add_subdirectory(${REACTNATIVE_DIR}/ReactCommon/jsi/jsi ${CMAKE_CURRENT_BINARY_DIR}/jsi)
-target_include_directories(jsi INTERFACE ${REACTNATIVE_DIR}/ReactCommon/jsi)
+target_include_directories(jsi INTERFACE ${REACTNATIVE_DIR_CMAKE}/ReactCommon/jsi)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/")
 
@@ -45,10 +46,10 @@ set_target_properties(fbjni PROPERTIES
 # Define a minimal version of libturbomodulejsijni.so that includes CallInvokerHolder.cpp.
 # This is the only part of the TurboModule system we need for now. Eventually when TurboModule
 # support ships with React Native, we'll need to strip this back out.
-list(APPEND TURBOMODULE_INC_DIRS "${REACTNATIVE_DIR}/ReactCommon/callinvoker")
-list(APPEND TURBOMODULE_INC_DIRS "${REACTNATIVE_DIR}/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni")
+list(APPEND TURBOMODULE_INC_DIRS "${REACTNATIVE_DIR_CMAKE}/ReactCommon/callinvoker")
+list(APPEND TURBOMODULE_INC_DIRS "${REACTNATIVE_DIR_CMAKE}/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni")
 add_library(turbomodulejsijni SHARED
-    ${REACTNATIVE_DIR}/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/ReactCommon/CallInvokerHolder.cpp)
+    ${REACTNATIVE_DIR_CMAKE}/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni/ReactCommon/CallInvokerHolder.cpp)
 target_include_directories(turbomodulejsijni PUBLIC "${TURBOMODULE_INC_DIRS}")
 target_link_libraries(turbomodulejsijni
     fbjni)

--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -27,7 +27,7 @@ file(TO_CMAKE_PATH "${REACTNATIVE_DIR}" REACTNATIVE_DIR_CMAKE)
 
 # Configure Babylon Native to use JSI
 set(NAPI_JAVASCRIPT_ENGINE "JSI" CACHE STRING "The JavaScript engine to power N-API")
-add_subdirectory(${REACTNATIVE_DIR}/ReactCommon/jsi/jsi ${CMAKE_CURRENT_BINARY_DIR}/jsi)
+add_subdirectory(${REACTNATIVE_DIR_CMAKE}/ReactCommon/jsi/jsi ${CMAKE_CURRENT_BINARY_DIR}/jsi)
 target_include_directories(jsi INTERFACE ${REACTNATIVE_DIR_CMAKE}/ReactCommon/jsi)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/src/")


### PR DESCRIPTION
The changes to the cmake file in #96 to include the CallInvoker in the build was configured to use the REACTNATIVE_DIR environment variable directly.  This does not work on windows as by default it will use backslashes in the path instead of forward slashes.  The fix is to convert the path string to one that is compatible with CMAKE.