### PR TITLE
Update to latest Babylon Native with render threading

### DIFF
--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -62,6 +62,11 @@ class DOMException {
 declare const global: any;
 global.atob = base64.decode;
 
+// This global object is part of Babylon Native.
+declare const _native: {
+    graphicsInitializationPromise: Promise<void>;
+}
+
 export function useEngine(): Engine | undefined {
     const [engine, setEngine] = useState<Engine>();
 
@@ -72,6 +77,7 @@ export function useEngine(): Engine | undefined {
         (async () => {
             if (await BabylonModule.initialize() && !disposed)
             {
+                await _native.graphicsInitializationPromise;
                 engine = new NativeEngine();
                 setEngine(engine);
             }

--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -71,7 +71,6 @@ target_link_libraries(BabylonNative
     AndroidExtensions
     Graphics
     JsRuntime
-    NativeWindow
     NativeEngine
     NativeInput
     NativeXr

--- a/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -2,7 +2,6 @@
 
 #include <Babylon/Graphics.h>
 #include <Babylon/JsRuntime.h>
-#include <Babylon/Plugins/NativeWindow.h>
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/NativeInput.h>
 #include <Babylon/Plugins/NativeXr.h>
@@ -48,11 +47,10 @@ namespace Babylon
             auto width = static_cast<size_t>(ANativeWindow_getWidth(windowPtr));
             auto height = static_cast<size_t>(ANativeWindow_getHeight(windowPtr));
 
-            m_graphics = Graphics::InitializeFromWindow<void*>(windowPtr, width, height);
+            m_graphics = Graphics::CreateGraphics(reinterpret_cast<void*>(windowPtr), width, height);
             m_graphics->AddToJavaScript(m_env);
 
-            Plugins::NativeEngine::Initialize(m_env);
-            Plugins::NativeWindow::Initialize(m_env, windowPtr, width, height);
+            Plugins::NativeEngine::Initialize(m_env, true);
             Plugins::NativeXr::Initialize(m_env);
 
             Polyfills::Window::Initialize(m_env);
@@ -73,8 +71,8 @@ namespace Babylon
         {
             auto width = static_cast<size_t>(ANativeWindow_getWidth(windowPtr));
             auto height = static_cast<size_t>(ANativeWindow_getHeight(windowPtr));
-            m_graphics->ReinitializeFromWindow<void*>(windowPtr, width, height);
-            Plugins::NativeWindow::Reinitialize(m_env, windowPtr, width, height);
+            m_graphics->UpdateWindow<void*>(windowPtr);
+            m_graphics->UpdateSize(width, height);
         }
 
         void SetPointerButtonState(uint32_t pointerId, uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -43,7 +43,6 @@ target_link_libraries(BabylonNative
     reactnative
     BabylonReactNativeShared
     JsRuntime
-    NativeWindow
     NativeEngine
     NativeInput
     NativeXr

--- a/Modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -33,7 +33,6 @@ Pod::Spec.new do |s|
                 'napi',
                 'NativeEngine',
                 'NativeInput',
-                'NativeWindow',
                 'NativeXR',
                 'SPIRV',
                 'spirv-cross-core',

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -94,7 +94,6 @@ Assembled/ios/libs/libWindow.a
 Assembled/ios/libs/libbimg.a
 Assembled/ios/libs/libOGLCompiler.a
 Assembled/ios/libs/libastc.a
-Assembled/ios/libs/libNativeWindow.a
 Assembled/ios/libs/libNativeEngine.a
 Assembled/ios/libs/libNativeXr.a
 Assembled/ios/libs/libspirv-cross-glsl.a

--- a/Package/iOS/CMakeLists.txt
+++ b/Package/iOS/CMakeLists.txt
@@ -18,7 +18,6 @@ set(PACKAGED_LIBS
     napi
     NativeEngine
     NativeInput
-    NativeWindow
     NativeXr
     SPIRV
     spirv-cross-core


### PR DESCRIPTION
This change updates to the latest BabylonNative submodule, and makes changes to work with the render threading updates (https://github.com/BabylonJS/BabylonNative/pull/451). 