### PR TITLE
Min support for manual rendering (as an implementation detail)

### DIFF
--- a/Modules/@babylonjs/react-native/shared/BabylonNative.h
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.h
@@ -6,9 +6,10 @@ namespace Babylon
 {
     using Dispatcher = std::function<void(std::function<void()>)>;
 
-    void Initialize(facebook::jsi::Runtime& jsiRuntime, Dispatcher jsDispatcher);
+    void Initialize(facebook::jsi::Runtime& jsiRuntime, Dispatcher jsDispatcher, bool autoRender = true);
     void Deinitialize();
     void UpdateView(void* windowPtr, size_t width, size_t height);
+    void RenderView();
     void SetPointerButtonState(uint32_t pointerId, uint32_t buttonId, bool isDown, uint32_t x, uint32_t y);
     void SetPointerPosition(uint32_t pointerId, uint32_t x, uint32_t y);
 }


### PR DESCRIPTION
This change adds the minimum needed to easily support manual rendering in the shared Babylon Native / React Native integration layer. Android and iOS continue to use automatic rendering, but this should let us use the shared code for the React Native for Windows integration (where we need to do manual rendering). Later we should expose something like `BeginRenderingView`/`EndRenderingView` to allow for more efficient render loops, but the RNW integration as is does not use that, so that's an improvement we can make later. We also need to sort out how to do the `ResetView` logic in the manual rendering case, but that already has other issues we need to figure out in the RNW integration. So again, min changes needed to bring the in-progress RNW integration onto the shared code.