### PR TITLE
Direct Assign IDXGISwapChain1 to the ISwapChainPanelNative in Babylon React Native(reworked)

### DIFF
--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
@@ -263,7 +263,7 @@ namespace winrt::BabylonReactNative::implementation {
             return;
 
         // Clear the back buffer and depth stencil view.
-        float clearColor[4]{ 0.392156899f, 0.584313750f, 0.929411829f, 1.000000000f };
+        float clearColor[4]{ 0.0f, 0.0f, 0.0, 1.0f };
         s_d3dContext->ClearRenderTargetView(_backBufferPtr.Get(), clearColor);
 
         Babylon::RenderView();

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
@@ -263,7 +263,7 @@ namespace winrt::BabylonReactNative::implementation {
             return;
 
         // Clear the back buffer and depth stencil view.
-        float clearColor[4]{ 0.0f, 0.0f, 0.0, 1.0f };
+        float clearColor[4]{ 0.0f, 0.0f, 0.0f, 1.0f };
         s_d3dContext->ClearRenderTargetView(_backBufferPtr.Get(), clearColor);
 
         Babylon::RenderView();

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
@@ -4,438 +4,438 @@
 
 
 namespace winrt::BabylonReactNative::implementation {
-	using namespace winrt::Windows::Foundation;
-	using namespace winrt::Windows::Devices::Input;
-	using namespace winrt::Windows::System::Threading;
-	using namespace winrt::Windows::UI::Core;
-	using namespace winrt::Windows::UI::Input;
-	using namespace winrt::Windows::UI::Xaml;
-	using namespace winrt::Windows::UI::Xaml::Input;
-	using namespace winrt::Windows::UI::Xaml::Media;
-	using namespace winrt::Windows::UI::Xaml::Controls;
-	using namespace winrt::Windows::ApplicationModel;
-	using namespace Concurrency;
+    using namespace winrt::Windows::Foundation;
+    using namespace winrt::Windows::Devices::Input;
+    using namespace winrt::Windows::System::Threading;
+    using namespace winrt::Windows::UI::Core;
+    using namespace winrt::Windows::UI::Input;
+    using namespace winrt::Windows::UI::Xaml;
+    using namespace winrt::Windows::UI::Xaml::Input;
+    using namespace winrt::Windows::UI::Xaml::Media;
+    using namespace winrt::Windows::UI::Xaml::Controls;
+    using namespace winrt::Windows::ApplicationModel;
+    using namespace Concurrency;
 
-	static EngineView* s_engineView{ nullptr };	// Only single view supported
-	static ID3D11Device1* s_d3dDevice{ nullptr };	// It will be released on bgfx.
-	static ::Microsoft::WRL::ComPtr<ID3D11DeviceContext1> s_d3dContext;
-	static Concurrency::critical_section s_criticalSection;
-	
-	EngineView::EngineView() {
-		if (s_engineView) return;
+    static EngineView* s_engineView{ nullptr };	// Only single view supported
+    static ID3D11Device1* s_d3dDevice{ nullptr };	// It will be released on bgfx.
+    static ::Microsoft::WRL::ComPtr<ID3D11DeviceContext1> s_d3dContext;
+    static Concurrency::critical_section s_criticalSection;
+    
+    EngineView::EngineView() {
+        if (s_engineView) return;
 
-		_revokerData.SizeChangedRevoker = SizeChanged(winrt::auto_revoke, { this, &EngineView::OnSizeChanged });
-		_revokerData.SuspendingRevoker = Application::Current().Suspending(winrt::auto_revoke, [weakThis{ get_weak() }](
-			auto const& /*sender*/,
-			auto const& /*args*/)
-		{
-			if (auto trueThis = weakThis.get())
-				trueThis->OnSuspending();
-		});
+        _revokerData.SizeChangedRevoker = SizeChanged(winrt::auto_revoke, { this, &EngineView::OnSizeChanged });
+        _revokerData.SuspendingRevoker = Application::Current().Suspending(winrt::auto_revoke, [weakThis{ get_weak() }](
+            auto const& /*sender*/,
+            auto const& /*args*/)
+        {
+            if (auto trueThis = weakThis.get())
+                trueThis->OnSuspending();
+        });
 
-		_revokerData.ResumingRevoker = Application::Current().Resuming(winrt::auto_revoke, [weakThis{ get_weak() }](
-			auto const& /*sender*/,
-			auto const& /*args*/)
-		{
-			if (auto trueThis = weakThis.get())
-			{
-				if (CoreWindow::GetForCurrentThread().Visible())
-					trueThis->OnResuming();
-			}
-		});
-		
-		auto swapChainPanel = static_cast<SwapChainPanel>(*this);
-		swapChainPanel.CompositionScaleChanged([this, weak_this{ get_weak() }]
-		(SwapChainPanel const& sender, IInspectable const& object)
-		{
-			if (auto trueThis{ weak_this.get() })
-				trueThis->OnCompositionScaleChanged(sender, object);
-		});
+        _revokerData.ResumingRevoker = Application::Current().Resuming(winrt::auto_revoke, [weakThis{ get_weak() }](
+            auto const& /*sender*/,
+            auto const& /*args*/)
+        {
+            if (auto trueThis = weakThis.get())
+            {
+                if (CoreWindow::GetForCurrentThread().Visible())
+                    trueThis->OnResuming();
+            }
+        });
+        
+        auto swapChainPanel = static_cast<SwapChainPanel>(*this);
+        swapChainPanel.CompositionScaleChanged([this, weak_this{ get_weak() }]
+        (SwapChainPanel const& sender, IInspectable const& object)
+        {
+            if (auto trueThis{ weak_this.get() })
+                trueThis->OnCompositionScaleChanged(sender, object);
+        });
 
-		RegisterInput();
-		RegisterRender();
+        RegisterInput();
+        RegisterRender();
 
-		s_engineView = this;
-	}
+        s_engineView = this;
+    }
 
-	EngineView::~EngineView()
-	{
-		if(_inputLoopWorker)
-			_inputLoopWorker.Cancel();
+    EngineView::~EngineView()
+    {
+        if(_inputLoopWorker)
+            _inputLoopWorker.Cancel();
 
-		if(_renderLoopWorker)
-			_renderLoopWorker.Cancel();
-		
-		s_criticalSection.lock();
-		_dxgiOutput = nullptr;
-		_backBufferPtr = nullptr;
-		_swapChain = nullptr;
-		s_criticalSection.unlock();
+        if(_renderLoopWorker)
+            _renderLoopWorker.Cancel();
+        
+        s_criticalSection.lock();
+        _dxgiOutput = nullptr;
+        _backBufferPtr = nullptr;
+        _swapChain = nullptr;
+        s_criticalSection.unlock();
 
-		s_engineView = nullptr;
-	}
+        s_engineView = nullptr;
+    }
 
-	void EngineView::RegisterInput()
-	{
-		WorkItemHandler workItemHandler([this](IAsyncAction const& /* action */) mutable
-		{
-			auto deviceTypes = static_cast<CoreInputDeviceTypes>(
-				static_cast<uint32_t>(Windows::UI::Core::CoreInputDeviceTypes::Mouse) |
-				static_cast<uint32_t>(Windows::UI::Core::CoreInputDeviceTypes::Touch) |
-				static_cast<uint32_t>(Windows::UI::Core::CoreInputDeviceTypes::Pen));
-			auto coreInput = CreateCoreIndependentInputSource(deviceTypes);
+    void EngineView::RegisterInput()
+    {
+        WorkItemHandler workItemHandler([this](IAsyncAction const& /* action */) mutable
+        {
+            auto deviceTypes = static_cast<CoreInputDeviceTypes>(
+                static_cast<uint32_t>(Windows::UI::Core::CoreInputDeviceTypes::Mouse) |
+                static_cast<uint32_t>(Windows::UI::Core::CoreInputDeviceTypes::Touch) |
+                static_cast<uint32_t>(Windows::UI::Core::CoreInputDeviceTypes::Pen));
+            auto coreInput = CreateCoreIndependentInputSource(deviceTypes);
 
-			auto PointerPressedRevoker = coreInput.PointerPressed(winrt::auto_revoke, { this, &EngineView::OnPointerPressed });
-			auto PointerMovedRevoker = coreInput.PointerMoved(winrt::auto_revoke, { this, &EngineView::OnPointerMoved });
-			auto PointerReleasedRevoker = coreInput.PointerReleased(winrt::auto_revoke, { this, &EngineView::OnPointerReleased });
+            auto PointerPressedRevoker = coreInput.PointerPressed(winrt::auto_revoke, { this, &EngineView::OnPointerPressed });
+            auto PointerMovedRevoker = coreInput.PointerMoved(winrt::auto_revoke, { this, &EngineView::OnPointerMoved });
+            auto PointerReleasedRevoker = coreInput.PointerReleased(winrt::auto_revoke, { this, &EngineView::OnPointerReleased });
 
-			coreInput.Dispatcher().ProcessEvents(Windows::UI::Core::CoreProcessEventsOption::ProcessUntilQuit);
-		});
+            coreInput.Dispatcher().ProcessEvents(Windows::UI::Core::CoreProcessEventsOption::ProcessUntilQuit);
+        });
 
-		// TODO: move to std::thread compared to consuming ThreadPool resources once engine lifecycle bugs are addressed and EngineView's destructor can be successfully invoked.
-		_inputLoopWorker = ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::TimeSliced);
-	}
+        // TODO: move to std::thread compared to consuming ThreadPool resources once engine lifecycle bugs are addressed and EngineView's destructor can be successfully invoked.
+        _inputLoopWorker = ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::TimeSliced);
+    }
 
-	void EngineView::RegisterRender()
-	{
-		s_criticalSection.lock();
-		CreateDeviceResources();
-		CreateSizeDependentResources();
-		s_criticalSection.unlock();
-		
-		// Calculate the updated frame and render once per vertical blanking interval
-		WorkItemHandler workItemHandler([this](IAsyncAction const& action) mutable
-		{
-			while (action.Status() == AsyncStatus::Started)
-				OnRendering();
-		});
+    void EngineView::RegisterRender()
+    {
+        s_criticalSection.lock();
+        CreateDeviceResources();
+        CreateSizeDependentResources();
+        s_criticalSection.unlock();
+        
+        // Calculate the updated frame and render once per vertical blanking interval
+        WorkItemHandler workItemHandler([this](IAsyncAction const& action) mutable
+        {
+            while (action.Status() == AsyncStatus::Started)
+                OnRendering();
+        });
 
-		_renderLoopWorker = ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::TimeSliced);
-	}
+        _renderLoopWorker = ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::TimeSliced);
+    }
 
