### PR TITLE
Update to latest BabylonNative with tracking states exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,6 @@
 #
 .DS_Store
 
-# Visual Studio Code
-#
-.vscode
-
 # Android Studio
 .project
 .classpath

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"msjsdiag.vscode-react-native",
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Android",
+            "cwd": "${workspaceFolder}/Apps/Playground",
+            "type": "reactnativedirect",
+            "request": "launch",
+            "platform": "android"
+        },
+        {
+            "name": "Debug iOS on Device",
+            "cwd": "${workspaceFolder}/Apps/Playground",
+            "type": "reactnativedirect",
+            "request": "launch",
+            "platform": "ios",
+            "port": 9221,
+            "target": "device"
+        },
+        {
+            "name": "Attach to Android",
+            "cwd": "${workspaceFolder}/Apps/Playground",
+            "type": "reactnativedirect",
+            "request": "attach"
+        },
+        {
+            "name": "Attach to iOS on Device",
+            "cwd": "${workspaceFolder}/Apps/Playground",
+            "type": "reactnativedirect",
+            "request": "attach",
+            "platform": "ios",
+            "port": 9221
+        },
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,14 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Android",
+            "name": "Build & Debug Android",
             "cwd": "${workspaceFolder}/Apps/Playground",
             "type": "reactnativedirect",
             "request": "launch",
             "platform": "android"
         },
         {
-            "name": "Debug iOS on Device",
+            "name": "Build & Debug iOS on Device",
             "cwd": "${workspaceFolder}/Apps/Playground",
             "type": "reactnativedirect",
             "request": "launch",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "react-native-tools.projectRoot": "./Apps/Playground"
+}

--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -75,23 +75,8 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
     }
   }, [rootNode, scale]);
 
