### PR TITLE
Bring in newest BabylonNative & Babylon.js

### DIFF
--- a/Apps/PackageTest/package-lock.json
+++ b/Apps/PackageTest/package-lock.json
@@ -908,16 +908,16 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-sZQigPvMDc0pcgwlKvTF5gsMzGwT8gelQIOyxELrohdFu12pHGhIr61+yVxxq9tpCdzyYD9kS8LM0w2y+5ypkg==",
+      "version": "5.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.6.tgz",
+      "integrity": "sha512-7Tg/MByT6nUHpV5TjVj1xHsmnbrk1hGMk/jKCui6bydR6YaGrkE0yoLAmJXX5ALGXhhKLIDj+qg3QHWVFsi1lA==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/react-native": {
       "version": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-Ni+H1eU+2ln+o4YnRNGVVogDKqYjEjSCfP93hSA3UeM9jrnk0giWZujtmBl8bz6NMczPaW3S3R5God6ZY5EVyg==",
+      "integrity": "sha512-WQ73fJAZ5AeNxQ5T12MYmmLHXieozUjiQIDXmULslsIOnc1FIhGGySubSDbLlqJzD78vbDl0bs4tmK35RZg1bQ==",
       "requires": {
         "base-64": "^0.1.0"
       }

--- a/Apps/PackageTest/package.json
+++ b/Apps/PackageTest/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0",
+    "@babylonjs/core": "^5.0.0-alpha.6",
     "@babylonjs/react-native": "file:../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -864,20 +864,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-sZQigPvMDc0pcgwlKvTF5gsMzGwT8gelQIOyxELrohdFu12pHGhIr61+yVxxq9tpCdzyYD9kS8LM0w2y+5ypkg==",
+      "version": "5.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.6.tgz",
+      "integrity": "sha512-7Tg/MByT6nUHpV5TjVj1xHsmnbrk1hGMk/jKCui6bydR6YaGrkE0yoLAmJXX5ALGXhhKLIDj+qg3QHWVFsi1lA==",
       "requires": {
         "tslib": ">=1.10.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.0.tgz",
-      "integrity": "sha512-feCmp4I+suBNLko3wGFNZpDg1Bqt9NxEuhKZ+epmaIWSqKEQAMhDvdehcq9vETTVKULkzRGZdDrZmEX0weG80g==",
+      "version": "5.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.6.tgz",
+      "integrity": "sha512-mnUkcA2a4Mdo484q7ckw+QxPYM8mfMaZjfSyt4YjwUxXRdOvbQUPyk/ZojrQjXajEFdzpxhqEU5Iu5CZr01w1A==",
       "requires": {
-        "@babylonjs/core": "4.2.0",
-        "babylonjs-gltf2interface": "4.2.0",
+        "@babylonjs/core": "5.0.0-alpha.6",
+        "babylonjs-gltf2interface": "5.0.0-alpha.6",
         "tslib": ">=1.10.0"
       }
     },
@@ -3306,9 +3306,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.0.tgz",
-      "integrity": "sha512-Fn/ThxwZWP9kEAqk+9FX9CAeF4ah/I0/8wzAZR8MQuYqlYpEfM+E/IztJ+4LoOOxQYMWNs5lgj8OXSkX0tqc4g=="
+      "version": "5.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.6.tgz",
+      "integrity": "sha512-rlsNUn+/anLusgeYwgiRmgo2KtTDA8HmaXTbaAesUHp4lSQfmCmWyl1SpTdGgBeBeG2ZVD9mOrSVamBc+L7YyA=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -11542,9 +11542,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tsutils": {
       "version": "3.17.1",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^4.2.0",
-    "@babylonjs/loaders": "^4.2.0",
+    "@babylonjs/core": "^5.0.0-alpha.6",
+    "@babylonjs/loaders": "^5.0.0-alpha.6",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@react-native-community/slider": "^2.0.9",
     "logkitty": "^0.7.1",

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -27,7 +27,7 @@
     "base-64": "^0.1.0"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^4.2.0",
+    "@babylonjs/core": "^5.0.0-alpha.6",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
     "react-native-permissions": "^2.1.4"


### PR DESCRIPTION
Bringing in the newest Babylon.js version, and updating BabylonNative to fix crashes when exiting XR Mode for Babylon.js versions newer than 5.0.0.

After this commit only versions of Babylon.js newer than 5.0.0-alpha.6 are compatible with BabylonReact-Native due to breaking changes between Babylon.js & BabylonNative.