-	void EngineView::OnSizeChanged(IInspectable const& /*sender*/, SizeChangedEventArgs const& args)
-	{
-		critical_section::scoped_lock lock(s_criticalSection);
+    void EngineView::OnSizeChanged(IInspectable const& /*sender*/, SizeChangedEventArgs const& args)
+    {
+        critical_section::scoped_lock lock(s_criticalSection);
 
-		const auto size = args.NewSize();
-		_width = std::max(size.Width, 1.0f);
-		_height = std::max(size.Height, 1.0f);
+        const auto size = args.NewSize();
+        _width = std::max(size.Width, 1.0f);
+        _height = std::max(size.Height, 1.0f);
 
-		CreateSizeDependentResources();
+        CreateSizeDependentResources();
 
-		auto swapChainPanel = static_cast<SwapChainPanel>(*this);
-		auto swapChainPanelNative = swapChainPanel.as<ISwapChainPanelNative>().get();
-		swapChainPanelNative->SetSwapChain(_swapChain.Get());
-	}
+        auto swapChainPanel = static_cast<SwapChainPanel>(*this);
+        auto swapChainPanelNative = swapChainPanel.as<ISwapChainPanelNative>().get();
+        swapChainPanelNative->SetSwapChain(_swapChain.Get());
+    }
 
-	void EngineView::OnPointerPressed(IInspectable const& /*sender*/, PointerEventArgs const& args)
-	{
-		const auto point = args.CurrentPoint();
-		const auto properties = point.Properties();
-		const auto deviceType = point.PointerDevice().PointerDeviceType();
-		const auto position = point.Position();
-		const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
-		const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
+    void EngineView::OnPointerPressed(IInspectable const& /*sender*/, PointerEventArgs const& args)
+    {
+        const auto point = args.CurrentPoint();
+        const auto properties = point.Properties();
+        const auto deviceType = point.PointerDevice().PointerDeviceType();
+        const auto position = point.Position();
+        const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
+        const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
 
-		if (deviceType == PointerDeviceType::Mouse)
-		{
-			if (properties.IsLeftButtonPressed())
-			{
-				_pressedMouseButtons.insert(Babylon::LEFT_MOUSE_BUTTON_ID);
-				Babylon::SetMouseButtonState(Babylon::LEFT_MOUSE_BUTTON_ID, true, x, y);
-			}
+        if (deviceType == PointerDeviceType::Mouse)
+        {
+            if (properties.IsLeftButtonPressed())
+            {
+                _pressedMouseButtons.insert(Babylon::LEFT_MOUSE_BUTTON_ID);
+                Babylon::SetMouseButtonState(Babylon::LEFT_MOUSE_BUTTON_ID, true, x, y);
+            }
 
-			if (properties.IsMiddleButtonPressed())
-			{
-				_pressedMouseButtons.insert(Babylon::MIDDLE_MOUSE_BUTTON_ID);
-				Babylon::SetMouseButtonState(Babylon::MIDDLE_MOUSE_BUTTON_ID, true, x, y);
-			}
+            if (properties.IsMiddleButtonPressed())
+            {
+                _pressedMouseButtons.insert(Babylon::MIDDLE_MOUSE_BUTTON_ID);
+                Babylon::SetMouseButtonState(Babylon::MIDDLE_MOUSE_BUTTON_ID, true, x, y);
+            }
 
-			if (properties.IsRightButtonPressed())
-			{
-				_pressedMouseButtons.insert(Babylon::RIGHT_MOUSE_BUTTON_ID);
-				Babylon::SetMouseButtonState(Babylon::RIGHT_MOUSE_BUTTON_ID, true, x, y);
-			}
-		}
-		else
-		{
-			const auto pointerId = point.PointerId();
-			Babylon::SetTouchButtonState(pointerId, true, x, y);
-		}
-	}
+            if (properties.IsRightButtonPressed())
+            {
+                _pressedMouseButtons.insert(Babylon::RIGHT_MOUSE_BUTTON_ID);
+                Babylon::SetMouseButtonState(Babylon::RIGHT_MOUSE_BUTTON_ID, true, x, y);
+            }
+        }
+        else
+        {
+            const auto pointerId = point.PointerId();
+            Babylon::SetTouchButtonState(pointerId, true, x, y);
+        }
+    }
 
-	void EngineView::OnPointerMoved(IInspectable const& /*sender*/, PointerEventArgs const& args)
-	{
-		const auto point = args.CurrentPoint();
-		const auto deviceType = point.PointerDevice().PointerDeviceType();
-		const auto position = point.Position();
-		const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
-		const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
+    void EngineView::OnPointerMoved(IInspectable const& /*sender*/, PointerEventArgs const& args)
+    {
+        const auto point = args.CurrentPoint();
+        const auto deviceType = point.PointerDevice().PointerDeviceType();
+        const auto position = point.Position();
+        const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
+        const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
 
-		if (deviceType == PointerDeviceType::Mouse)
-		{
-			Babylon::SetMousePosition(x, y);
-		}
-		else
-		{
-			const auto pointerId = point.PointerId();
-			Babylon::SetTouchPosition(pointerId, x, y);
-		}
-	}
+        if (deviceType == PointerDeviceType::Mouse)
+        {
+            Babylon::SetMousePosition(x, y);
+        }
+        else
+        {
+            const auto pointerId = point.PointerId();
+            Babylon::SetTouchPosition(pointerId, x, y);
+        }
+    }
 
