### PR TITLE
Regenerate Podfile.lock (via pod install) for RN 0.64

### DIFF
--- a/Apps/Playground/ios/Podfile.lock
+++ b/Apps/Playground/ios/Podfile.lock
@@ -1,66 +1,64 @@
 PODS:
   - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.5)
-  - CocoaLibEvent (1.0.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.64.0-rc.2)
-  - FBReactNativeSpec (0.64.0-rc.2):
+  - FBLazyVector (0.64.0)
+  - FBReactNativeSpec (0.64.0):
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.0-rc.2)
-    - RCTTypeSafety (= 0.64.0-rc.2)
-    - React-Core (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - Flipper (0.54.0):
-    - Flipper-Folly (~> 2.2)
-    - Flipper-RSocket (~> 1.1)
+    - RCTRequired (= 0.64.0)
+    - RCTTypeSafety (= 0.64.0)
+    - React-Core (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - Flipper (0.75.1):
+    - Flipper-Folly (~> 2.5)
+    - Flipper-RSocket (~> 1.3)
   - Flipper-DoubleConversion (1.1.7)
-  - Flipper-Folly (2.2.0):
+  - Flipper-Folly (2.5.1):
     - boost-for-react-native
-    - CocoaLibEvent (~> 1.0)
     - Flipper-DoubleConversion
     - Flipper-Glog
-    - OpenSSL-Universal (= 1.0.2.19)
+    - libevent (~> 2.1.12)
+    - OpenSSL-Universal (= 1.1.180)
   - Flipper-Glog (0.3.6)
   - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.1.0):
-    - Flipper-Folly (~> 2.2)
-  - FlipperKit (0.54.0):
-    - FlipperKit/Core (= 0.54.0)
-  - FlipperKit/Core (0.54.0):
-    - Flipper (~> 0.54.0)
+  - Flipper-RSocket (1.3.1):
+    - Flipper-Folly (~> 2.5)
+  - FlipperKit (0.75.1):
+    - FlipperKit/Core (= 0.75.1)
+  - FlipperKit/Core (0.75.1):
+    - Flipper (~> 0.75.1)
     - FlipperKit/CppBridge
     - FlipperKit/FBCxxFollyDynamicConvert
     - FlipperKit/FBDefines
     - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.54.0):
-    - Flipper (~> 0.54.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.54.0):
-    - Flipper-Folly (~> 2.2)
-  - FlipperKit/FBDefines (0.54.0)
-  - FlipperKit/FKPortForwarding (0.54.0):
+  - FlipperKit/CppBridge (0.75.1):
+    - Flipper (~> 0.75.1)
+  - FlipperKit/FBCxxFollyDynamicConvert (0.75.1):
+    - Flipper-Folly (~> 2.5)
+  - FlipperKit/FBDefines (0.75.1)
+  - FlipperKit/FKPortForwarding (0.75.1):
     - CocoaAsyncSocket (~> 7.6)
     - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.54.0)
-  - FlipperKit/FlipperKitLayoutPlugin (0.54.0):
+  - FlipperKit/FlipperKitHighlightOverlay (0.75.1)
+  - FlipperKit/FlipperKitLayoutPlugin (0.75.1):
     - FlipperKit/Core
     - FlipperKit/FlipperKitHighlightOverlay
     - FlipperKit/FlipperKitLayoutTextSearchable
     - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.54.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.54.0):
+  - FlipperKit/FlipperKitLayoutTextSearchable (0.75.1)
+  - FlipperKit/FlipperKitNetworkPlugin (0.75.1):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.54.0):
+  - FlipperKit/FlipperKitReactPlugin (0.75.1):
     - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.54.0):
+  - FlipperKit/FlipperKitUserDefaultsPlugin (0.75.1):
     - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.54.0):
+  - FlipperKit/SKIOSNetworkPlugin (0.75.1):
     - FlipperKit/Core
     - FlipperKit/FlipperKitNetworkPlugin
   - glog (0.3.5)
-  - OpenSSL-Universal (1.0.2.19):
-    - OpenSSL-Universal/Static (= 1.0.2.19)
-  - OpenSSL-Universal/Static (1.0.2.19)
+  - libevent (2.1.12)
+  - OpenSSL-Universal (1.1.180)
   - Permission-Camera (3.0.0):
     - RNPermissions
   - RCT-Folly (2020.01.13.00):
@@ -72,258 +70,258 @@ PODS:
     - boost-for-react-native
     - DoubleConversion
     - glog