-  const trackingStateToString = (trackingState: WebXRTrackingState | undefined) : string =>
-  {
-    if (trackingState == undefined) {
-      return ""
-    }
-
-    switch(trackingState) {
-      case WebXRTrackingState.NOT_TRACKING:
-        return "Not Tracking";
-        break;
-      case WebXRTrackingState.TRACKING:
-        return "Tracking";
-        break;
-      case WebXRTrackingState.TRACKING_LOST:
-        return "Tracking Lost";
-        break;
-    }
+  const trackingStateToString = (trackingState: WebXRTrackingState | undefined) : string => {
+    return trackingState === undefined ? "" : WebXRTrackingState[trackingState];
   }
 
   const onToggleXr = useCallback(() => {
@@ -107,9 +92,9 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
           setXrSession(session);
 
           setTrackingState(xr.baseExperience.camera.trackingState);
-          xr.baseExperience.camera.onTrackingStateChanged.add((newTrackingState) =>{
+          xr.baseExperience.camera.onTrackingStateChanged.add((newTrackingState) => {
             setTrackingState(newTrackingState);
-          })
+          });
 
           // TODO: Figure out why getFrontPosition stopped working
           //box.position = (scene.activeCamera as TargetCamera).getFrontPosition(2);

--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -77,7 +77,7 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
 
   const trackingStateToString = (trackingState: WebXRTrackingState | undefined) : string => {
     return trackingState === undefined ? "" : WebXRTrackingState[trackingState];
-  }
+  };
 
   const onToggleXr = useCallback(() => {
     (async () => {

--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -9,7 +9,8 @@ import React, { useState, FunctionComponent, useEffect, useCallback } from 'reac
 import { SafeAreaView, StatusBar, Button, View, Text, ViewProps, Image } from 'react-native';
 
 import { EngineView, useEngine, EngineViewCallbacks } from '@babylonjs/react-native';
-import { Scene, Vector3, Mesh, ArcRotateCamera, Camera, PBRMetallicRoughnessMaterial, Color3, TargetCamera, WebXRSessionManager, Engine, WebXRTrackingState } from '@babylonjs/core';
+import { Scene, Vector3, ArcRotateCamera, Camera, WebXRSessionManager, SceneLoader, TransformNode, DeviceSourceManager, DeviceType, DeviceSource, PointerInput, WebXRTrackingState } from '@babylonjs/core';
+import '@babylonjs/loaders';
 import Slider from '@react-native-community/slider';
 
 const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
@@ -19,7 +20,7 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
   const engine = useEngine();
   const [toggleView, setToggleView] = useState(false);
   const [camera, setCamera] = useState<Camera>();
-  const [box, setBox] = useState<Mesh>();
+  const [rootNode, setRootNode] = useState<TransformNode>();
   const [scene, setScene] = useState<Scene>();
   const [xrSession, setXrSession] = useState<WebXRSessionManager>();
   const [scale, setScale] = useState<number>(defaultScale);
@@ -35,26 +36,44 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
       (scene.activeCamera as ArcRotateCamera).beta -= Math.PI / 8;
       setCamera(scene.activeCamera!);
       scene.createDefaultLight(true);
+      const rootNode = new TransformNode("Root Container", scene);
+      setRootNode(rootNode);
 
-      const box = Mesh.CreateBox("box", 0.3, scene);
-      setBox(box);
-      const mat = new PBRMetallicRoughnessMaterial("mat", scene);
-      mat.metallic = 1;
-      mat.roughness = 0.5;
-      mat.baseColor = Color3.Red();
-      box.material = mat;
+      const deviceSourceManager = new DeviceSourceManager(engine);
+      deviceSourceManager.onDeviceConnectedObservable.add(device => {
+        if (device.deviceType === DeviceType.Touch) {
+          const touch: DeviceSource<DeviceType.Touch> = deviceSourceManager.getDeviceSource(device.deviceType, device.deviceSlot)!;
+          touch.onInputChangedObservable.add(touchEvent => {
+            if (touchEvent.inputIndex === PointerInput.Horizontal) {
+              if (touchEvent.currentState && touchEvent.previousState) {
+                rootNode.rotate(Vector3.Down(), (touchEvent.currentState - touchEvent.previousState) * 0.005);
+              }
+            }
+          })
+        }
+      })
+
+      const transformContainer = new TransformNode("Transform Container", scene);
+      transformContainer.parent = rootNode;
+      transformContainer.scaling.scaleInPlace(0.2);
+      transformContainer.position.y -= .2;
 
       scene.beforeRender = function () {
-        box.rotate(Vector3.Up(), 0.005 * scene.getAnimationRatio());
+        transformContainer.rotate(Vector3.Up(), 0.005 * scene.getAnimationRatio());
       };
+
+      SceneLoader.ImportMeshAsync("", "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxAnimated/glTF-Binary/BoxAnimated.glb").then(result => {
+        const mesh = result.meshes[0];
+        mesh.parent = transformContainer;
+      });
     }
   }, [engine]);
 
   useEffect(() => {
-    if (box) {
-      box.scaling = new Vector3(scale, scale, scale);
+    if (rootNode) {
+      rootNode.scaling = new Vector3(scale, scale, scale);
     }
-  }, [box, scale]);
+  }, [rootNode, scale]);
 
   const trackingStateToString = (trackingState: WebXRTrackingState | undefined) : string =>
   {
@@ -82,7 +101,7 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
         setXrSession(undefined);
         setTrackingState(undefined);
       } else {
-        if (box !== undefined && scene !== undefined) {
+        if (rootNode !== undefined && scene !== undefined) {
           const xr = await scene.createDefaultXRExperienceAsync({ disableDefaultUI: true, disableTeleportation: true })
           const session = await xr.baseExperience.enterXRAsync("immersive-ar", "unbounded", xr.renderTarget);
           setXrSession(session);
@@ -95,14 +114,12 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
           // TODO: Figure out why getFrontPosition stopped working
           //box.position = (scene.activeCamera as TargetCamera).getFrontPosition(2);
           const cameraRay = scene.activeCamera!.getForwardRay(1);
-          box.position = cameraRay.origin.add(cameraRay.direction.scale(cameraRay.length));
-          box.rotate(Vector3.Up(), 3.14159);
-
-          //CreateSpheres(scene, 10);
+          rootNode.position = cameraRay.origin.add(cameraRay.direction.scale(cameraRay.length));
+          rootNode.rotate(Vector3.Up(), 3.14159);
         }
       }
     })();
-  }, [box, scene, xrSession]);
+  }, [rootNode, scene, xrSession]);
 
   const onInitialized = useCallback(async(engineViewCallbacks: EngineViewCallbacks) => {
     setEngineViewCallbacks(engineViewCallbacks);

--- a/Apps/Playground/ios/Podfile.lock
+++ b/Apps/Playground/ios/Podfile.lock
@@ -466,7 +466,7 @@ SPEC CHECKSUMS:
   React-jsi: b32a31da32e030f30bbf9a8d3a9c8325df9e793f
   React-jsiexecutor: 7ab9cdcdd18d57652fb041f8a147fe9658d4e00a
   React-jsinspector: 2e28bb487e42dda6c94dbfa0c648d1343767a0fb
-  react-native-babylon: cbcec38c3e3d9fc1aee538508a1f751619bb335b
+  react-native-babylon: 05685525bfa89aae82b2fccd0a56351e954df545
   react-native-slider: b34d943dc60deb96d952ba6b6b249aa8091e86da
   React-RCTActionSheet: 1702a1a85e550b5c36e2e03cb2bd3adea053de95
   React-RCTAnimation: ddda576010a878865a4eab83a78acd92176ef6a1


### PR DESCRIPTION
With this change I'm updating BabylonNative to the latest from master which exposes the tracking states. Along with updating BabylonNative I'm also adding in some improvements to the Playground app. I've updated the Playground app to display a message about what state XR tracking is in. Additionally I am checking in some VSCode settings that add debug targets and make deployment/testing easier within VSCode.

With these changes I performed the following manual tests on Android and iOS for Debug and Release flavors:
1. [x] **Basic rendering** - launch the Playground app and make sure the model loaded and is rendering at 60fps.
1. [x] **Animation** - make sure the loaded model is animating.
1. [x] **Input handling** - swipe across the display and make sure the model rotates around the y-axis.
1. [x] **Display rotation** - rotate the device 90 degrees and make sure the view rotates and renders correctly.
1. [x] **View replacement** - tap the *Toggle EngineView* button twice to replace the render target view.
1. [x] **Engine dispose** - tap the *Toggle EngineScreen* button twice to dispose and re-instantiate the Babylon engine.
1. [x] **Suspend/resume** - switch to a different app and then back to the Playground and make sure it is still rendering correctly.
1. [x] **Dev mode reload** - in the Metro server console window, press the `R` key on the keyboard to reload the JS engine and make sure rendering restarts successfully.
1. [x] **XR mode** - tap the *Start XR* button and make sure XR mode is working.
1. [x] **XR display rotation** - rotate the device 90 degrees and make sure the view rotates and renders correctly.
1. [x] **XR view replacement** - tap the *Toggle EngineView* button twice to replace the render target view.
1. [x] **XR suspend/resume** - switch to a different app and then back to the Playground and make sure it is still rendering correctly.