-	void EngineView::OnPointerReleased(IInspectable const& /*sender*/, PointerEventArgs const& args)
-	{
-		const auto point = args.CurrentPoint();
-		const auto properties = point.Properties();
-		const auto deviceType = point.PointerDevice().PointerDeviceType();
-		const auto position = point.Position();
-		const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
-		const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
+    void EngineView::OnPointerReleased(IInspectable const& /*sender*/, PointerEventArgs const& args)
+    {
+        const auto point = args.CurrentPoint();
+        const auto properties = point.Properties();
+        const auto deviceType = point.PointerDevice().PointerDeviceType();
+        const auto position = point.Position();
+        const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
+        const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
 
-		if (point.PointerDevice().PointerDeviceType() == PointerDeviceType::Mouse)
-		{
-			if (!properties.IsLeftButtonPressed() &&
-				_pressedMouseButtons.find(Babylon::LEFT_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
-			{
-				_pressedMouseButtons.erase(Babylon::LEFT_MOUSE_BUTTON_ID);
-				Babylon::SetMouseButtonState(Babylon::LEFT_MOUSE_BUTTON_ID, false, x, y);
-			}
+        if (point.PointerDevice().PointerDeviceType() == PointerDeviceType::Mouse)
+        {
+            if (!properties.IsLeftButtonPressed() &&
+                _pressedMouseButtons.find(Babylon::LEFT_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
+            {
+                _pressedMouseButtons.erase(Babylon::LEFT_MOUSE_BUTTON_ID);
+                Babylon::SetMouseButtonState(Babylon::LEFT_MOUSE_BUTTON_ID, false, x, y);
+            }
 
-			if (!properties.IsMiddleButtonPressed() &&
-				_pressedMouseButtons.find(Babylon::MIDDLE_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
-			{
-				_pressedMouseButtons.erase(Babylon::MIDDLE_MOUSE_BUTTON_ID);
-				Babylon::SetMouseButtonState(Babylon::MIDDLE_MOUSE_BUTTON_ID, false, x, y);
-			}
+            if (!properties.IsMiddleButtonPressed() &&
+                _pressedMouseButtons.find(Babylon::MIDDLE_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
+            {
+                _pressedMouseButtons.erase(Babylon::MIDDLE_MOUSE_BUTTON_ID);
+                Babylon::SetMouseButtonState(Babylon::MIDDLE_MOUSE_BUTTON_ID, false, x, y);
+            }
 
-			if (!properties.IsRightButtonPressed() &&
-				_pressedMouseButtons.find(Babylon::RIGHT_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
-			{
-				_pressedMouseButtons.erase(Babylon::RIGHT_MOUSE_BUTTON_ID);
-				Babylon::SetMouseButtonState(Babylon::RIGHT_MOUSE_BUTTON_ID, false, x, y);
-			}
-		}
-		else
-		{
-			const auto pointerId = point.PointerId();
-			Babylon::SetTouchButtonState(pointerId, false, x, y);
-		}
-	}
+            if (!properties.IsRightButtonPressed() &&
+                _pressedMouseButtons.find(Babylon::RIGHT_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
+            {
+                _pressedMouseButtons.erase(Babylon::RIGHT_MOUSE_BUTTON_ID);
+                Babylon::SetMouseButtonState(Babylon::RIGHT_MOUSE_BUTTON_ID, false, x, y);
+            }
+        }
+        else
+        {
+            const auto pointerId = point.PointerId();
+            Babylon::SetTouchButtonState(pointerId, false, x, y);
+        }
+    }
 
-	void EngineView::OnCompositionScaleChanged(SwapChainPanel const& sender, IInspectable const& /*object*/)
-	{
-		if (_compositionScaleX != sender.CompositionScaleX() || _compositionScaleY != sender.CompositionScaleY())
-		{
-			critical_section::scoped_lock lock(s_criticalSection);
+    void EngineView::OnCompositionScaleChanged(SwapChainPanel const& sender, IInspectable const& /*object*/)
+    {
+        if (_compositionScaleX != sender.CompositionScaleX() || _compositionScaleY != sender.CompositionScaleY())
+        {
+            critical_section::scoped_lock lock(s_criticalSection);
 
-			// Store values so they can be accessed from a background thread.
-			_compositionScaleX = sender.CompositionScaleX();
-			_compositionScaleY = sender.CompositionScaleY();
+            // Store values so they can be accessed from a background thread.
+            _compositionScaleX = sender.CompositionScaleX();
+            _compositionScaleY = sender.CompositionScaleY();
 
-			// Recreate size-dependent resources when the composition scale changes.
-			CreateSizeDependentResources();
+            // Recreate size-dependent resources when the composition scale changes.
+            CreateSizeDependentResources();
 
-			auto swapChainPanel = static_cast<SwapChainPanel>(*this);
-			auto swapChainPanelNative = swapChainPanel.as<ISwapChainPanelNative>().get();;
-			swapChainPanelNative->SetSwapChain(_swapChain.Get());
-		}
-	}
+            auto swapChainPanel = static_cast<SwapChainPanel>(*this);
+            auto swapChainPanelNative = swapChainPanel.as<ISwapChainPanelNative>().get();;
+            swapChainPanelNative->SetSwapChain(_swapChain.Get());
+        }
+    }
 
-	void EngineView::OnSuspending()
-	{
-		critical_section::scoped_lock lock(s_criticalSection);
+    void EngineView::OnSuspending()
+    {
+        critical_section::scoped_lock lock(s_criticalSection);
 
-		::Microsoft::WRL::ComPtr<IDXGIDevice3> dxgiDevice;
-		s_d3dDevice->QueryInterface(__uuidof(IDXGIDevice3), &dxgiDevice);
+        ::Microsoft::WRL::ComPtr<IDXGIDevice3> dxgiDevice;
+        s_d3dDevice->QueryInterface(__uuidof(IDXGIDevice3), &dxgiDevice);
 
-		// Hints to the driver that the app is entering an idle state and that its memory can be used temporarily for other apps.
-		dxgiDevice->Trim();
-	}
+        // Hints to the driver that the app is entering an idle state and that its memory can be used temporarily for other apps.
+        dxgiDevice->Trim();
+    }
 
-	void EngineView::OnResuming()
-	{}
+    void EngineView::OnResuming()
+    {}
 
-	void EngineView::OnRendering()
-	{
-		Concurrency::critical_section::scoped_lock lock(s_criticalSection);
+    void EngineView::OnRendering()
+    {
+        Concurrency::critical_section::scoped_lock lock(s_criticalSection);
 
-		if (!_backBufferPtr)
-			return;
+        if (!_backBufferPtr)
+            return;
 
-		// Clear the back buffer and depth stencil view.
-		float clearColor[4]{ 0.392156899f, 0.584313750f, 0.929411829f, 1.000000000f };
-		s_d3dContext->ClearRenderTargetView(_backBufferPtr.Get(), clearColor);
+        // Clear the back buffer and depth stencil view.
+        float clearColor[4]{ 0.392156899f, 0.584313750f, 0.929411829f, 1.000000000f };
+        s_d3dContext->ClearRenderTargetView(_backBufferPtr.Get(), clearColor);
 
-		Babylon::RenderView();
+        Babylon::RenderView();
 
-		// present
-		DXGI_PRESENT_PARAMETERS parameters = { 0 };
-		parameters.DirtyRectsCount = 0;
-		parameters.pDirtyRects = nullptr;
-		parameters.pScrollRect = nullptr;
-		parameters.pScrollOffset = nullptr;
+        // present
+        DXGI_PRESENT_PARAMETERS parameters = { 0 };
+        parameters.DirtyRectsCount = 0;
+        parameters.pDirtyRects = nullptr;
+        parameters.pScrollRect = nullptr;
+        parameters.pScrollOffset = nullptr;
 
-		HRESULT hr = S_OK;
+        HRESULT hr = S_OK;
 
-		hr = _swapChain->Present1(1, 0, &parameters);
+        hr = _swapChain->Present1(1, 0, &parameters);
 
-		if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
-		{
-			OnDeviceLost();
-		}
+        if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
+        {
+            OnDeviceLost();
+        }
 
-		// Halt the thread until the next vblank is reached.
-		// This ensures the app isn't updating and rendering faster than the display can refresh,
-		// which would unnecessarily spend extra CPU and GPU resources.  This helps improve battery life.
-		_dxgiOutput->WaitForVBlank();
-	}
+        // Halt the thread until the next vblank is reached.
+        // This ensures the app isn't updating and rendering faster than the display can refresh,
+        // which would unnecessarily spend extra CPU and GPU resources.  This helps improve battery life.
+        _dxgiOutput->WaitForVBlank();
+    }
 
-	void EngineView::OnDeviceLost()
-	{
-		_swapChain = nullptr;
+    void EngineView::OnDeviceLost()
+    {
+        _swapChain = nullptr;
 
-		// Make sure the rendering state has been released.
-		s_d3dContext->OMSetRenderTargets(0, nullptr, nullptr);
-		s_d3dContext->Flush();
+        // Make sure the rendering state has been released.
+        s_d3dContext->OMSetRenderTargets(0, nullptr, nullptr);
+        s_d3dContext->Flush();
 
-		if(s_d3dDevice)
-		{
-			s_d3dDevice->Release();
-			s_d3dDevice = nullptr;
-		}
-		
-		CreateDeviceResources();
-		CreateSizeDependentResources();
-	}
+        if(s_d3dDevice)
+        {
+            s_d3dDevice->Release();
+            s_d3dDevice = nullptr;
+        }
+        
+        CreateDeviceResources();
+        CreateSizeDependentResources();
+    }
 
-	void EngineView::CreateDeviceResources()
-	{
-		if(s_d3dDevice) return;
-		
-		D3D_FEATURE_LEVEL featureLevels[] =
-		{
-			D3D_FEATURE_LEVEL_11_1,
-			D3D_FEATURE_LEVEL_11_0,
-			D3D_FEATURE_LEVEL_10_1,
-			D3D_FEATURE_LEVEL_10_0,
-			D3D_FEATURE_LEVEL_9_3,
-			D3D_FEATURE_LEVEL_9_2,
-			D3D_FEATURE_LEVEL_9_1
-		};
+    void EngineView::CreateDeviceResources()
+    {
+        if(s_d3dDevice) return;
+        
+        D3D_FEATURE_LEVEL featureLevels[] =
+        {
+            D3D_FEATURE_LEVEL_11_1,
+            D3D_FEATURE_LEVEL_11_0,
+            D3D_FEATURE_LEVEL_10_1,
+            D3D_FEATURE_LEVEL_10_0,
+            D3D_FEATURE_LEVEL_9_3,
+            D3D_FEATURE_LEVEL_9_2,
+            D3D_FEATURE_LEVEL_9_1
+        };
 
-		ID3D11Device* device{ nullptr };
-		::Microsoft::WRL::ComPtr<ID3D11DeviceContext> context;
-		D3D11CreateDevice(
-			nullptr,
-			D3D_DRIVER_TYPE_HARDWARE,
-			0,
-			D3D11_CREATE_DEVICE_BGRA_SUPPORT
+        ID3D11Device* device{ nullptr };
+        ::Microsoft::WRL::ComPtr<ID3D11DeviceContext> context;
+        D3D11CreateDevice(
+            nullptr,
+            D3D_DRIVER_TYPE_HARDWARE,
+            0,
+            D3D11_CREATE_DEVICE_BGRA_SUPPORT
 #if defined(_DEBUG)
-			| D3D11_CREATE_DEVICE_DEBUG
+            | D3D11_CREATE_DEVICE_DEBUG
 #endif
-			,
-			featureLevels,
-			ARRAYSIZE(featureLevels),
-			D3D11_SDK_VERSION,
-			&device,
-			NULL,
-			&context
-		);
+            ,
+            featureLevels,
+            ARRAYSIZE(featureLevels),
+            D3D11_SDK_VERSION,
+            &device,
+            NULL,
+            &context
+        );
 
-		// Get D3D11.1 device
-		if (s_d3dDevice) s_d3dDevice->Release();
-		device->QueryInterface(__uuidof(ID3D11Device1), (void**)&s_d3dDevice);
+        // Get D3D11.1 device
+        if (s_d3dDevice) s_d3dDevice->Release();
+        device->QueryInterface(__uuidof(ID3D11Device1), (void**)&s_d3dDevice);
 
-		// Get D3D11.1 context
-		context.As(&s_d3dContext);
-	}
+        // Get D3D11.1 context
+        context.As(&s_d3dContext);
+    }
 
-	void EngineView::CreateSizeDependentResources()
-	{
-		s_d3dContext->OMSetRenderTargets(0, nullptr, nullptr);
-		s_d3dContext->Flush();
+    void EngineView::CreateSizeDependentResources()
+    {
+        s_d3dContext->OMSetRenderTargets(0, nullptr, nullptr);
+        s_d3dContext->Flush();
 
-		// Set render target size to the rendered size of the panel including the composition scale, 
-		// defaulting to the minimum of 1px if no size was specified.
-		_renderTargetWidth = _width * _compositionScaleX;
-		_renderTargetHeight = _height * _compositionScaleY;
+        // Set render target size to the rendered size of the panel including the composition scale, 
+        // defaulting to the minimum of 1px if no size was specified.
+        _renderTargetWidth = _width * _compositionScaleX;
+        _renderTargetHeight = _height * _compositionScaleY;
 
-		// If the swap chain already exists, then resize it.
-		if (_swapChain)
-		{
-			_backBufferPtr = nullptr;
+        // If the swap chain already exists, then resize it.
+        if (_swapChain)
+        {
+            _backBufferPtr = nullptr;
 
-			HRESULT hr = _swapChain->ResizeBuffers(
-				2,
-				static_cast<UINT>(_renderTargetWidth),
-				static_cast<UINT>(_renderTargetHeight),
-				DXGI_FORMAT_B8G8R8A8_UNORM,
-				0
-			);
+            HRESULT hr = _swapChain->ResizeBuffers(
+                2,
+                static_cast<UINT>(_renderTargetWidth),
+                static_cast<UINT>(_renderTargetHeight),
+                DXGI_FORMAT_B8G8R8A8_UNORM,
+                0
+            );
 
-			if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
-			{
-				// If the device was removed for any reason, a new device and swap chain will need to be created.
-				OnDeviceLost();
-				return;
+            if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
+            {
+                // If the device was removed for any reason, a new device and swap chain will need to be created.
+                OnDeviceLost();
+                return;
 
-			}
-		}
-		else // Otherwise, create a new one
-		{
-			DXGI_SWAP_CHAIN_DESC1 scd{ 0 };
-			scd.Width = static_cast<UINT>(_renderTargetWidth);
-			scd.Height = static_cast<UINT>(_renderTargetHeight);
-			scd.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
-			scd.Stereo = false;
-			scd.SampleDesc.Count = 1;
-			scd.SampleDesc.Quality = 0;
-			scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-			scd.BufferCount = 2;
-			scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-			scd.Flags = 0;
+            }
+        }
+        else // Otherwise, create a new one
+        {
+            DXGI_SWAP_CHAIN_DESC1 scd{ 0 };
+            scd.Width = static_cast<UINT>(_renderTargetWidth);
+            scd.Height = static_cast<UINT>(_renderTargetHeight);
+            scd.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+            scd.Stereo = false;
+            scd.SampleDesc.Count = 1;
+            scd.SampleDesc.Quality = 0;
+            scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+            scd.BufferCount = 2;
+            scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+            scd.Flags = 0;
 
-			// Get underlying DXGI Device from D3D Device.
-			::Microsoft::WRL::ComPtr<IDXGIDevice1> dxgiDevice;
-			s_d3dDevice->QueryInterface(__uuidof(IDXGIDevice1), &dxgiDevice);
-			
-			// Get adapter.
-			::Microsoft::WRL::ComPtr<IDXGIAdapter> dxgiAdapter;
-			dxgiDevice->GetAdapter(&dxgiAdapter);
+            // Get underlying DXGI Device from D3D Device.
+            ::Microsoft::WRL::ComPtr<IDXGIDevice1> dxgiDevice;
+            s_d3dDevice->QueryInterface(__uuidof(IDXGIDevice1), &dxgiDevice);
+            
+            // Get adapter.
+            ::Microsoft::WRL::ComPtr<IDXGIAdapter> dxgiAdapter;
+            dxgiDevice->GetAdapter(&dxgiAdapter);
 
-			dxgiAdapter->EnumOutputs(0, &_dxgiOutput);
+            dxgiAdapter->EnumOutputs(0, &_dxgiOutput);
 
-			// Get factory.
-			::Microsoft::WRL::ComPtr<IDXGIFactory2> dxgiFactory;
-			dxgiAdapter->GetParent(IID_PPV_ARGS(&dxgiFactory));
+            // Get factory.
+            ::Microsoft::WRL::ComPtr<IDXGIFactory2> dxgiFactory;
+            dxgiAdapter->GetParent(IID_PPV_ARGS(&dxgiFactory));
 
-			// Create swap chain.
-			::Microsoft::WRL::ComPtr<IDXGISwapChain1> swapChain;
-			dxgiFactory->CreateSwapChainForComposition(
-				s_d3dDevice,
-				&scd,
-				nullptr,
-				&swapChain
-			);
-			swapChain.As(&_swapChain);
+            // Create swap chain.
+            ::Microsoft::WRL::ComPtr<IDXGISwapChain1> swapChain;
+            dxgiFactory->CreateSwapChainForComposition(
+                s_d3dDevice,
+                &scd,
+                nullptr,
+                &swapChain
+            );
+            swapChain.As(&_swapChain);
 
-			// Ensure that DXGI does not queue more than one frame at a time. This both reduces 
-			// latency and ensures that the application will only render after each VSync, minimizing 
-			// power consumption.
-			dxgiDevice->SetMaximumFrameLatency(1);
-		}
+            // Ensure that DXGI does not queue more than one frame at a time. This both reduces 
+            // latency and ensures that the application will only render after each VSync, minimizing 
+            // power consumption.
+            dxgiDevice->SetMaximumFrameLatency(1);
+        }
 
-		::Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
-		::Microsoft::WRL::ComPtr<ID3D11RenderTargetView> backBufferPtr;
-		_swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&texture);
-		s_d3dDevice->CreateRenderTargetView(texture.Get(), nullptr, &backBufferPtr);
-		backBufferPtr.As(&_backBufferPtr);
+        ::Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+        ::Microsoft::WRL::ComPtr<ID3D11RenderTargetView> backBufferPtr;
+        _swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&texture);
+        s_d3dDevice->CreateRenderTargetView(texture.Get(), nullptr, &backBufferPtr);
+        backBufferPtr.As(&_backBufferPtr);
 
-		// Use windowTypePtr == 2 for xaml swap chain panels
-		auto swapChainPanel = static_cast<SwapChainPanel>(*this);
-		auto windowTypePtr = reinterpret_cast<void*>(2);
-		auto windowPtr = get_abi(swapChainPanel);
+        // Use windowTypePtr == 2 for xaml swap chain panels
+        auto swapChainPanel = static_cast<SwapChainPanel>(*this);
+        auto windowTypePtr = reinterpret_cast<void*>(2);
+        auto windowPtr = get_abi(swapChainPanel);
 
-		Babylon::UpdateView(windowPtr, (size_t)_renderTargetWidth, (size_t)_renderTargetHeight, windowTypePtr, s_d3dDevice, _backBufferPtr.Get());
-	}
+        Babylon::UpdateView(windowPtr, (size_t)_renderTargetWidth, (size_t)_renderTargetHeight, windowTypePtr, s_d3dDevice, _backBufferPtr.Get());
+    }
 }

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
@@ -2,21 +2,77 @@
 #include "EngineView.h"
 #include "EngineView.g.cpp"
 
-using namespace winrt::Windows::Devices::Input;
-using namespace winrt::Windows::Foundation;
-using namespace winrt::Windows::System::Threading;
-using namespace winrt::Windows::UI::Core;
-using namespace winrt::Windows::UI::Input;
-using namespace winrt::Windows::UI::Xaml;
-using namespace winrt::Windows::UI::Xaml::Input;
-using namespace winrt::Windows::UI::Xaml::Media;
-using namespace winrt::Windows::UI::Xaml::Controls;
 
 namespace winrt::BabylonReactNative::implementation {
-    EngineView::EngineView() {
+    using namespace winrt::Windows::Foundation;
+	using namespace winrt::Windows::Devices::Input;
+	using namespace winrt::Windows::System::Threading;
+	using namespace winrt::Windows::UI::Core;
+	using namespace winrt::Windows::UI::Input;
+	using namespace winrt::Windows::UI::Xaml;
+	using namespace winrt::Windows::UI::Xaml::Input;
+	using namespace winrt::Windows::UI::Xaml::Media;
+	using namespace winrt::Windows::UI::Xaml::Controls;
+	using namespace winrt::Windows::ApplicationModel;
+	using namespace Concurrency;
 
-        _revokerData.SizeChangedRevoker = SizeChanged(winrt::auto_revoke, { this, &EngineView::OnSizeChanged });
 
+	EngineView::EngineView() {
+		_revokerData.SizeChangedRevoker = SizeChanged(winrt::auto_revoke, { this, &EngineView::OnSizeChanged });
+		_revokerData.SuspendingRevoker = Application::Current().Suspending(winrt::auto_revoke, [weakThis{ get_weak() }](
+			auto const& /*sender*/,
+			auto const& /*args*/)
+		{
+			if (auto trueThis = weakThis.get())
+				trueThis->OnSuspending();
+		});
+
+		_revokerData.ResumingRevoker = Application::Current().Resuming(winrt::auto_revoke, [weakThis{ get_weak() }](
+			auto const& /*sender*/,
+			auto const& /*args*/)
+		{
+			if (auto trueThis = weakThis.get())
+			{
+				if (CoreWindow::GetForCurrentThread().Visible())
+					trueThis->OnResuming();
+			}
+		});
+
+		auto swapChainPanel = static_cast<SwapChainPanel>(*this);
+		swapChainPanel.CompositionScaleChanged([this, weak_this{ get_weak() }]
+		(SwapChainPanel const& sender, IInspectable const& object)
+		{
+			if (auto trueThis{ weak_this.get() })
+				trueThis->OnCompositionScaleChanged(sender, object);
+		});
+
+		RegisterInput();
+
+		RegisterRender();
+	}
+
+	EngineView::~EngineView()
+	{
+		_criticalSection.lock();
+		_dxgiOutput = nullptr;
+		_backBufferPtr = nullptr;
+		_swapChain = nullptr;
+		_d3dContext = nullptr;
+		//_d3dDevice = nullptr;		// It will be released on bgfx.
+		_criticalSection.unlock();
+
+		_inputLoopWorker.Cancel();
+		_renderLoopWorker.Cancel();
+		
+		_resetView.wait();	// waiting for bgfx to shutdown..
+	}
+
+	void EngineView::Reset()
+	{}
+
+
+	void EngineView::RegisterInput()
+	{
         WorkItemHandler workItemHandler([weakThis{ this->get_weak() }](IAsyncAction const& /* action */)
         {
             if (auto trueThis = weakThis.get())
@@ -37,138 +93,360 @@ namespace winrt::BabylonReactNative::implementation {
 
         // TODO: move to std::thread compared to consuming ThreadPool resources once engine lifecycle bugs are addressed and EngineView's destructor can be successfully invoked.
         _inputLoopWorker = ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::TimeSliced);
-
-        _revokerData.RenderingRevoker = CompositionTarget::Rendering(winrt::auto_revoke, [weakThis{ this->get_weak() }](auto const&, auto const&)
-        {
-            if (auto trueThis = weakThis.get())
-            {
-                trueThis->OnRendering();
-            }
-        });
     }
+    
+	void EngineView::RegisterRender()
+	{
+		_criticalSection.lock();
+		CreateDeviceResources();
+		CreateSizeDependentResources();
+		_criticalSection.unlock();
+		
+		std::promise<void> promise;
+		_resetView = promise.get_future();
 
-    void EngineView::OnSizeChanged(IInspectable const& /*sender*/, SizeChangedEventArgs const& args)
-    {
-        const auto size = args.NewSize();
-        _width = static_cast<size_t>(size.Width);
-        _height = static_cast<size_t>(size.Height);
+		// Calculate the updated frame and render once per vertical blanking interval
+		WorkItemHandler workItemHandler([this, p = std::move(promise)](IAsyncAction const& action) mutable
+		{
+			{
+				critical_section::scoped_lock lock(_criticalSection);
+				Babylon::EnableView();
+			}
 
-        // Use windowTypePtr == 2 for xaml swap chain panels
-        auto windowTypePtr = reinterpret_cast<void*>(2);
-        auto windowPtr = get_abi(static_cast<winrt::Windows::UI::Xaml::Controls::SwapChainPanel>(*this));
-        Babylon::UpdateView(windowPtr, _width, _height, windowTypePtr);
-    }
+			while (action.Status() == AsyncStatus::Started)
+				OnRendering();
 
-    void EngineView::OnPointerPressed(IInspectable const& /*sender*/, PointerEventArgs const& args)
-    {
-        const auto point = args.CurrentPoint();
-        const auto properties = point.Properties();
-        const auto deviceType = point.PointerDevice().PointerDeviceType();
-        const auto position = point.Position();
-        const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
-        const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
-        const auto pointerId = point.PointerId();
+			{
+				critical_section::scoped_lock lock(_criticalSection);
+				Babylon::DisableView();
+				p.set_value();
+			}
+		});
 
-        if (!_inputSource.HasCapture())
-        {
-            _inputSource.SetPointerCapture();
-        }
+		_renderLoopWorker = ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::TimeSliced);
+	}
 
-        _pressedPointers.insert(pointerId);
+	void EngineView::OnSizeChanged(IInspectable const& /*sender*/, SizeChangedEventArgs const& args)
+	{
+		critical_section::scoped_lock lock(_criticalSection);
 
-        if (deviceType == PointerDeviceType::Mouse)
-        {
-            if (properties.IsLeftButtonPressed())
-            {
-                _pressedMouseButtons.insert(Babylon::LEFT_MOUSE_BUTTON_ID);
-                Babylon::SetMouseButtonState(Babylon::LEFT_MOUSE_BUTTON_ID, true, x, y);
-            }
+		const auto size = args.NewSize();
+		_width = std::max(size.Width, 1.0f);
+		_height = std::max(size.Height, 1.0f);
 
-            if (properties.IsMiddleButtonPressed())
-            {
-                _pressedMouseButtons.insert(Babylon::MIDDLE_MOUSE_BUTTON_ID);
-                Babylon::SetMouseButtonState(Babylon::MIDDLE_MOUSE_BUTTON_ID, true, x, y);
-            }
+		CreateSizeDependentResources();
 
-            if (properties.IsRightButtonPressed())
-            {
-                _pressedMouseButtons.insert(Babylon::RIGHT_MOUSE_BUTTON_ID);
-                Babylon::SetMouseButtonState(Babylon::RIGHT_MOUSE_BUTTON_ID, true, x, y);
-            }
-        }
-        else
-        {
-            Babylon::SetTouchButtonState(pointerId, true, x, y);
-        }
-    }
+		auto swapChainPanel = static_cast<SwapChainPanel>(*this);
+		auto swapChainPanelNative = swapChainPanel.as<ISwapChainPanelNative>().get();;
+		swapChainPanelNative->SetSwapChain(_swapChain.Get());
 
-    void EngineView::OnPointerMoved(IInspectable const& /*sender*/, PointerEventArgs const& args)
-    {
-        const auto point = args.CurrentPoint();
-        const auto deviceType = point.PointerDevice().PointerDeviceType();
-        const auto position = point.Position();
-        const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
-        const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
+		// Set render targets to the screen.
+		ID3D11RenderTargetView* const targets[1] = { _backBufferPtr.Get() };
+		_d3dContext->OMSetRenderTargets(1, targets, nullptr);
+	}
 
-        if (deviceType == PointerDeviceType::Mouse)
-        {
-            Babylon::SetMousePosition(x, y);
-        }
-        else
-        {
-            const auto pointerId = point.PointerId();
-            Babylon::SetTouchPosition(pointerId, x, y);
-        }
-    }
+	void EngineView::OnPointerPressed(IInspectable const& /*sender*/, PointerEventArgs const& args)
+	{
+		const auto point = args.CurrentPoint();
+		const auto properties = point.Properties();
+		const auto deviceType = point.PointerDevice().PointerDeviceType();
+		const auto position = point.Position();
+		const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
+		const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
 
-    void EngineView::OnPointerReleased(IInspectable const& /*sender*/, PointerEventArgs const& args)
-    {
-        const auto point = args.CurrentPoint();
-        const auto properties = point.Properties();
-        const auto deviceType = point.PointerDevice().PointerDeviceType();
-        const auto position = point.Position();
-        const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
-        const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
-        const auto pointerId = point.PointerId();
+		if (deviceType == PointerDeviceType::Mouse)
+		{
+			if (properties.IsLeftButtonPressed())
+			{
+				_pressedMouseButtons.insert(Babylon::LEFT_MOUSE_BUTTON_ID);
+				Babylon::SetMouseButtonState(Babylon::LEFT_MOUSE_BUTTON_ID, true, x, y);
+			}
 
-        _pressedPointers.erase(pointerId);
-        if (_pressedPointers.size() == 0 &&
-            _inputSource.HasCapture())
-        {
-            _inputSource.ReleasePointerCapture();
-        }
+			if (properties.IsMiddleButtonPressed())
+			{
+				_pressedMouseButtons.insert(Babylon::MIDDLE_MOUSE_BUTTON_ID);
+				Babylon::SetMouseButtonState(Babylon::MIDDLE_MOUSE_BUTTON_ID, true, x, y);
+			}
 
-        if (point.PointerDevice().PointerDeviceType() == PointerDeviceType::Mouse)
-        {
-            if (!properties.IsLeftButtonPressed() &&
-                _pressedMouseButtons.find(Babylon::LEFT_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
-            {
-                _pressedMouseButtons.erase(Babylon::LEFT_MOUSE_BUTTON_ID);
-                Babylon::SetMouseButtonState(Babylon::LEFT_MOUSE_BUTTON_ID, false, x, y);
-            }
+			if (properties.IsRightButtonPressed())
+			{
+				_pressedMouseButtons.insert(Babylon::RIGHT_MOUSE_BUTTON_ID);
+				Babylon::SetMouseButtonState(Babylon::RIGHT_MOUSE_BUTTON_ID, true, x, y);
+			}
+		}
+		else
+		{
+			const auto pointerId = point.PointerId();
+			Babylon::SetTouchButtonState(pointerId, true, x, y);
+		}
+	}
 
-            if (!properties.IsMiddleButtonPressed() &&
-                _pressedMouseButtons.find(Babylon::MIDDLE_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
-            {
-                _pressedMouseButtons.erase(Babylon::MIDDLE_MOUSE_BUTTON_ID);
-                Babylon::SetMouseButtonState(Babylon::MIDDLE_MOUSE_BUTTON_ID, false, x, y);
-            }
+	void EngineView::OnPointerMoved(IInspectable const& /*sender*/, PointerEventArgs const& args)
+	{
+		const auto point = args.CurrentPoint();
+		const auto deviceType = point.PointerDevice().PointerDeviceType();
+		const auto position = point.Position();
+		const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
+		const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
 
-            if (!properties.IsRightButtonPressed() &&
-                _pressedMouseButtons.find(Babylon::RIGHT_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
-            {
-                _pressedMouseButtons.erase(Babylon::RIGHT_MOUSE_BUTTON_ID);
-                Babylon::SetMouseButtonState(Babylon::RIGHT_MOUSE_BUTTON_ID, false, x, y);
-            }
-        }
-        else
-        {
-            Babylon::SetTouchButtonState(pointerId, false, x, y);
-        }
-    }
+		if (deviceType == PointerDeviceType::Mouse)
+		{
+			Babylon::SetMousePosition(x, y);
+		}
+		else
+		{
+			const auto pointerId = point.PointerId();
+			Babylon::SetTouchPosition(pointerId, x, y);
+		}
+	}
 
-    void EngineView::OnRendering()
-    {
-        Babylon::RenderView();
-    }
+	void EngineView::OnPointerReleased(IInspectable const& /*sender*/, PointerEventArgs const& args)
+	{
+		const auto point = args.CurrentPoint();
+		const auto properties = point.Properties();
+		const auto deviceType = point.PointerDevice().PointerDeviceType();
+		const auto position = point.Position();
+		const uint32_t x = position.X < 0 ? 0 : static_cast<uint32_t>(position.X);
+		const uint32_t y = position.Y < 0 ? 0 : static_cast<uint32_t>(position.Y);
+
+		if (point.PointerDevice().PointerDeviceType() == PointerDeviceType::Mouse)
+		{
+			if (!properties.IsLeftButtonPressed() &&
+				_pressedMouseButtons.find(Babylon::LEFT_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
+			{
+				_pressedMouseButtons.erase(Babylon::LEFT_MOUSE_BUTTON_ID);
+				Babylon::SetMouseButtonState(Babylon::LEFT_MOUSE_BUTTON_ID, false, x, y);
+			}
+
+			if (!properties.IsMiddleButtonPressed() &&
+				_pressedMouseButtons.find(Babylon::MIDDLE_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
+			{
+				_pressedMouseButtons.erase(Babylon::MIDDLE_MOUSE_BUTTON_ID);
+				Babylon::SetMouseButtonState(Babylon::MIDDLE_MOUSE_BUTTON_ID, false, x, y);
+			}
+
+			if (!properties.IsRightButtonPressed() &&
+				_pressedMouseButtons.find(Babylon::RIGHT_MOUSE_BUTTON_ID) != _pressedMouseButtons.end())
+			{
+				_pressedMouseButtons.erase(Babylon::RIGHT_MOUSE_BUTTON_ID);
+				Babylon::SetMouseButtonState(Babylon::RIGHT_MOUSE_BUTTON_ID, false, x, y);
+			}
+		}
+		else
+		{
+			const auto pointerId = point.PointerId();
+			Babylon::SetTouchButtonState(pointerId, false, x, y);
+		}
+	}
+
+	void EngineView::OnCompositionScaleChanged(SwapChainPanel const& sender, IInspectable const& /*object*/)
+	{
+		if (_compositionScaleX != sender.CompositionScaleX() || _compositionScaleY != sender.CompositionScaleY())
+		{
+			critical_section::scoped_lock lock(_criticalSection);
+
+			// Store values so they can be accessed from a background thread.
+			_compositionScaleX = sender.CompositionScaleX();
+			_compositionScaleY = sender.CompositionScaleY();
+
+			// Recreate size-dependent resources when the composition scale changes.
+			CreateSizeDependentResources();
+
+			auto swapChainPanel = static_cast<SwapChainPanel>(*this);
+			auto swapChainPanelNative = swapChainPanel.as<ISwapChainPanelNative>().get();;
+			swapChainPanelNative->SetSwapChain(_swapChain.Get());
+
+			// Set render targets to the screen.
+			ID3D11RenderTargetView* const targets[1] = { _backBufferPtr.Get() };
+			_d3dContext->OMSetRenderTargets(1, targets, nullptr);
+		}
+	}
+
+	void EngineView::OnSuspending()
+	{
+		critical_section::scoped_lock lock(_criticalSection);
+
+		::Microsoft::WRL::ComPtr<IDXGIDevice3> dxgiDevice;
+		_d3dDevice.As(&dxgiDevice);
+
+		// Hints to the driver that the app is entering an idle state and that its memory can be used temporarily for other apps.
+		dxgiDevice->Trim();
+	}
+
+	void EngineView::OnResuming()
+	{}
+	
+	void EngineView::OnRendering()
+	{
+		Concurrency::critical_section::scoped_lock lock(_criticalSection);
+
+		if (!_backBufferPtr)
+			return;
+
+		// Clear the back buffer and depth stencil view.
+		float clearColor[4]{ 0.392156899f, 0.584313750f, 0.929411829f, 1.000000000f };
+		_d3dContext->ClearRenderTargetView(_backBufferPtr.Get(), clearColor);
+
+		Babylon::RenderView();
+
+		// present
+		DXGI_PRESENT_PARAMETERS parameters = { 0 };
+		parameters.DirtyRectsCount = 0;
+		parameters.pDirtyRects = nullptr;
+		parameters.pScrollRect = nullptr;
+		parameters.pScrollOffset = nullptr;
+
+		HRESULT hr = S_OK;
+
+		hr = _swapChain->Present1(1, 0, &parameters);
+
+		if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
+		{
+			OnDeviceLost();
+		}
+
+		// Halt the thread until the next vblank is reached.
+		// This ensures the app isn't updating and rendering faster than the display can refresh,
+		// which would unnecessarily spend extra CPU and GPU resources.  This helps improve battery life.
+		_dxgiOutput->WaitForVBlank();
+	}
+
+	void EngineView::OnDeviceLost()
+	{
+		_swapChain = nullptr;
+
+		// Make sure the rendering state has been released.
+		_d3dContext->OMSetRenderTargets(0, nullptr, nullptr);
+		_d3dContext->Flush();
+
+		CreateDeviceResources();
+		CreateSizeDependentResources();
+	}
+
+	void EngineView::CreateDeviceResources()
+	{
+		D3D_FEATURE_LEVEL featureLevels[] =
+		{
+			D3D_FEATURE_LEVEL_11_1,
+			D3D_FEATURE_LEVEL_11_0,
+			D3D_FEATURE_LEVEL_10_1,
+			D3D_FEATURE_LEVEL_10_0,
+			D3D_FEATURE_LEVEL_9_3,
+			D3D_FEATURE_LEVEL_9_2,
+			D3D_FEATURE_LEVEL_9_1
+		};
+
+		::Microsoft::WRL::ComPtr<ID3D11Device> device;
+		::Microsoft::WRL::ComPtr<ID3D11DeviceContext> context;
+		D3D11CreateDevice(
+			nullptr,
+			D3D_DRIVER_TYPE_HARDWARE,
+			0,
+			D3D11_CREATE_DEVICE_BGRA_SUPPORT
+#if defined(_DEBUG)
+			| D3D11_CREATE_DEVICE_DEBUG
+#endif
+			,
+			featureLevels,
+			ARRAYSIZE(featureLevels),
+			D3D11_SDK_VERSION,
+			&device,
+			NULL,
+			&context
+		);
+
+		// Get D3D11.1 device
+		device.As(&_d3dDevice);
+
+		// Get D3D11.1 context
+		context.As(&_d3dContext);
+	}
+
+	void EngineView::CreateSizeDependentResources()
+	{
+		_d3dContext->OMSetRenderTargets(0, nullptr, nullptr);
+		_d3dContext->Flush();
+
+		// Set render target size to the rendered size of the panel including the composition scale, 
+		// defaulting to the minimum of 1px if no size was specified.
+		_renderTargetWidth = _width * _compositionScaleX;
+		_renderTargetHeight = _height * _compositionScaleY;
+
+		// If the swap chain already exists, then resize it.
+		if (_swapChain)
+		{
+			_backBufferPtr = nullptr;
+
+			HRESULT hr = _swapChain->ResizeBuffers(
+				2,
+				static_cast<UINT>(_renderTargetWidth),
+				static_cast<UINT>(_renderTargetHeight),
+				DXGI_FORMAT_B8G8R8A8_UNORM,
+				0
+			);
+
+			if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET)
+			{
+				// If the device was removed for any reason, a new device and swap chain will need to be created.
+				OnDeviceLost();
+				return;
+
+			}
+		}
+		else // Otherwise, create a new one
+		{
+			DXGI_SWAP_CHAIN_DESC1 scd{ 0 };
+			scd.Width = static_cast<UINT>(_renderTargetWidth);
+			scd.Height = static_cast<UINT>(_renderTargetHeight);
+			scd.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+			scd.Stereo = false;
+			scd.SampleDesc.Count = 1;
+			scd.SampleDesc.Quality = 0;
+			scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+			scd.BufferCount = 2;
+			scd.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+			scd.Flags = 0;
+
+			// Get underlying DXGI Device from D3D Device.
+			::Microsoft::WRL::ComPtr<IDXGIDevice1> dxgiDevice;
+			_d3dDevice.As(&dxgiDevice);
+
+			// Get adapter.
+			::Microsoft::WRL::ComPtr<IDXGIAdapter> dxgiAdapter;
+			dxgiDevice->GetAdapter(&dxgiAdapter);
+
+			dxgiAdapter->EnumOutputs(0, &_dxgiOutput);
+
+			// Get factory.
+			::Microsoft::WRL::ComPtr<IDXGIFactory2> dxgiFactory;
+			dxgiAdapter->GetParent(IID_PPV_ARGS(&dxgiFactory));
+
+			// Create swap chain.
+			::Microsoft::WRL::ComPtr<IDXGISwapChain1> swapChain;
+			dxgiFactory->CreateSwapChainForComposition(
+				_d3dDevice.Get(),
+				&scd,
+				nullptr,
+				&swapChain
+			);
+			swapChain.As(&_swapChain);
+
+			// Ensure that DXGI does not queue more than one frame at a time. This both reduces 
+			// latency and ensures that the application will only render after each VSync, minimizing 
+			// power consumption.
+			dxgiDevice->SetMaximumFrameLatency(1);
+		}
+
+		::Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+		::Microsoft::WRL::ComPtr<ID3D11RenderTargetView> backBufferPtr;
+		_swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (LPVOID*)&texture);
+		_d3dDevice->CreateRenderTargetView(texture.Get(), nullptr, &backBufferPtr);
+		backBufferPtr.As(&_backBufferPtr);
+
+		// Use windowTypePtr == 2 for xaml swap chain panels
+		auto windowTypePtr = reinterpret_cast<void*>(2);
+		auto windowPtr = reinterpret_cast<void*>(0);
+
+		Babylon::UpdateView(windowPtr, (size_t)_renderTargetWidth, (size_t)_renderTargetHeight, windowTypePtr, _d3dDevice.Get(), _backBufferPtr.Get());
+	}
 }

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
@@ -4,7 +4,7 @@
 
 
 namespace winrt::BabylonReactNative::implementation {
-    using namespace winrt::Windows::Foundation;
+	using namespace winrt::Windows::Foundation;
 	using namespace winrt::Windows::Devices::Input;
 	using namespace winrt::Windows::System::Threading;
 	using namespace winrt::Windows::UI::Core;
@@ -106,20 +106,8 @@ namespace winrt::BabylonReactNative::implementation {
 		// Calculate the updated frame and render once per vertical blanking interval
 		WorkItemHandler workItemHandler([this](IAsyncAction const& action) mutable
 		{
-			//{
-			//	critical_section::scoped_lock lock(s_criticalSection);
-			//	Babylon::EnableView();
-			//}
-
 			while (action.Status() == AsyncStatus::Started)
 				OnRendering();
-			
-			// I successfully shut down bgfx when working with live scripting, but after that, 
-			// bgfx related calls are called, causing a crash.Do not shut down bgfx.
-			//{
-			//	critical_section::scoped_lock lock(s_criticalSection);
-			//	Babylon::DisableView();
-			//}
 		});
 
 		_renderLoopWorker = ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::TimeSliced);
@@ -136,7 +124,7 @@ namespace winrt::BabylonReactNative::implementation {
 		CreateSizeDependentResources();
 
 		auto swapChainPanel = static_cast<SwapChainPanel>(*this);
-		auto swapChainPanelNative = swapChainPanel.as<ISwapChainPanelNative>().get();;
+		auto swapChainPanelNative = swapChainPanel.as<ISwapChainPanelNative>().get();
 		swapChainPanelNative->SetSwapChain(_swapChain.Get());
 	}
 

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -1,23 +1,45 @@
 #pragma once
 #include "EngineView.g.h"
 #include <unordered_set>
+#include <concrt.h>
 
 namespace winrt::BabylonReactNative::implementation {
     struct EngineView : EngineViewT<EngineView>
     {
     public:
         EngineView();
+        ~EngineView() noexcept;
+
+        void Reset();
 
     private:
         void OnSizeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::SizeChangedEventArgs const& args);
         void OnPointerPressed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Core::PointerEventArgs const& args);
         void OnPointerMoved(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Core::PointerEventArgs const& args);
         void OnPointerReleased(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Core::PointerEventArgs const& args);
+        void OnCompositionScaleChanged(Windows::UI::Xaml::Controls::SwapChainPanel const& sender, Windows::Foundation::IInspectable const& object);
+        void OnSuspending();
+        void OnResuming();
+        void OnDeviceLost();
         void OnRendering();
         uint32_t GetButtonId(winrt::Windows::Devices::Input::PointerDeviceType deviceType, winrt::Windows::UI::Input::PointerPointProperties properties);
 
-        size_t _width{ 1 };
-        size_t _height{ 1 };
+        void RegisterInput();
+        void RegisterRender();
+
+        void CreateDeviceResources();
+        void CreateSizeDependentResources();
+        
+
+		float _renderTargetHeight;
+		float _renderTargetWidth;
+              
+        float _compositionScaleX{ 1.0f };
+        float _compositionScaleY{ 1.0f };
+              
+        float _height{ 1.0f };
+        float _width{ 1.0f };
+
         winrt::Windows::Foundation::IAsyncAction _inputLoopWorker{};
         std::unordered_set<uint32_t> _pressedMouseButtons{};
         winrt::Windows::UI::Core::CoreIndependentInputSource _inputSource{ nullptr };
@@ -26,12 +48,22 @@ namespace winrt::BabylonReactNative::implementation {
         struct RevokerData
         {
             winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker SizeChangedRevoker{};
+            winrt::Windows::UI::Xaml::IApplication::Suspending_revoker SuspendingRevoker{};
+            winrt::Windows::UI::Xaml::IApplication::Resuming_revoker ResumingRevoker{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerPressed_revoker PointerPressedRevoker{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerMoved_revoker PointerMovedRevoker{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerReleased_revoker PointerReleasedRevoker{};
-            winrt::Windows::UI::Xaml::Media::CompositionTarget::Rendering_revoker RenderingRevoker{};
         };
         RevokerData _revokerData{};
+
+        Concurrency::critical_section _criticalSection;
+		::Microsoft::WRL::ComPtr<ID3D11Device1> _d3dDevice;
+		::Microsoft::WRL::ComPtr<ID3D11DeviceContext1> _d3dContext;
+		::Microsoft::WRL::ComPtr<IDXGISwapChain2>_swapChain;
+		::Microsoft::WRL::ComPtr <ID3D11RenderTargetView> _backBufferPtr;
+        ::Microsoft::WRL::ComPtr<IDXGIOutput> _dxgiOutput;
+        winrt::Windows::Foundation::IAsyncAction _renderLoopWorker{};
+        std::future<void> _resetView;
     };
 }
 

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -42,22 +42,17 @@ namespace winrt::BabylonReactNative::implementation {
 
         winrt::Windows::Foundation::IAsyncAction _inputLoopWorker{};
         std::unordered_set<uint32_t> _pressedMouseButtons{};
-        winrt::Windows::UI::Core::CoreIndependentInputSource _inputSource{ nullptr };
-        std::unordered_set<uint32_t> _pressedPointers{};
 
         struct RevokerData
         {
             winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker SizeChangedRevoker{};
             winrt::Windows::UI::Xaml::IApplication::Suspending_revoker SuspendingRevoker{};
             winrt::Windows::UI::Xaml::IApplication::Resuming_revoker ResumingRevoker{};
-            winrt::Windows::UI::Core::CoreIndependentInputSource::PointerPressed_revoker PointerPressedRevoker{};
-            winrt::Windows::UI::Core::CoreIndependentInputSource::PointerMoved_revoker PointerMovedRevoker{};
-            winrt::Windows::UI::Core::CoreIndependentInputSource::PointerReleased_revoker PointerReleasedRevoker{};
         };
         RevokerData _revokerData{};
 
         Concurrency::critical_section _criticalSection;
-		::Microsoft::WRL::ComPtr<ID3D11Device1> _d3dDevice;
+        ID3D11Device1* _d3dDevice{ nullptr };
 		::Microsoft::WRL::ComPtr<ID3D11DeviceContext1> _d3dContext;
 		::Microsoft::WRL::ComPtr<IDXGISwapChain2>_swapChain;
 		::Microsoft::WRL::ComPtr <ID3D11RenderTargetView> _backBufferPtr;

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -28,9 +28,8 @@ namespace winrt::BabylonReactNative::implementation {
         void CreateDeviceResources();
         void CreateSizeDependentResources();
         
-
-		float _renderTargetHeight;
-		float _renderTargetWidth;
+        float _renderTargetHeight{ 1.0f };
+        float _renderTargetWidth{ 1.0f };
               
         float _compositionScaleX{ 1.0f };
         float _compositionScaleY{ 1.0f };
@@ -49,8 +48,8 @@ namespace winrt::BabylonReactNative::implementation {
         };
         RevokerData _revokerData{};
 
-		::Microsoft::WRL::ComPtr<IDXGISwapChain2>_swapChain;
-		::Microsoft::WRL::ComPtr <ID3D11RenderTargetView> _backBufferPtr;
+        ::Microsoft::WRL::ComPtr<IDXGISwapChain2>_swapChain;
+        ::Microsoft::WRL::ComPtr <ID3D11RenderTargetView> _backBufferPtr;
         ::Microsoft::WRL::ComPtr<IDXGIOutput> _dxgiOutput;
         winrt::Windows::Foundation::IAsyncAction _renderLoopWorker{};
     };

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -10,8 +10,6 @@ namespace winrt::BabylonReactNative::implementation {
         EngineView();
         ~EngineView() noexcept;
 
-        void Reset();
-
     private:
         void OnSizeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Xaml::SizeChangedEventArgs const& args);
         void OnPointerPressed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::UI::Core::PointerEventArgs const& args);
@@ -51,14 +49,10 @@ namespace winrt::BabylonReactNative::implementation {
         };
         RevokerData _revokerData{};
 
-        Concurrency::critical_section _criticalSection;
-        ID3D11Device1* _d3dDevice{ nullptr };
-		::Microsoft::WRL::ComPtr<ID3D11DeviceContext1> _d3dContext;
 		::Microsoft::WRL::ComPtr<IDXGISwapChain2>_swapChain;
 		::Microsoft::WRL::ComPtr <ID3D11RenderTargetView> _backBufferPtr;
         ::Microsoft::WRL::ComPtr<IDXGIOutput> _dxgiOutput;
         winrt::Windows::Foundation::IAsyncAction _renderLoopWorker{};
-        std::future<void> _resetView;
     };
 }
 

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -48,6 +48,7 @@ namespace winrt::BabylonReactNative::implementation {
         };
         RevokerData _revokerData{};
 
+        DXGI_SAMPLE_DESC _sampleDesc{ 1, 0 };
         ::Microsoft::WRL::ComPtr<IDXGISwapChain2>_swapChain;
         ::Microsoft::WRL::ComPtr <ID3D11RenderTargetView> _backBufferPtr;
         ::Microsoft::WRL::ComPtr<IDXGIOutput> _dxgiOutput;

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -50,7 +50,7 @@ namespace winrt::BabylonReactNative::implementation {
 
         DXGI_SAMPLE_DESC _sampleDesc{ 1, 0 };
         ::Microsoft::WRL::ComPtr<IDXGISwapChain2>_swapChain;
-        ::Microsoft::WRL::ComPtr <ID3D11RenderTargetView> _backBufferPtr;
+        ::Microsoft::WRL::ComPtr<ID3D11RenderTargetView> _backBufferPtr;
         ::Microsoft::WRL::ComPtr <ID3D11DepthStencilView> _depthBufferPtr;
         ::Microsoft::WRL::ComPtr<IDXGIOutput> _dxgiOutput;
         winrt::Windows::Foundation::IAsyncAction _renderLoopWorker{};

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -51,6 +51,7 @@ namespace winrt::BabylonReactNative::implementation {
         DXGI_SAMPLE_DESC _sampleDesc{ 1, 0 };
         ::Microsoft::WRL::ComPtr<IDXGISwapChain2>_swapChain;
         ::Microsoft::WRL::ComPtr <ID3D11RenderTargetView> _backBufferPtr;
+        ::Microsoft::WRL::ComPtr <ID3D11DepthStencilView> _depthBufferPtr;
         ::Microsoft::WRL::ComPtr<IDXGIOutput> _dxgiOutput;
         winrt::Windows::Foundation::IAsyncAction _renderLoopWorker{};
     };

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineViewManager.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineViewManager.cpp
@@ -19,6 +19,13 @@ namespace winrt::BabylonReactNative::implementation {
     }
 
     FrameworkElement EngineViewManager::CreateView() noexcept {
+        if (_engineView)
+        {
+            EngineView* view = get_self<EngineView>(_engineView);
+            view->Reset();
+            return _engineView; // Recycle View
+        }
+
         _engineView = make<EngineView>();
         return _engineView;
     }

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineViewManager.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineViewManager.cpp
@@ -19,15 +19,7 @@ namespace winrt::BabylonReactNative::implementation {
     }
 
     FrameworkElement EngineViewManager::CreateView() noexcept {
-        if (_engineView)
-        {
-            EngineView* view = get_self<EngineView>(_engineView);
-            view->Reset();
-            return _engineView; // Recycle View
-        }
-
-        _engineView = make<EngineView>();
-        return _engineView;
+        return make<EngineView>();
     }
 
     // IViewManagerWithReactContext

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineViewManager.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineViewManager.h
@@ -37,7 +37,6 @@ namespace winrt::BabylonReactNative::implementation {
 
     private:
         winrt::Microsoft::ReactNative::IReactContext _reactContext{ nullptr };
-        winrt::BabylonReactNative::EngineView _engineView{ nullptr };
     };
 
 } // namespace winrt::BabylonReactNative::implementation

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/pch.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/pch.h
@@ -26,8 +26,6 @@
 #include <d2d1_2.h>
 #include <windows.ui.xaml.media.dxinterop.h>
 
-#include <future>
-
 // BabylonNative
 #ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 #define NODE_ADDON_API_DISABLE_NODE_SPECIFIC

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/pch.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/pch.h
@@ -21,6 +21,13 @@
 
 #include <winrt/Microsoft.ReactNative.h>
 
+#include <wrl/client.h>
+#include <d3d11_2.h>
+#include <d2d1_2.h>
+#include <windows.ui.xaml.media.dxinterop.h>
+
+#include <future>
+
 // BabylonNative
 #ifndef NODE_ADDON_API_DISABLE_NODE_SPECIFIC
 #define NODE_ADDON_API_DISABLE_NODE_SPECIFIC

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -84,7 +84,7 @@ namespace Babylon
             }
         }
 
-        void UpdateView(void* windowPtr, void* windowTypePtr, void* contextPtr, void* backBufferPtr, size_t width, size_t height)
+        void UpdateView(void* windowPtr, void* windowTypePtr, void* contextPtr, void* backBufferPtr, void* depthBufferPtr, size_t width, size_t height)
         {
             // TODO: We shouldn't have to dispatch to the JS thread for CreateGraphics/UpdateWindow/UpdateSize, but not doing so results in a crash.
             //       I don't understand the issue yet, but for now just retain the pre-refactor logic. We'll need to resolve this to enable manual
@@ -97,11 +97,11 @@ namespace Babylon
             auto renderDispatcher = m_autoRender ? m_jsDispatcher : g_inlineDispatcher;
             auto jsDispatcher = m_autoRender ? g_inlineDispatcher : m_jsDispatcher;
 
-            renderDispatcher([this, windowPtr, width, height, windowTypePtr, contextPtr, backBufferPtr, jsDispatcher{ std::move(jsDispatcher) }]()
+            renderDispatcher([this, windowPtr, width, height, windowTypePtr, contextPtr, backBufferPtr, depthBufferPtr, jsDispatcher{ std::move(jsDispatcher) }]()
             {
                 if (!m_graphics)
                 {
-                    m_graphics = Graphics::CreateGraphics(windowPtr, windowTypePtr, contextPtr, backBufferPtr, width, height);
+                    m_graphics = Graphics::CreateGraphics(windowPtr, windowTypePtr, contextPtr, backBufferPtr, depthBufferPtr, width, height);
                     jsDispatcher([this]()
                     {
                         m_graphics->AddToJavaScript(m_env);
@@ -111,7 +111,7 @@ namespace Babylon
                 }
                 else
                 {
-                    m_graphics->UpdateWindow(windowPtr, windowTypePtr, contextPtr, backBufferPtr);
+                    m_graphics->UpdateWindow(windowPtr, windowTypePtr, contextPtr, backBufferPtr, depthBufferPtr);
                     m_graphics->UpdateSize(width, height);
                 }
             });
@@ -257,11 +257,11 @@ namespace Babylon
         }
     }
 
-    void UpdateView(void* windowPtr, size_t width, size_t height, void* windowTypePtr, void* contextPtr, void* backBufferPtr)
+    void UpdateView(void* windowPtr, size_t width, size_t height, void* windowTypePtr, void* contextPtr, void* backBufferPtr, void* depthBufferPtr)
     {
         if (auto nativeModule{ g_nativeModule.lock() })
         {
-            nativeModule->UpdateView(windowPtr, windowTypePtr, contextPtr, backBufferPtr, width, height);
+            nativeModule->UpdateView(windowPtr, windowTypePtr, contextPtr, backBufferPtr, depthBufferPtr, width, height);
         }
         else
         {

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -111,7 +111,6 @@ namespace Babylon
                 {
                     m_graphics->UpdateWindow(windowPtr, windowTypePtr);
                     m_graphics->UpdateSize(width, height);
-                    m_graphics->EnableRendering();
                 }
             });
         }
@@ -123,7 +122,8 @@ namespace Babylon
                 throw std::runtime_error{ "RenderView can only be called when automatic rendering is disabled." };
             }
 
-            m_graphics->RenderCurrentFrame();
+            if(m_graphics)
+				m_graphics->RenderCurrentFrame();
         }
 
         void ResetView()
@@ -143,6 +143,22 @@ namespace Babylon
             });
         }
 
+        void EnableView()
+        {
+            if (m_graphics)
+            {
+                m_graphics->EnableRendering();
+            }
+        }
+		
+		void DisableView()
+        {            
+			if (m_graphics)
+			{
+				m_graphics->DisableRendering();
+			}
+        }
+		
         void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
         {
             if (isDown)
@@ -279,6 +295,30 @@ namespace Babylon
         }
     }
 
+	void EnableView()
+	{
+		if (auto nativeModule{ g_nativeModule.lock() })
+		{
+			nativeModule->EnableView();
+		}
+		else
+		{
+			throw std::runtime_error{ "EnableView must not be called before Initialize." };
+		}
+	}
+
+	void DisableView()
+	{
+		if (auto nativeModule{ g_nativeModule.lock() })
+		{
+			nativeModule->DisableView();
+		}
+		else
+		{
+			throw std::runtime_error{ "DisableView must not be called before Initialize." };
+		}
+	}
+	
     void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
     {
         if (auto nativeModule{ g_nativeModule.lock() })

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -279,7 +279,6 @@ namespace Babylon
             throw std::runtime_error{ "RenderView must not be called before Initialize." };
         }
     }
-	
     void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
     {
         if (auto nativeModule{ g_nativeModule.lock() })

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -144,66 +144,7 @@ namespace Babylon
                 }
             });
         }
-       
-        struct JSGuard
-        {
-            JSGuard(Dispatcher& dispatcher)
-            {
-                std::promise<void> promise;
-                std::future<void> future = promise.get_future();
-                std::future<void> blocking = get().get_future();
-                dispatcher([&]() mutable
-                {
-                    promise.set_value();
-                    blocking.wait();
-				});
-                future.wait();
-            }
-
-            ~JSGuard()
-            {
-                get().set_value();
-            }
-
-            static std::promise<void>& get()
-            {
-                static std::promise<void> promise;
-                return promise;
-            }
-        };
-
-        void EnableView()
-        {
-            if (!m_graphics)
-                return;
-            
-            if (m_autoRender)
-            {
-                m_graphics->EnableRendering();
-            }
-            else
-            {
-                JSGuard guard(m_jsDispatcher);
-                m_graphics->EnableRendering();
-            }
-        }
-		
-        void DisableView()
-        {            
-            if (!m_graphics)
-                return;
-
-            if (m_autoRender)
-            {
-                m_graphics->EnableRendering();
-            }
-            else
-            {
-                JSGuard guard(m_jsDispatcher);
-                m_graphics->DisableRendering();
-            }
-        }
-		
+       			
         void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
         {
             if (isDown)
@@ -337,30 +278,6 @@ namespace Babylon
         else
         {
             throw std::runtime_error{ "RenderView must not be called before Initialize." };
-        }
-    }
-
-    void EnableView()
-    {
-        if (auto nativeModule{ g_nativeModule.lock() })
-        {
-            nativeModule->EnableView();
-        }
-        else
-        {
-            throw std::runtime_error{ "EnableView must not be called before Initialize." };
-        }
-    }
-
-    void DisableView()
-    {
-        if (auto nativeModule{ g_nativeModule.lock() })
-        {
-            nativeModule->DisableView();
-        }
-        else
-        {
-            throw std::runtime_error{ "DisableView must not be called before Initialize." };
         }
     }
 	

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -144,7 +144,6 @@ namespace Babylon
                 }
             });
         }
-       			
         void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
         {
             if (isDown)

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -125,7 +125,7 @@ namespace Babylon
             }
 
             if(m_graphics)
-				m_graphics->RenderCurrentFrame();
+                m_graphics->RenderCurrentFrame();
         }
 
         void ResetView()
@@ -145,32 +145,32 @@ namespace Babylon
             });
         }
        
-		struct JSGuard
-		{
-			JSGuard(Dispatcher& dispatcher)
-			{
+        struct JSGuard
+        {
+            JSGuard(Dispatcher& dispatcher)
+            {
                 std::promise<void> promise;
-				std::future<void> future = promise.get_future();
+                std::future<void> future = promise.get_future();
                 std::future<void> blocking = get().get_future();
                 dispatcher([&]() mutable
-				{
+                {
                     promise.set_value();
                     blocking.wait();
 				});
-				future.wait();
-			}
+                future.wait();
+            }
 
-			~JSGuard()
-			{
+            ~JSGuard()
+            {
                 get().set_value();
-			}
+            }
 
             static std::promise<void>& get()
             {
                 static std::promise<void> promise;
                 return promise;
             }
-		};
+        };
 
         void EnableView()
         {
@@ -188,15 +188,15 @@ namespace Babylon
             }
         }
 		
-		void DisableView()
+        void DisableView()
         {            
             if (!m_graphics)
                 return;
 
-			if (m_autoRender)
-			{
-			    m_graphics->EnableRendering();
-			}
+            if (m_autoRender)
+            {
+                m_graphics->EnableRendering();
+            }
             else
             {
                 JSGuard guard(m_jsDispatcher);
@@ -340,29 +340,29 @@ namespace Babylon
         }
     }
 
-	void EnableView()
-	{
-		if (auto nativeModule{ g_nativeModule.lock() })
-		{
-			nativeModule->EnableView();
-		}
-		else
-		{
-			throw std::runtime_error{ "EnableView must not be called before Initialize." };
-		}
-	}
+    void EnableView()
+    {
+        if (auto nativeModule{ g_nativeModule.lock() })
+        {
+            nativeModule->EnableView();
+        }
+        else
+        {
+            throw std::runtime_error{ "EnableView must not be called before Initialize." };
+        }
+    }
 
-	void DisableView()
-	{
-		if (auto nativeModule{ g_nativeModule.lock() })
-		{
-			nativeModule->DisableView();
-		}
-		else
-		{
-			throw std::runtime_error{ "DisableView must not be called before Initialize." };
-		}
-	}
+    void DisableView()
+    {
+        if (auto nativeModule{ g_nativeModule.lock() })
+        {
+            nativeModule->DisableView();
+        }
+        else
+        {
+            throw std::runtime_error{ "DisableView must not be called before Initialize." };
+        }
+    }
 	
     void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
     {

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.h
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.h
@@ -8,7 +8,7 @@ namespace Babylon
 
     void Initialize(facebook::jsi::Runtime& jsiRuntime, Dispatcher jsDispatcher, bool autoRender = true);
     void Deinitialize();
-    void UpdateView(void* windowPtr, size_t width, size_t height, void* windowTypePtr = nullptr, void* contextPtr = nullptr, void* backBufferPtr = nullptr);
+    void UpdateView(void* windowPtr, size_t width, size_t height, void* windowTypePtr = nullptr, void* contextPtr = nullptr, void* backBufferPtr = nullptr, void* depthBufferPtr = nullptr);
     void RenderView();
     void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y);
     void SetMousePosition(uint32_t x, uint32_t y);

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.h
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.h
@@ -10,8 +10,6 @@ namespace Babylon
     void Deinitialize();
     void UpdateView(void* windowPtr, size_t width, size_t height, void* windowTypePtr = nullptr, void* contextPtr = nullptr, void* backBufferPtr = nullptr);
     void RenderView();
-    void EnableView();
-    void DisableView();
     void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y);
     void SetMousePosition(uint32_t x, uint32_t y);
     void SetTouchButtonState(uint32_t pointerId, bool isDown, uint32_t x, uint32_t y);

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.h
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.h
@@ -10,8 +10,8 @@ namespace Babylon
     void Deinitialize();
     void UpdateView(void* windowPtr, size_t width, size_t height, void* windowTypePtr = nullptr, void* contextPtr = nullptr, void* backBufferPtr = nullptr);
     void RenderView();
