### PR TITLE
Make Playground more testable and add manual test steps to docs

### DIFF
--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -9,7 +9,8 @@ import React, { useState, FunctionComponent, useEffect, useCallback } from 'reac
 import { SafeAreaView, StatusBar, Button, View, Text, ViewProps, Image } from 'react-native';
 
 import { EngineView, useEngine, EngineViewCallbacks } from '@babylonjs/react-native';
-import { Scene, Vector3, Mesh, ArcRotateCamera, Camera, PBRMetallicRoughnessMaterial, Color3, TargetCamera, WebXRSessionManager, Engine } from '@babylonjs/core';
+import { Scene, Vector3, ArcRotateCamera, Camera, WebXRSessionManager, SceneLoader, AbstractMesh, TransformNode } from '@babylonjs/core';
+import '@babylonjs/loaders';
 import Slider from '@react-native-community/slider';
 
 const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
@@ -19,7 +20,7 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
   const engine = useEngine();
   const [toggleView, setToggleView] = useState(false);
   const [camera, setCamera] = useState<Camera>();
-  const [box, setBox] = useState<Mesh>();
+  const [rootNode, setRootNode] = useState<TransformNode>();
   const [scene, setScene] = useState<Scene>();
   const [xrSession, setXrSession] = useState<WebXRSessionManager>();
   const [scale, setScale] = useState<number>(defaultScale);
@@ -34,26 +35,30 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
       (scene.activeCamera as ArcRotateCamera).beta -= Math.PI / 8;
       setCamera(scene.activeCamera!);
       scene.createDefaultLight(true);
-
-      const box = Mesh.CreateBox("box", 0.3, scene);
-      setBox(box);
-      const mat = new PBRMetallicRoughnessMaterial("mat", scene);
-      mat.metallic = 1;
-      mat.roughness = 0.5;
-      mat.baseColor = Color3.Red();
-      box.material = mat;
+      const node = new TransformNode("Root Container", scene);
+      setRootNode(node);
 
       scene.beforeRender = function () {
-        box.rotate(Vector3.Up(), 0.005 * scene.getAnimationRatio());
+        node.rotate(Vector3.Up(), 0.005 * scene.getAnimationRatio());
       };
+
+      const transformContainer = new TransformNode("Transform Container", scene);
+      transformContainer.parent = node;
+      transformContainer.scaling.scaleInPlace(0.2);
+      transformContainer.position.y -= .2;
+
+      SceneLoader.ImportMeshAsync("", "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxAnimated/glTF-Binary/BoxAnimated.glb").then(result => {
+        const mesh = result.meshes[0];
+        mesh.parent = transformContainer;
+      });
     }
   }, [engine]);
 
   useEffect(() => {
-    if (box) {
-      box.scaling = new Vector3(scale, scale, scale);
+    if (rootNode) {
+      rootNode.scaling = new Vector3(scale, scale, scale);
     }
-  }, [box, scale]);
+  }, [rootNode, scale]);
 
   const onToggleXr = useCallback(() => {
     (async () => {
@@ -61,19 +66,19 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
         await xrSession.exitXRAsync();
         setXrSession(undefined);
       } else {
-        if (box !== undefined && scene !== undefined) {
+        if (rootNode !== undefined && scene !== undefined) {
           const xr = await scene.createDefaultXRExperienceAsync({ disableDefaultUI: true, disableTeleportation: true })
           const session = await xr.baseExperience.enterXRAsync("immersive-ar", "unbounded", xr.renderTarget);
           setXrSession(session);
           // TODO: Figure out why getFrontPosition stopped working
           //box.position = (scene.activeCamera as TargetCamera).getFrontPosition(2);
           const cameraRay = scene.activeCamera!.getForwardRay(1);
-          box.position = cameraRay.origin.add(cameraRay.direction.scale(cameraRay.length));
-          box.rotate(Vector3.Up(), 3.14159);
+          rootNode.position = cameraRay.origin.add(cameraRay.direction.scale(cameraRay.length));
+          rootNode.rotate(Vector3.Up(), 3.14159);
         }
       }
     })();
-  }, [box, scene, xrSession]);
+  }, [rootNode, scene, xrSession]);
 
   const onInitialized = useCallback(async(engineViewCallbacks: EngineViewCallbacks) => {
     setEngineViewCallbacks(engineViewCallbacks);

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ export JAVA_HOME=$(/usr/libexec/java_home -v 13)
 - The `ANDROID_HOME` environment variable must be defined (typically %LOCALAPPDATA%/Android/sdk).
 - The `JAVA_HOME` environment variable must be defined (typically %ProgramFiles%/Android/Android Studio/jre).
 
-
 ### **Building and Running the Playground App**
 
 On either Mac or Windows, NPM is used to build and run the Playground sample/test app from the command line. Open a command prompt at the root of the BabylonReactNative repo if you don't have one already open.
@@ -115,6 +114,23 @@ npm run ios
 ```
 
 After having run the above commands, you can also open `Apps/Playground/ios/Playground.xcworkspace` in XCode and run the app from there.
+
+### **Testing in the Playground App** ###
+
+When making local changes, the following manual test steps should be performed within the Playground app to prevent regressions. These should be checked on Android and iOS, and ideally in both debug and release, but minimally in release.
+
+1. **Basic rendering** - launch the Playground app and make sure the model loaded and is rendering at 60fps.
+1. **Animation** - make sure the loaded model is animating.
+1. **Input handling** - swipe across the display and make sure the model rotates around the y-axis.
+1. **Display rotation** - rotate the device 90 degrees and make sure the view rotates and renders correctly.
+1. **View replacement** - tap the *Toggle EngineView* button twice to replace the render target view.
+1. **Engine dispose** - tap the *Toggle EngineScreen* button twice to dispose and re-instantiate the Babylon engine.
+1. **Suspend/resume** - switch to a different app and then back to the Playground and make sure it is still rendering correctly.
+1. **Dev mode reload** - in the Metro server console window, press the `R` key on the keyboard to reload the JS engine and make sure rendering restarts successfully.
+1. **XR mode** - tap the *Start XR* button and make sure XR mode is working.
+1. **XR display rotation** - rotate the device 90 degrees and make sure the view rotates and renders correctly.
+1. **XR view replacement** - tap the *Toggle EngineView* button twice to replace the render target view.
+1. **XR suspend/resume** - switch to a different app and then back to the Playground and make sure it is still rendering correctly.
 
 ### **Building the NPM Package**
 


### PR DESCRIPTION
The goal of this change is two-fold:
1. Use more features in the Playground app to make it easier to quickly test that basic functionality is still working.
1. Document a small set of manual test steps that cover the most critical functionality to prevent regressions.

The main features additionally in use in the Playground app with this change are:
1. Loading a glb
1. Rendering a glb with animation
1. Handling touch input