### PR TITLE
Fix xr button ui to handle fast refresh correctly

### DIFF
--- a/Apps/Playground/App.tsx
+++ b/Apps/Playground/App.tsx
@@ -93,13 +93,15 @@ const EngineScreen: FunctionComponent<ViewProps> = (props: ViewProps) => {
     (async () => {
       if (xrSession) {
         await xrSession.exitXRAsync();
-        setXrSession(undefined);
-        setTrackingState(undefined);
       } else {
         if (rootNode !== undefined && scene !== undefined) {
           const xr = await scene.createDefaultXRExperienceAsync({ disableDefaultUI: true, disableTeleportation: true })
           const session = await xr.baseExperience.enterXRAsync("immersive-ar", "unbounded", xr.renderTarget);
           setXrSession(session);
+          session.onXRSessionEnded.add(() => {
+            setXrSession(undefined);
+            setTrackingState(undefined);
+          })
 
           setTrackingState(xr.baseExperience.camera.trackingState);
           xr.baseExperience.camera.onTrackingStateChanged.add((newTrackingState) => {


### PR DESCRIPTION
Right now the xr session/xr button state is updated based on presses. This does not work correctly during fast refresh scenarios. This change updates the Playground app to observe xr session ended events to update the xr button state.