-	void EnableView();
-	void DisableView();
+    void EnableView();
+    void DisableView();
     void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y);
     void SetMousePosition(uint32_t x, uint32_t y);
     void SetTouchButtonState(uint32_t pointerId, bool isDown, uint32_t x, uint32_t y);

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.h
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.h
@@ -8,8 +8,10 @@ namespace Babylon
 
     void Initialize(facebook::jsi::Runtime& jsiRuntime, Dispatcher jsDispatcher, bool autoRender = true);
     void Deinitialize();
-    void UpdateView(void* windowPtr, size_t width, size_t height, void* windowTypePtr = nullptr);
+    void UpdateView(void* windowPtr, size_t width, size_t height, void* windowTypePtr = nullptr, void* contextPtr = nullptr, void* backBufferPtr = nullptr);
     void RenderView();
+	void EnableView();
+	void DisableView();
     void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y);
     void SetMousePosition(uint32_t x, uint32_t y);
     void SetTouchButtonState(uint32_t pointerId, bool isDown, uint32_t x, uint32_t y);


### PR DESCRIPTION
This pull request solves several problems on the Windows version.

1. Problems not being able to redraw when changing JavaScript.
2. Crash occurs when changing the window size in debug mode.
3. By creating a render-only thread, the React native UI is smooth.
4. Destructor not being called in EngineView.

ReactNative has a pre-pull request.
https://github.com/BabylonJS/BabylonNative/pull/606