### PR TITLE
Fix NativeEngine memory leak

### DIFF
--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -67,22 +67,23 @@ export function useEngine(): Engine | undefined {
 
     useEffect(() => {
         let disposed = false;
+        let engine: Engine | undefined = undefined;
 
         (async () => {
             if (await BabylonModule.initialize() && !disposed)
             {
-                setEngine(new NativeEngine());
+                engine = new NativeEngine();
+                setEngine(engine);
             }
         })();
 
         return () => {
             disposed = true;
-            setEngine(engine => {
-                if (engine) {
-                    DisposeEngine(engine);
-                }
-                return undefined;
-            });
+            // NOTE: Do not use setEngine with a callback to dispose the engine instance as that callback does not get called during component unmount when compiled in release.
+            if (engine) {
+                DisposeEngine(engine);
+            }
+            setEngine(undefined);
         };
     }, []);
 


### PR DESCRIPTION
With React hooks, a state setter can optionally take a lambda that receives the old state value and returns the new state value. We were relying on this to get the old `NativeEngine` instance and dispose it when the containing component is unmounted. However, what I have found is that the state setter lambda is not actually invoked during an unmount, and so we were not disposing the `NativeEngine` instance, which resulted in the XR session not being exited or cleaned up, which meant we were leaking a very large amount of memory if the `EngineView` is unmounted while in XR mode. Other resources are leaked as well in this scenario, but the XR resources are most noticeable.

This change also updates to the latest BabylonNative submodule, which brings in `XMLHttpRequest` memory leak fixes as well.

This change (including the BabylonNative update) addresses the bulk of https://github.com/BabylonJS/BabylonReactNative/issues/102.