-  - RCTRequired (0.64.0-rc.2)
-  - RCTTypeSafety (0.64.0-rc.2):
-    - FBLazyVector (= 0.64.0-rc.2)
+  - RCTRequired (0.64.0)
+  - RCTTypeSafety (0.64.0):
+    - FBLazyVector (= 0.64.0)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTRequired (= 0.64.0-rc.2)
-    - React-Core (= 0.64.0-rc.2)
-  - React (0.64.0-rc.2):
-    - React-Core (= 0.64.0-rc.2)
-    - React-Core/DevSupport (= 0.64.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.64.0-rc.2)
-    - React-RCTActionSheet (= 0.64.0-rc.2)
-    - React-RCTAnimation (= 0.64.0-rc.2)
-    - React-RCTBlob (= 0.64.0-rc.2)
-    - React-RCTImage (= 0.64.0-rc.2)
-    - React-RCTLinking (= 0.64.0-rc.2)
-    - React-RCTNetwork (= 0.64.0-rc.2)
-    - React-RCTSettings (= 0.64.0-rc.2)
-    - React-RCTText (= 0.64.0-rc.2)
-    - React-RCTVibration (= 0.64.0-rc.2)
-  - React-callinvoker (0.64.0-rc.2)
-  - React-Core (0.64.0-rc.2):
+    - RCTRequired (= 0.64.0)
+    - React-Core (= 0.64.0)
+  - React (0.64.0):
+    - React-Core (= 0.64.0)
+    - React-Core/DevSupport (= 0.64.0)
+    - React-Core/RCTWebSocket (= 0.64.0)
+    - React-RCTActionSheet (= 0.64.0)
+    - React-RCTAnimation (= 0.64.0)
+    - React-RCTBlob (= 0.64.0)
+    - React-RCTImage (= 0.64.0)
+    - React-RCTLinking (= 0.64.0)
+    - React-RCTNetwork (= 0.64.0)
+    - React-RCTSettings (= 0.64.0)
+    - React-RCTText (= 0.64.0)
+    - React-RCTVibration (= 0.64.0)
+  - React-callinvoker (0.64.0)
+  - React-Core (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.0-rc.2)
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-Core/Default (= 0.64.0)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.64.0-rc.2):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
-    - Yoga
-  - React-Core/Default (0.64.0-rc.2):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
-    - Yoga
-  - React-Core/DevSupport (0.64.0-rc.2):
-    - glog
-    - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.64.0-rc.2)
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-jsinspector (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.64.0-rc.2):
+  - React-Core/CoreModulesHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.64.0-rc.2):
+  - React-Core/Default (0.64.0):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
+    - Yoga
+  - React-Core/DevSupport (0.64.0):
+    - glog
+    - RCT-Folly (= 2020.01.13.00)
+    - React-Core/Default (= 0.64.0)
+    - React-Core/RCTWebSocket (= 0.64.0)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-jsinspector (= 0.64.0)
+    - React-perflogger (= 0.64.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.64.0-rc.2):
+  - React-Core/RCTAnimationHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.64.0-rc.2):
+  - React-Core/RCTBlobHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.64.0-rc.2):
+  - React-Core/RCTImageHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.64.0-rc.2):
+  - React-Core/RCTLinkingHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.64.0-rc.2):
+  - React-Core/RCTNetworkHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.64.0-rc.2):
+  - React-Core/RCTSettingsHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.64.0-rc.2):
+  - React-Core/RCTTextHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
     - React-Core/Default
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.64.0-rc.2):
+  - React-Core/RCTVibrationHeaders (0.64.0):
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/Default (= 0.64.0-rc.2)
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsiexecutor (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-Core/Default
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
     - Yoga
-  - React-CoreModules (0.64.0-rc.2):
-    - FBReactNativeSpec (= 0.64.0-rc.2)
+  - React-Core/RCTWebSocket (0.64.0):
+    - glog
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0-rc.2)
-    - React-Core/CoreModulesHeaders (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-RCTImage (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - React-cxxreact (0.64.0-rc.2):
+    - React-Core/Default (= 0.64.0)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsiexecutor (= 0.64.0)
+    - React-perflogger (= 0.64.0)
+    - Yoga
+  - React-CoreModules (0.64.0):
+    - FBReactNativeSpec (= 0.64.0)
+    - RCT-Folly (= 2020.01.13.00)
+    - RCTTypeSafety (= 0.64.0)
+    - React-Core/CoreModulesHeaders (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-RCTImage (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - React-cxxreact (0.64.0):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-jsinspector (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
-    - React-runtimeexecutor (= 0.64.0-rc.2)
-  - React-jsi (0.64.0-rc.2):
+    - React-callinvoker (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-jsinspector (= 0.64.0)
+    - React-perflogger (= 0.64.0)
+    - React-runtimeexecutor (= 0.64.0)
+  - React-jsi (0.64.0):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-jsi/Default (= 0.64.0-rc.2)
-  - React-jsi/Default (0.64.0-rc.2):
+    - React-jsi/Default (= 0.64.0)
+  - React-jsi/Default (0.64.0):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-  - React-jsiexecutor (0.64.0-rc.2):
+  - React-jsiexecutor (0.64.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
-  - React-jsinspector (0.64.0-rc.2)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-perflogger (= 0.64.0)
+  - React-jsinspector (0.64.0)
   - react-native-babylon (0.0.1):
     - React
-  - react-native-slider (4.0.0-rc.2):
+  - react-native-slider (4.0.0-rc.3):
     - React-Core
-  - React-perflogger (0.64.0-rc.2)
-  - React-RCTActionSheet (0.64.0-rc.2):
-    - React-Core/RCTActionSheetHeaders (= 0.64.0-rc.2)
-  - React-RCTAnimation (0.64.0-rc.2):
-    - FBReactNativeSpec (= 0.64.0-rc.2)
+  - React-perflogger (0.64.0)
+  - React-RCTActionSheet (0.64.0):
+    - React-Core/RCTActionSheetHeaders (= 0.64.0)
+  - React-RCTAnimation (0.64.0):
+    - FBReactNativeSpec (= 0.64.0)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0-rc.2)
-    - React-Core/RCTAnimationHeaders (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - React-RCTBlob (0.64.0-rc.2):
-    - FBReactNativeSpec (= 0.64.0-rc.2)
+    - RCTTypeSafety (= 0.64.0)
+    - React-Core/RCTAnimationHeaders (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - React-RCTBlob (0.64.0):
+    - FBReactNativeSpec (= 0.64.0)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTBlobHeaders (= 0.64.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-RCTNetwork (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - React-RCTImage (0.64.0-rc.2):
-    - FBReactNativeSpec (= 0.64.0-rc.2)
+    - React-Core/RCTBlobHeaders (= 0.64.0)
+    - React-Core/RCTWebSocket (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-RCTNetwork (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - React-RCTImage (0.64.0):
+    - FBReactNativeSpec (= 0.64.0)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0-rc.2)
-    - React-Core/RCTImageHeaders (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-RCTNetwork (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - React-RCTLinking (0.64.0-rc.2):
-    - FBReactNativeSpec (= 0.64.0-rc.2)
-    - React-Core/RCTLinkingHeaders (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - React-RCTNetwork (0.64.0-rc.2):
-    - FBReactNativeSpec (= 0.64.0-rc.2)
+    - RCTTypeSafety (= 0.64.0)
+    - React-Core/RCTImageHeaders (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-RCTNetwork (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - React-RCTLinking (0.64.0):
+    - FBReactNativeSpec (= 0.64.0)
+    - React-Core/RCTLinkingHeaders (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - React-RCTNetwork (0.64.0):
+    - FBReactNativeSpec (= 0.64.0)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0-rc.2)
-    - React-Core/RCTNetworkHeaders (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - React-RCTSettings (0.64.0-rc.2):
-    - FBReactNativeSpec (= 0.64.0-rc.2)
+    - RCTTypeSafety (= 0.64.0)
+    - React-Core/RCTNetworkHeaders (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - React-RCTSettings (0.64.0):
+    - FBReactNativeSpec (= 0.64.0)
     - RCT-Folly (= 2020.01.13.00)
-    - RCTTypeSafety (= 0.64.0-rc.2)
-    - React-Core/RCTSettingsHeaders (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - React-RCTText (0.64.0-rc.2):
-    - React-Core/RCTTextHeaders (= 0.64.0-rc.2)
-  - React-RCTVibration (0.64.0-rc.2):
-    - FBReactNativeSpec (= 0.64.0-rc.2)
+    - RCTTypeSafety (= 0.64.0)
+    - React-Core/RCTSettingsHeaders (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - React-RCTText (0.64.0):
+    - React-Core/RCTTextHeaders (= 0.64.0)
+  - React-RCTVibration (0.64.0):
+    - FBReactNativeSpec (= 0.64.0)
     - RCT-Folly (= 2020.01.13.00)
-    - React-Core/RCTVibrationHeaders (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.64.0-rc.2)
-  - React-runtimeexecutor (0.64.0-rc.2):
-    - React-jsi (= 0.64.0-rc.2)
-  - ReactCommon/turbomodule/core (0.64.0-rc.2):
+    - React-Core/RCTVibrationHeaders (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - ReactCommon/turbomodule/core (= 0.64.0)
+  - React-runtimeexecutor (0.64.0):
+    - React-jsi (= 0.64.0)
+  - ReactCommon/turbomodule/core (0.64.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2020.01.13.00)
-    - React-callinvoker (= 0.64.0-rc.2)
-    - React-Core (= 0.64.0-rc.2)
-    - React-cxxreact (= 0.64.0-rc.2)
-    - React-jsi (= 0.64.0-rc.2)
-    - React-perflogger (= 0.64.0-rc.2)
+    - React-callinvoker (= 0.64.0)
+    - React-Core (= 0.64.0)
+    - React-cxxreact (= 0.64.0)
+    - React-jsi (= 0.64.0)
+    - React-perflogger (= 0.64.0)
   - RNPermissions (3.0.0):
     - React-Core
   - Yoga (1.14.0)
@@ -333,26 +331,26 @@ PODS:
 DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
-  - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
-  - Flipper (~> 0.54.0)
+  - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
+  - Flipper (~> 0.75.1)
   - Flipper-DoubleConversion (= 1.1.7)
-  - Flipper-Folly (~> 2.2)
+  - Flipper-Folly (~> 2.5)
   - Flipper-Glog (= 0.3.6)
   - Flipper-PeerTalk (~> 0.0.4)
-  - Flipper-RSocket (~> 1.1)
-  - FlipperKit (~> 0.54.0)
-  - FlipperKit/Core (~> 0.54.0)
-  - FlipperKit/CppBridge (~> 0.54.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (~> 0.54.0)
-  - FlipperKit/FBDefines (~> 0.54.0)
-  - FlipperKit/FKPortForwarding (~> 0.54.0)
-  - FlipperKit/FlipperKitHighlightOverlay (~> 0.54.0)
-  - FlipperKit/FlipperKitLayoutPlugin (~> 0.54.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (~> 0.54.0)
-  - FlipperKit/FlipperKitNetworkPlugin (~> 0.54.0)
-  - FlipperKit/FlipperKitReactPlugin (~> 0.54.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.54.0)
-  - FlipperKit/SKIOSNetworkPlugin (~> 0.54.0)
+  - Flipper-RSocket (~> 1.3)
+  - FlipperKit (~> 0.75.1)
+  - FlipperKit/Core (~> 0.75.1)
+  - FlipperKit/CppBridge (~> 0.75.1)
+  - FlipperKit/FBCxxFollyDynamicConvert (~> 0.75.1)
+  - FlipperKit/FBDefines (~> 0.75.1)
+  - FlipperKit/FKPortForwarding (~> 0.75.1)
+  - FlipperKit/FlipperKitHighlightOverlay (~> 0.75.1)
+  - FlipperKit/FlipperKitLayoutPlugin (~> 0.75.1)
+  - FlipperKit/FlipperKitLayoutTextSearchable (~> 0.75.1)
+  - FlipperKit/FlipperKitNetworkPlugin (~> 0.75.1)
+  - FlipperKit/FlipperKitReactPlugin (~> 0.75.1)
+  - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.75.1)
+  - FlipperKit/SKIOSNetworkPlugin (~> 0.75.1)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Permission-Camera (from `../node_modules/react-native-permissions/ios/Camera`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -389,7 +387,6 @@ SPEC REPOS:
   trunk:
     - boost-for-react-native
     - CocoaAsyncSocket
-    - CocoaLibEvent
     - Flipper
     - Flipper-DoubleConversion
     - Flipper-Folly
@@ -397,6 +394,7 @@ SPEC REPOS:
     - Flipper-PeerTalk
     - Flipper-RSocket
     - FlipperKit
+    - libevent
     - OpenSSL-Universal
     - YogaKit
 
@@ -406,7 +404,7 @@ EXTERNAL SOURCES:
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   FBReactNativeSpec:
-    :path: "../node_modules/react-native/Libraries/FBReactNativeSpec"
+    :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   Permission-Camera:
@@ -469,49 +467,49 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: cde416483dac037923206447da6e1454df403714
-  FBLazyVector: b21700af840f633338ac968a36da9aa3a8268887
-  FBReactNativeSpec: f46aced58ed5eb28d4e0e1fda8953b0fabf99068
-  Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
+  FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
+  FBReactNativeSpec: 16b48647aef6a06d1944ffe203223eddff37b0aa
+  Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
-  Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
+  Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
-  FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
+  Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
+  FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
+  libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
+  OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   Permission-Camera: 358081c7b8210849958af181ce9ddeb11932aa82
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
-  RCTRequired: fa44b153ba69cb9dd6cec5084b86719e3be7c90b
-  RCTTypeSafety: 8e815e0f29ed65901e4e2963a90063a4cfcb7d5e
-  React: b15c115b6d33432ab036d4ba7e37b45401499256
-  React-callinvoker: e8eb22bce9032ae162e090bd4496f8d7f843a58a
-  React-Core: 0730699f3d551241ceb811c516b9a1695474ba24
-  React-CoreModules: 573f7fea888ed0432c2eca21a0678700aa3b0f4a
-  React-cxxreact: f04960e50d616fa00dcbe4a00549330bf5090f90
-  React-jsi: 506ee28d88192ca5a722d935376a198c84d9ce4c
-  React-jsiexecutor: 6460524de9e4c96a983e52aa63c44603560af362
-  React-jsinspector: 611432ab882ba76844598bc5e16bdf10e63816a8
-  react-native-babylon: 0f2e35e718e867ed39ef0f4f4de8b5e52302a74f
-  react-native-slider: ffa2f979ffa81e29876f8adad58e8ed83de9d438
-  React-perflogger: bca76d7279e5fb9863de266154026e0d5bd79f86
-  React-RCTActionSheet: 685edbce7c0ea41c467539899a8c2eea4dc8fde9
-  React-RCTAnimation: 325fad5fe7d13823c46753bb76db756737a4df8c
-  React-RCTBlob: 0fa85fe13af364ec36a9587cee1b3fbd796e7d45
-  React-RCTImage: 0f2d5452f3d407f4a12c952d2d3e1348df720bae
-  React-RCTLinking: fe9fb3e830b42842b67b2a0e283a531f5932436c
-  React-RCTNetwork: 75dc7a11b91eeb21bc76523192c7ff6bbedd4b07
-  React-RCTSettings: 2e7a3d2a26e1619d0e8160ba2771b97fbfd1e208
-  React-RCTText: 15b5da436786b77032c9c97f3dcc4d7bfd793c4b
-  React-RCTVibration: 93c2f243bebd392a4fad35f55e3d79dd096a4f92
-  React-runtimeexecutor: 15492c8842d72b14765986b5bfbaaf5468210f13
-  ReactCommon: c8ae344df0376e043f2899a5badb60709d24821e
+  RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
+  RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
+  React: 98eac01574128a790f0bbbafe2d1a8607291ac24
+  React-callinvoker: def3f7fae16192df68d9b69fd4bbb59092ee36bc
+  React-Core: 70a52aa5dbe9b83befae82038451a7df9fd54c5a
+  React-CoreModules: 052edef46117862e2570eb3a0f06d81c61d2c4b8
+  React-cxxreact: c1dc71b30653cfb4770efdafcbdc0ad6d388baab
+  React-jsi: 74341196d9547cbcbcfa4b3bbbf03af56431d5a1
+  React-jsiexecutor: 06a9c77b56902ae7ffcdd7a4905f664adc5d237b
+  React-jsinspector: 0ae35a37b20d5e031eb020a69cc5afdbd6406301
+  react-native-babylon: 67b39de846123d0846b28ce0e38671c7e3c4e04f
+  react-native-slider: e45c8376012e5ace012e5eef62e9c85c68e50a0f
+  React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
+  React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
+  React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f
+  React-RCTBlob: 283b8e5025e7f954176bc48164f846909002f3ed
+  React-RCTImage: 5088a484faac78f2d877e1b79125d3bb1ea94a16
+  React-RCTLinking: 5e8fbb3e9a8bc2e4e3eb15b1eb8bda5fcac27b8c
+  React-RCTNetwork: 38ec277217b1e841d5e6a1fa78da65b9212ccb28
+  React-RCTSettings: 242d6e692108c3de4f3bb74b7586a8799e9ab070
+  React-RCTText: 8746736ac8eb5a4a74719aa695b7a236a93a83d2
+  React-RCTVibration: 0fd6b21751a33cb72fce1a4a33ab9678416d307a
+  React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
+  ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
   RNPermissions: 350964d19150b183796a88180fb7ec62a1e41422
-  Yoga: 17d4f4db4e2efbaa7c3bc316ce4f762d02c4023d
+  Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: afc31dedf4017d462f46d5ea262633292114bf0b
+PODFILE CHECKSUM: 6b5a8feda09816950d2c787ef58c08eea3c22840
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1


### PR DESCRIPTION
Podfile.lock should have been updated with the upgrade to RN 0.64; doing it now. 😁

Note that RN 0.64 requires cocoapods version 1.10.1 or newer, which is why I updated it. This will require folks with older versions of cocoapods to update, otherwise they will get an error on `pod install`.