### PR TITLE
Force CMake to version 3.19.6 to fix Android build breaks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,10 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: actions-setup-cmake
+        uses: jwlawson/actions-setup-cmake@v1.8
+        with:
+          cmake-version: '3.19.6'
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,10 +12,10 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
-      - name: actions-setup-cmake
+      - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
-          cmake-version: '3.19.6'
+          cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.8
+        with:
+          cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -43,7 +43,7 @@ const buildIphoneSimulator = async () => {
 const buildIOS = gulp.series(makeXCodeProj, buildIphoneOS, buildIphoneSimulator);
 
 const buildAndroid = async () => {
-  exec('./gradlew babylonjs_react-native:assembleRelease --stacktrace --info', '../Apps/Playground/android');
+  exec('./gradlew babylonjs_react-native:assembleRelease --stacktrace --info --no-parallel --max-workers=1', '../Apps/Playground/android');
 };
 
 const initializeSubmodulesWindowsAgent = async () => {

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -43,7 +43,7 @@ const buildIphoneSimulator = async () => {
 const buildIOS = gulp.series(makeXCodeProj, buildIphoneOS, buildIphoneSimulator);
 
 const buildAndroid = async () => {
-  exec('./gradlew babylonjs_react-native:assembleRelease', '../Apps/Playground/android');
+  exec('./gradlew babylonjs_react-native:assembleRelease --stacktrace --info', '../Apps/Playground/android');
 };
 
 const initializeSubmodulesWindowsAgent = async () => {

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -43,7 +43,7 @@ const buildIphoneSimulator = async () => {
 const buildIOS = gulp.series(makeXCodeProj, buildIphoneOS, buildIphoneSimulator);
 
 const buildAndroid = async () => {
-  exec('./gradlew babylonjs_react-native:assembleRelease --stacktrace --info --no-parallel --max-workers=1', '../Apps/Playground/android');
+  exec('./gradlew babylonjs_react-native:assembleRelease --stacktrace --info', '../Apps/Playground/android');
 };
 
 const initializeSubmodulesWindowsAgent = async () => {


### PR DESCRIPTION
This is related to https://github.com/BabylonJS/BabylonNative/issues/654 and https://github.com/BabylonJS/BabylonReactNative/issues/190. CMake 3.20.0 (released 10 days ago, and now used on ADO Ubuntu agents and GitHub Mac agents) seems to have a regression that causes our Android builds to fail. To mitigate this, explicitly install CMake 3.19.6 (the last version that seemed to work without errors). Ideally we will figure out how to make things work with CMake 3.20.0, or a new version of CMake is released that fixes the underlying problem, but using an older version will unblock folks for now.