### PR TITLE
Don't bgfx::shutdown for debug builds since it doesn't work with fast refresh

### DIFF
--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -83,10 +83,16 @@ export function useEngine(): Engine | undefined {
             if (engine) {
                 DisposeEngine(engine);
             }
-            BabylonModule.reset();
+            // Ideally we would always do a reset here as we don't want different behavior between debug and release. Unfortunately, fast refresh has some strange behavior that
+            // makes it quite difficult to get this to work correctly (e.g. it re-runs previous useEffect instances, which means it can try to use Babylon Native in a de-initialized state).
+            // TODO: https://github.com/BabylonJS/BabylonReactNative/issues/125
+            if (!__DEV__) {
+                BabylonModule.reset();
+            }
             setEngine(undefined);
         };
     }, []);
 
+    console.log("ABOUT TO RETURN ENGINE INSTANCE");
     return engine;
 }

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -93,6 +93,5 @@ export function useEngine(): Engine | undefined {
         };
     }, []);
 
-    console.log("ABOUT TO RETURN ENGINE INSTANCE");
     return engine;
 }

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ When making local changes, the following manual test steps should be performed w
 1. **View replacement** - tap the *Toggle EngineView* button twice to replace the render target view.
 1. **Engine dispose** - tap the *Toggle EngineScreen* button twice to dispose and re-instantiate the Babylon engine.
 1. **Suspend/resume** - switch to a different app and then back to the Playground and make sure it is still rendering correctly.
-1. **Dev mode reload** - in the Metro server console window, press the `R` key on the keyboard to reload the JS engine and make sure rendering restarts successfully.
+1. **Fast refresh** (debug only) - save the App.tsx file to trigger a fast refresh.
+1. **Dev mode reload** (debug only) - in the Metro server console window, press the `R` key on the keyboard to reload the JS engine and make sure rendering restarts successfully.
 1. **XR mode** - tap the *Start XR* button and make sure XR mode is working.
 1. **XR display rotation** - rotate the device 90 degrees and make sure the view rotates and renders correctly.
 1. **XR view replacement** - tap the *Toggle EngineView* button twice to replace the render target view.


### PR DESCRIPTION
I spent a few hours trying to get this to work, but there is some really weird behavior with fast refresh that makes this quite hard to fix. Since it is blocking other people, I'm doing a quick fix to just not call bgfx::shutdown for debug builds. We should try for a real fix later, which I'm tracking with https://github.com/BabylonJS/BabylonReactNative/issues/125.