### PR TITLE
Get dev mode reload working

### DIFF
--- a/Modules/@babylonjs/react-native/BabylonModule.ts
+++ b/Modules/@babylonjs/react-native/BabylonModule.ts
@@ -1,6 +1,31 @@
 import { NativeModules } from 'react-native';
+import { NativeEngine } from '@babylonjs/core';
 
-export const BabylonModule: {
+// This global object is part of Babylon Native.
+declare const _native: {
+    graphicsInitializationPromise: Promise<void>;
+    engineInstance: NativeEngine;
+}
+
+const NativeBabylonModule: {
     initialize(): Promise<boolean>;
     whenInitialized(): Promise<boolean>;
 } = NativeModules.BabylonModule;
+
+export const BabylonModule = {
+    initialize: async () => {
+        const initialized = await NativeBabylonModule.initialize();
+        if (initialized) {
+            await _native.graphicsInitializationPromise;
+        }
+        return initialized;
+    },
+
+    whenInitialized: NativeBabylonModule.whenInitialized,
+
+    createEngine: () => {
+        const engine = new NativeEngine();
+        _native.engineInstance = engine;
+        return engine;
+    }
+};

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -62,11 +62,6 @@ class DOMException {
 declare const global: any;
 global.atob = base64.decode;
 
-// This global object is part of Babylon Native.
-declare const _native: {
-    graphicsInitializationPromise: Promise<void>;
-}
-
 export function useEngine(): Engine | undefined {
     const [engine, setEngine] = useState<Engine>();
 
@@ -77,9 +72,7 @@ export function useEngine(): Engine | undefined {
         (async () => {
             if (await BabylonModule.initialize() && !disposed)
             {
-                await _native.graphicsInitializationPromise;
-                engine = new NativeEngine();
-                (_native as any).engineInstance = engine;
+                engine = BabylonModule.createEngine();
                 setEngine(engine);
             }
         })();

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -79,11 +79,14 @@ export function useEngine(): Engine | undefined {
             {
                 await _native.graphicsInitializationPromise;
                 engine = new NativeEngine();
+                console.log("SETTING _native.engineInstance");
+                (_native as any).engineInstance = engine;
                 setEngine(engine);
             }
         })();
 
         return () => {
+            console.log("DISPOSING");
             disposed = true;
             // NOTE: Do not use setEngine with a callback to dispose the engine instance as that callback does not get called during component unmount when compiled in release.
             if (engine) {

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -79,14 +79,12 @@ export function useEngine(): Engine | undefined {
             {
                 await _native.graphicsInitializationPromise;
                 engine = new NativeEngine();
-                console.log("SETTING _native.engineInstance");
                 (_native as any).engineInstance = engine;
                 setEngine(engine);
             }
         })();
 
         return () => {
-            console.log("DISPOSING");
             disposed = true;
             // NOTE: Do not use setEngine with a callback to dispose the engine instance as that callback does not get called during component unmount when compiled in release.
             if (engine) {

--- a/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
+++ b/Modules/@babylonjs/react-native/android/src/main/cpp/BabylonNativeInterop.cpp
@@ -16,7 +16,6 @@
 
 #include <optional>
 #include <sstream>
-#include <thread>
 #include <unistd.h>
 
 #include <jsi/jsi.h>
@@ -30,10 +29,10 @@ namespace Babylon
 {
     namespace
     {
-//        void log(const char *str)
-//        {
-//            __android_log_print(ANDROID_LOG_VERBOSE, "BabylonNative", "%s", str);
-//        }
+        void log(const char *str)
+        {
+            __android_log_print(ANDROID_LOG_VERBOSE, "BabylonNative", "%s", str);
+        }
 
         bool isShuttingDown{false};
     }
@@ -47,7 +46,7 @@ namespace Babylon
         {
             isShuttingDown = false;
 
-            m_runtime = &JsRuntime::CreateForJavaScript(m_env, CreateJsRuntimeDispatcher(m_env, jsiRuntime, callInvoker, isShuttingDown));
+            m_runtime = &JsRuntime::CreateForJavaScript(m_env, CreateJsRuntimeDispatcher(m_env, jsiRuntime, std::move(callInvoker), isShuttingDown));
 
             auto width = static_cast<size_t>(ANativeWindow_getWidth(windowPtr));
             auto height = static_cast<size_t>(ANativeWindow_getHeight(windowPtr));
@@ -66,24 +65,18 @@ namespace Babylon
             m_nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(m_env);
         }
 
+        // NOTE: This only happens when the JS engine is shutting down (other than when the app exits, this only
+        //       happens during a dev mode reload). In this case, EngineHook.ts won't call NativeEngine.dispose,
+        //       so we need to manually do it here to properly clean up these resources.
         ~Native()
         {
-            log("DESTROYING NATIVE INTEROP INSTANCE");
-            //auto& localIsShuttingDown = isShuttingDown;
-            m_runtime->Dispatch([graphics{m_graphics}](Napi::Env env){
-                log("IN DISPATCH FOR CLEANUP");
-                auto native = JsRuntime::NativeObject::GetFromJavaScript(env);
-                auto engine = native.Get("engineInstance").As<Napi::Object>();
-                auto dispose = engine.Get("dispose").As<Napi::Function>();
-                auto isUndefined = dispose.IsUndefined();
-                dispose.Call(engine, {});
-                //Napi::Eval(env, "_native.engineInstance.dispose()", "");
-                isShuttingDown = true;
-            });
-            while(!isShuttingDown){ std::this_thread::yield(); }
+            auto native = JsRuntime::NativeObject::GetFromJavaScript(m_env);
+            auto engine = native.Get("engineInstance").As<Napi::Object>();
+            auto dispose = engine.Get("dispose").As<Napi::Function>();
+            dispose.Call(engine, {});
+            isShuttingDown = true;
 
-            // TODO: Figure out why this causes the app to crash
-            //Napi::Detach(m_env);
+            Napi::Detach(m_env);
         }
 
         void Refresh(ANativeWindow* windowPtr)
@@ -112,7 +105,7 @@ namespace Babylon
         }
 
     private:
-        std::shared_ptr<Graphics> m_graphics{};
+        std::unique_ptr<Graphics> m_graphics{};
         Napi::Env m_env;
         JsRuntime* m_runtime;
         Plugins::NativeInput* m_nativeInput;

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/BabylonModule.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/BabylonModule.java
@@ -24,7 +24,8 @@ public final class BabylonModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onCatalystInstanceDestroy() {
-        new Handler(Looper.getMainLooper()).post(BabylonNativeInterop::deinitialize);
+        //new Handler(Looper.getMainLooper()).post(BabylonNativeInterop::deinitialize);
+        BabylonNativeInterop.deinitialize();
     }
 
     @ReactMethod

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/BabylonModule.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/BabylonModule.java
@@ -25,7 +25,7 @@ public final class BabylonModule extends ReactContextBaseJavaModule {
     // NOTE: This happens during dev mode reload, when the JS engine is being shutdown and restarted.
     @Override
     public void onCatalystInstanceDestroy() {
-        BabylonNativeInterop.deinitialize();
+        this.getReactApplicationContext().runOnJSQueueThread(BabylonNativeInterop::deinitialize);
     }
 
     @ReactMethod

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/BabylonModule.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/BabylonModule.java
@@ -22,9 +22,9 @@ public final class BabylonModule extends ReactContextBaseJavaModule {
         return "BabylonModule";
     }
 
+    // NOTE: This happens during dev mode reload, when the JS engine is being shutdown and restarted.
     @Override
     public void onCatalystInstanceDestroy() {
-        //new Handler(Looper.getMainLooper()).post(BabylonNativeInterop::deinitialize);
         BabylonNativeInterop.deinitialize();
     }
 

--- a/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/BabylonNativeInterop.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/BabylonNativeInterop.java
@@ -132,7 +132,7 @@ final class BabylonNativeInterop {
         return BabylonNativeInterop.getOrCreateFuture(reactContext);
     }
 
-    // Must be called from the Android UI thread
+    // Must be called from the JavaScript thread
     static void deinitialize() {
         BabylonNativeInterop.destroyOldNativeInstances(null);
     }

--- a/Modules/@babylonjs/react-native/ios/BabylonModule.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonModule.mm
@@ -1,10 +1,11 @@
 #import "BabylonNativeInterop.h"
 
 #import <React/RCTBridgeModule.h>
+#import <React/RCTInvalidating.h>
 
 #import <Foundation/Foundation.h>
 
-@interface BabylonModule : NSObject <RCTBridgeModule>
+@interface BabylonModule : NSObject <RCTBridgeModule, RCTInvalidating>
 @end
 
 @implementation BabylonModule
@@ -19,6 +20,17 @@ RCT_EXPORT_METHOD(initialize:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseR
 
 RCT_EXPORT_METHOD(whenInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [BabylonNativeInterop whenInitialized:self.bridge resolve:resolve];
+}
+
+- (dispatch_queue_t)methodQueue
+{
+  //return dispatch_get_main_queue();
+    return RCTJSThread;
+}
+
+- (void)invalidate
+{
+    [BabylonNativeInterop reset];
 }
 
 @end

--- a/Modules/@babylonjs/react-native/ios/BabylonModule.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonModule.mm
@@ -1,11 +1,10 @@
 #import "BabylonNativeInterop.h"
 
 #import <React/RCTBridgeModule.h>
-#import <React/RCTInvalidating.h>
 
 #import <Foundation/Foundation.h>
 
-@interface BabylonModule : NSObject <RCTBridgeModule, RCTInvalidating>
+@interface BabylonModule : NSObject <RCTBridgeModule>
 @end
 
 @implementation BabylonModule
@@ -20,17 +19,6 @@ RCT_EXPORT_METHOD(initialize:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseR
 
 RCT_EXPORT_METHOD(whenInitialized:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [BabylonNativeInterop whenInitialized:self.bridge resolve:resolve];
-}
-
-- (dispatch_queue_t)methodQueue
-{
-  //return dispatch_get_main_queue();
-    return RCTJSThread;
-}
-
-- (void)invalidate
-{
-    [BabylonNativeInterop reset];
 }
 
 @end

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -56,8 +56,8 @@ namespace Babylon
         isShuttingDown = false;
         m_impl->graphics = Graphics::CreateGraphics(reinterpret_cast<void*>(windowPtr), width, height);
 
-        m_impl->runtime = &JsRuntime::CreateForJavaScript(m_impl->env, CreateJsRuntimeDispatcher(m_impl->env, jsiRuntime, callInvoker, isShuttingDown));
-        
+        m_impl->runtime = &JsRuntime::CreateForJavaScript(m_impl->env, CreateJsRuntimeDispatcher(m_impl->env, jsiRuntime, std::move(callInvoker), isShuttingDown));
+
         m_impl->graphics->AddToJavaScript(m_impl->env);
 
         Polyfills::Window::Initialize(m_impl->env);

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -71,6 +71,9 @@ namespace Babylon
         m_impl->nativeInput = &Babylon::Plugins::NativeInput::CreateForJavaScript(m_impl->env);
     }
 
+    // NOTE: This only happens when the JS engine is shutting down (other than when the app exits, this only
+    //       happens during a dev mode reload). In this case, EngineHook.ts won't call NativeEngine.dispose,
+    //       so we need to manually do it here to properly clean up these resources.
     Native::~Native()
     {
         auto native = JsRuntime::NativeObject::GetFromJavaScript(m_impl->env);

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -54,9 +54,7 @@ namespace Babylon
         : m_impl{ std::make_unique<Native::Impl>(jsiRuntime, callInvoker) }
     {
         isShuttingDown = false;
-        //dispatch_sync(dispatch_get_main_queue(), ^{
-            m_impl->graphics = Graphics::CreateGraphics(reinterpret_cast<void*>(windowPtr), width, height);
-        //});
+        m_impl->graphics = Graphics::CreateGraphics(reinterpret_cast<void*>(windowPtr), width, height);
 
         m_impl->runtime = &JsRuntime::CreateForJavaScript(m_impl->env, CreateJsRuntimeDispatcher(m_impl->env, jsiRuntime, callInvoker, isShuttingDown));
         
@@ -75,18 +73,11 @@ namespace Babylon
 
     Native::~Native()
     {
-//        m_impl->runtime->Dispatch([graphics{m_impl->graphics}](Napi::Env env){
-            auto native = JsRuntime::NativeObject::GetFromJavaScript(m_impl->env);
-            auto engine = native.Get("engineInstance").As<Napi::Object>();
-            auto dispose = engine.Get("dispose").As<Napi::Function>();
-            dispose.Call(engine, {});
-            isShuttingDown = true;
-//        });
-//
-//        while (!isShuttingDown)
-//        {
-//            std::this_thread::yield();
-//        }
+        auto native = JsRuntime::NativeObject::GetFromJavaScript(m_impl->env);
+        auto engine = native.Get("engineInstance").As<Napi::Object>();
+        auto dispose = engine.Get("dispose").As<Napi::Function>();
+        dispose.Call(engine, {});
+        isShuttingDown = true;
     }
 
     void Native::Refresh(void* windowPtr, size_t width, size_t height)

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -45,7 +45,7 @@ namespace Babylon
 
         Napi::Env env;
         std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker;
-        std::shared_ptr<Graphics> graphics{};
+        std::unique_ptr<Graphics> graphics{};
         JsRuntime* runtime{};
         Plugins::NativeInput* nativeInput{};
     };

--- a/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/ios/BabylonNative.cpp
@@ -24,6 +24,11 @@ namespace Babylon
 {
     using namespace facebook;
 
+    namespace
+    {
+        bool isShuttingDown{false};
+    }
+
     class Native::Impl
     {
     public:
@@ -32,10 +37,15 @@ namespace Babylon
             , jsCallInvoker{ callInvoker }
         {
         }
+        
+        ~Impl()
+        {
+            Napi::Detach(env);
+        }
 
         Napi::Env env;
         std::shared_ptr<facebook::react::CallInvoker> jsCallInvoker;
-        std::unique_ptr<Graphics> m_graphics{};
+        std::shared_ptr<Graphics> graphics{};
         JsRuntime* runtime{};
         Plugins::NativeInput* nativeInput{};
     };
@@ -43,13 +53,14 @@ namespace Babylon
     Native::Native(facebook::jsi::Runtime& jsiRuntime, std::shared_ptr<facebook::react::CallInvoker> callInvoker, void* windowPtr, size_t width, size_t height)
         : m_impl{ std::make_unique<Native::Impl>(jsiRuntime, callInvoker) }
     {
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            m_impl->m_graphics = Graphics::CreateGraphics(reinterpret_cast<void*>(windowPtr), width, height);
-        });
+        isShuttingDown = false;
+        //dispatch_sync(dispatch_get_main_queue(), ^{
+            m_impl->graphics = Graphics::CreateGraphics(reinterpret_cast<void*>(windowPtr), width, height);
+        //});
 
-        m_impl->runtime = &JsRuntime::CreateForJavaScript(m_impl->env, CreateJsRuntimeDispatcher(m_impl->env, jsiRuntime, callInvoker));
+        m_impl->runtime = &JsRuntime::CreateForJavaScript(m_impl->env, CreateJsRuntimeDispatcher(m_impl->env, jsiRuntime, callInvoker, isShuttingDown));
         
-        m_impl->m_graphics->AddToJavaScript(m_impl->env);
+        m_impl->graphics->AddToJavaScript(m_impl->env);
 
         Polyfills::Window::Initialize(m_impl->env);
         // NOTE: React Native's XMLHttpRequest is slow and allocates a lot of memory. This does not override
@@ -64,17 +75,29 @@ namespace Babylon
 
     Native::~Native()
     {
+//        m_impl->runtime->Dispatch([graphics{m_impl->graphics}](Napi::Env env){
+            auto native = JsRuntime::NativeObject::GetFromJavaScript(m_impl->env);
+            auto engine = native.Get("engineInstance").As<Napi::Object>();
+            auto dispose = engine.Get("dispose").As<Napi::Function>();
+            dispose.Call(engine, {});
+            isShuttingDown = true;
+//        });
+//
+//        while (!isShuttingDown)
+//        {
+//            std::this_thread::yield();
+//        }
     }
 
     void Native::Refresh(void* windowPtr, size_t width, size_t height)
     {
-        m_impl->m_graphics->UpdateWindow<void*>(windowPtr);
-        m_impl->m_graphics->UpdateSize(width, height);
+        m_impl->graphics->UpdateWindow<void*>(windowPtr);
+        m_impl->graphics->UpdateSize(width, height);
     }
 
     void Native::Resize(size_t width, size_t height)
     {
-        m_impl->m_graphics->UpdateSize(width, height);
+        m_impl->graphics->UpdateSize(width, height);
     }
 
     void Native::SetPointerButtonState(uint32_t pointerId, uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)

--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.h
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.h
@@ -7,5 +7,4 @@
 + (void)setView:(RCTBridge*)bridge jsRunLoop:(NSRunLoop*)jsRunLoop mktView:(MTKView*)mtkView;
 + (void)reportTouchEvent:(NSSet<UITouch*>*)touches withEvent:(UIEvent*)event;
 + (void)whenInitialized:(RCTBridge*)bridge resolve:(RCTPromiseResolveBlock)resolve;
-+ (void)reset;
 @end

--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.h
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.h
@@ -7,4 +7,5 @@
 + (void)setView:(RCTBridge*)bridge jsRunLoop:(NSRunLoop*)jsRunLoop mktView:(MTKView*)mtkView;
 + (void)reportTouchEvent:(NSSet<UITouch*>*)touches withEvent:(UIEvent*)event;
 + (void)whenInitialized:(RCTBridge*)bridge resolve:(RCTPromiseResolveBlock)resolve;
++ (void)reset;
 @end

--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
@@ -127,6 +127,11 @@ static NSMutableArray* activeTouches;
         const std::lock_guard<std::mutex> lock(mapMutex);
 
         currentBridge = bridge;
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self
+            selector:@selector(handleBridgeWillBeInvalidatedNotification:)
+            name:RCTBridgeWillInvalidateModulesNotification
+            object:bridge];
 
         currentNativeInstance.reset();
 
@@ -144,6 +149,15 @@ static NSMutableArray* activeTouches;
 
         initializationPromises.erase(initializationPromisesIterator);
     }
+}
+
++ (void)handleBridgeWillBeInvalidatedNotification:(NSNotification *)notification
+{
+    currentNativeInstance.reset();
+}
+
++ (void)reset {
+    currentNativeInstance.reset();
 }
 
 @end

--- a/Modules/@babylonjs/react-native/shared/DispatchFunction.h
+++ b/Modules/@babylonjs/react-native/shared/DispatchFunction.h
@@ -4,15 +4,24 @@
 
 #include <jsi/jsi.h>
 #include <ReactCommon/CallInvoker.h>
+#include <android/log.h>
 
 namespace Babylon
 {
     using namespace facebook;
 
+    //namespace
+    //{
+        void log(const char *str)
+        {
+            __android_log_print(ANDROID_LOG_VERBOSE, "BabylonNative", "%s", str);
+        }
+    //}
+
     // Creates a JsRuntime::DispatchFunctionT that integrates with the React Native execution environment.
-    inline JsRuntime::DispatchFunctionT CreateJsRuntimeDispatcher(Napi::Env env, jsi::Runtime& jsiRuntime, std::shared_ptr<react::CallInvoker> callInvoker)
+    inline JsRuntime::DispatchFunctionT CreateJsRuntimeDispatcher(Napi::Env env, jsi::Runtime& jsiRuntime, std::shared_ptr<react::CallInvoker> callInvoker, const bool& isShuttingDown)
     {
-        return [env, &jsiRuntime, callInvoker](std::function<void(Napi::Env)> func)
+        return [env, &jsiRuntime, callInvoker, &isShuttingDown](std::function<void(Napi::Env)> func)
         {
             // Ideally we would just use CallInvoker::invokeAsync directly, but currently it does not seem to integrate well with the React Native logbox.
             // To work around this, we wrap all functions in a try/catch, and when there is an exception, we do the following:
@@ -23,11 +32,17 @@ namespace Babylon
             // 1. setImmediate queues the callback, and that queue is drained immediately following the invocation of the function passed to CallInvoker::invokeAsync.
             // 2. The immediates queue is drained as part of the class bridge, which knows how to display the logbox for unhandled exceptions.
             // In the future, CallInvoker::invokeAsync likely will properly integrate with logbox, at which point we can remove the try/catch and just call func directly.
-            callInvoker->invokeAsync([env, &jsiRuntime, func{std::move(func)}]
+            log("DISPATCHING");
+            callInvoker->invokeAsync([env, &jsiRuntime, func{std::move(func)}, &isShuttingDown]
             {
+                log("INVOKEASYNC");
                 try
                 {
-                    func(env);
+                    if (!isShuttingDown)
+                    {
+                        log("INVOKING FUNC");
+                        func(env);
+                    }
                 }
                 catch (...)
                 {

--- a/Modules/@babylonjs/react-native/shared/DispatchFunction.h
+++ b/Modules/@babylonjs/react-native/shared/DispatchFunction.h
@@ -4,7 +4,7 @@
 
 #include <jsi/jsi.h>
 #include <ReactCommon/CallInvoker.h>
-#include <android/log.h>
+//#include <android/log.h>
 
 namespace Babylon
 {
@@ -14,7 +14,7 @@ namespace Babylon
     //{
         void log(const char *str)
         {
-            __android_log_print(ANDROID_LOG_VERBOSE, "BabylonNative", "%s", str);
+            //__android_log_print(ANDROID_LOG_VERBOSE, "BabylonNative", "%s", str);
         }
     //}
 

--- a/Modules/@babylonjs/react-native/shared/DispatchFunction.h
+++ b/Modules/@babylonjs/react-native/shared/DispatchFunction.h
@@ -27,6 +27,7 @@ namespace Babylon
             {
                 try
                 {
+                    // If JS engine shutdown is in progress, don't dispatch any new work.
                     if (!isShuttingDown)
                     {
                         func(env);

--- a/Modules/@babylonjs/react-native/shared/DispatchFunction.h
+++ b/Modules/@babylonjs/react-native/shared/DispatchFunction.h
@@ -4,19 +4,10 @@
 
 #include <jsi/jsi.h>
 #include <ReactCommon/CallInvoker.h>
-//#include <android/log.h>
 
 namespace Babylon
 {
     using namespace facebook;
-
-    //namespace
-    //{
-        void log(const char *str)
-        {
-            //__android_log_print(ANDROID_LOG_VERBOSE, "BabylonNative", "%s", str);
-        }
-    //}
 
     // Creates a JsRuntime::DispatchFunctionT that integrates with the React Native execution environment.
     inline JsRuntime::DispatchFunctionT CreateJsRuntimeDispatcher(Napi::Env env, jsi::Runtime& jsiRuntime, std::shared_ptr<react::CallInvoker> callInvoker, const bool& isShuttingDown)
@@ -32,15 +23,12 @@ namespace Babylon
             // 1. setImmediate queues the callback, and that queue is drained immediately following the invocation of the function passed to CallInvoker::invokeAsync.
             // 2. The immediates queue is drained as part of the class bridge, which knows how to display the logbox for unhandled exceptions.
             // In the future, CallInvoker::invokeAsync likely will properly integrate with logbox, at which point we can remove the try/catch and just call func directly.
-            log("DISPATCHING");
             callInvoker->invokeAsync([env, &jsiRuntime, func{std::move(func)}, &isShuttingDown]
             {
-                log("INVOKEASYNC");
                 try
                 {
                     if (!isShuttingDown)
                     {
-                        log("INVOKING FUNC");
                         func(env);
                     }
                 }


### PR DESCRIPTION
This change includes a bunch of fixes for React Native dev mode reload (which reloads the JS engine).
- Update to the latest BabylonNative submodule which includes a fix to actually delete the napi instance on `Napi::Detach`.
- Set the current `NativeEngine` instance on the `_native` object so we can get it on the native side and manually dispose it (since during a reload the `EngineHook`'s cleanup function will not be called, but we still need to release these resources).
- Have the native interop code grab the current `NativeEngine` instance off of `_native` during teardown and call `dispose` on it.
- Prevent the JS dispatcher from actually doing anything if we are in the process of shutting down the JS engine.

These changes are a little icky and there is a fair bit of duplication across Android and iOS. I have a bigger cleanup planned for this code that will consolidate a lot of the Android and iOS code, but that will happen later.

Fixes #84