### PR TITLE
Move to most recent master of BabylonNative submodule and improve UWP tooling

### DIFF
--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -328,7 +328,8 @@
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210122.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', $(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210122.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210122.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210122.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
-  <Target Name="BuildBabylonNativeStaticLibs" BeforeTargets="PrepareForBuild">
+  <Target Name="BuildBabylonNativeStaticLibs" BeforeTargets="PrepareForBuild"
+          Condition="'$(BabylonNativeBuildDir)' != ''">
     <Message Text="Building BabylonNative static libs for $(Platform) $(Configuration)"/>
     <Exec Command="$(ProjectDir)\..\scripts\Build.bat -Platform $(Platform) -Configuration $(Configuration)"/>
   </Target>

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -192,7 +192,7 @@
         NativeXr.lib;
         nvtt.lib;
         OGLCompilerd.lib;
-        openxr_loader.lib;
+        openxr_loaderd.lib;
         OSDependentd.lib;
         pvrtc.lib;
         spirv-cross-core.lib;
@@ -327,5 +327,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210122.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', $(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210122.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210122.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210122.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
+  <Target Name="BuildBabylonNativeStaticLibs" BeforeTargets="PrepareForBuild">
+    <Message Text="Building BabylonNative static libs for $(Platform) $(Configuration)"/>
+    <Exec Command="$(ProjectDir)\..\scripts\Build.bat -Platform $(Platform) -Configuration $(Configuration)"/>
   </Target>
 </Project>


### PR DESCRIPTION
This review does the following:

1. Move us to the most recent master commit for BabylonNative
2. Updates the BabylonReactNative.dll vcxproj to look for a newly named openxr_loaderd.lib library
3. Adds an additional target to rebuild the cmake generates solutions for BabylonNative static libs