### PR TITLE
Fix iOS input handling

### DIFF
--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
@@ -24,7 +24,7 @@ namespace {
 
 @implementation BabylonNativeInterop
 
-static NSMutableArray* activeTouches;
+static NSMutableArray* activeTouches = [NSMutableArray new];
 
 + (void)initialize:(RCTBridge*)bridge {
     auto jsCallInvoker{ bridge.jsCallInvoker };

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.9",
+    "@babylonjs/core": "^5.0.0-alpha.13",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
     "react-native-permissions": "^2.1.4"


### PR DESCRIPTION
In the platform convergence refactor, actually instantiating the touch state array got lost, and Objective C "helps" by not having the concept of dereferencing null and happily continues on and just returns null/false values from functions called on that array. 😡

Also, updating the minimum Babylon.js version required (missed after the "big refactor").