### PR TITLE
Fix webxrsessionmanager propagation for custom enterXRAsync call

### DIFF
--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -69,10 +69,10 @@ if (Platform.OS == "windows") {
     WebXRExperienceHelper.prototype.enterXRAsync = async function (...args: any[]): Promise<any> {
         // TODO: https://github.com/BabylonJS/BabylonNative/issues/577
         // Windows HMDs require different rendering behaviors than default xr rendering for mobile devices
-        const sessionManager = await originalEnterXRAsync.apply(this, args);
-        this.scene.clearColor = Color3.Black().toColor4();
-        this.scene.autoClear = true;
-        return new Promise<any>((resolve) => {
+        return new Promise<any>(async (resolve) => {
+            const sessionManager = await originalEnterXRAsync.apply(this, args);
+            this.scene.clearColor = Color3.Black().toColor4();
+            this.scene.autoClear = true;
             resolve(sessionManager);
         });
     }

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -69,9 +69,12 @@ if (Platform.OS == "windows") {
     WebXRExperienceHelper.prototype.enterXRAsync = async function (...args: any[]): Promise<any> {
         // TODO: https://github.com/BabylonJS/BabylonNative/issues/577
         // Windows HMDs require different rendering behaviors than default xr rendering for mobile devices
-        await originalEnterXRAsync.apply(this, args);
+        const sessionManager = await originalEnterXRAsync.apply(this, args);
         this.scene.clearColor = Color3.Black().toColor4();
         this.scene.autoClear = true;
+        return new Promise<any>((resolve) => {
+            resolve(sessionManager);
+        });
     }
 }
 


### PR DESCRIPTION
We are currently failing to propagate the WebXRSessionManager for windows enterXRAsync calls. This change should fix things.