### PR TITLE
Move BabylonNative UWP build out of submodule

### DIFF
--- a/Apps/PackageTest/0.63.1/package-lock.json
+++ b/Apps/PackageTest/0.63.1/package-lock.json
@@ -917,7 +917,7 @@
     },
     "@babylonjs/react-native": {
       "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-i9G1c7VflKGzbZClWa1PiJNcxOJxW4SMKBp4e6fhVhPrEs9sjNyg+IEbi0/xJvvrk5hFg3VmNB8xXFUU4Jmg5w==",
+      "integrity": "sha512-pjoRv6RG7vuCyBS1HVbfeuf99aLTMGrvelJNmaseGWsW13xfEL+svFlGxA6XiVHGbdfKuDCizWJfyIvtfzJ/xQ==",
       "requires": {
         "base-64": "^0.1.0",
         "semver": "^7.3.2"

--- a/Apps/PackageTest/0.64.0/package-lock.json
+++ b/Apps/PackageTest/0.64.0/package-lock.json
@@ -1190,7 +1190,7 @@
     },
     "@babylonjs/react-native": {
       "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-ZT8sk3eROxnAgGsl5NWjqaIN4wVa42P+AVhLivUcCwfk+PPNHbuGwG9kqU0Q/TFzpFgiRAFsePBTv04Sknu/Sg==",
+      "integrity": "sha512-pjoRv6RG7vuCyBS1HVbfeuf99aLTMGrvelJNmaseGWsW13xfEL+svFlGxA6XiVHGbdfKuDCizWJfyIvtfzJ/xQ==",
       "requires": {
         "base-64": "^0.1.0",
         "semver": "^7.3.2"
@@ -1208,7 +1208,7 @@
     },
     "@babylonjs/react-native-windows": {
       "version": "file:../../../Package/Assembled-Windows/babylonjs-react-native-windows-0.0.1.tgz",
-      "integrity": "sha512-tMqfOJ42Y2KycUjD2tIdMshqpZcUjSFGnszEc9ZlRWBPKSYdGW3ykHj2YKRyxpy156IqQA3IuAkFFw0wO6R0qg=="
+      "integrity": "sha512-I0JZNDjKnGm5z2SMPsfmKb5LNV3whhLhB2uS53TsWEZ6cWwEc5rW9XzEKYDYd4Lg7NrlOxeBhpd/QxPsXsZciw=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -29,11 +29,11 @@
   </PropertyGroup>
   <PropertyGroup Label="BabylonReactNativeProps">
     <BabylonReactNativeDir Condition="'$(BabylonReactNativeDir)' == '' And Exists('$(ProjectDir)\..\..\..\react-native')">$(ProjectDir)\..\..\..\react-native</BabylonReactNativeDir>
-    <BabylonNativeDir Condition="Exists('$(BabylonReactNativeDir)\submodules\BabylonNative')">$(BabylonReactNativeDir)\submodules\BabylonNative</BabylonNativeDir>
-    <BabylonNativeBuildDir Condition="'$(Platform)'=='x64' And '$(BabylonNativeDir)' != ''">$(BabylonNativeDir)\Build_uwp_x64\</BabylonNativeBuildDir>
-    <BabylonNativeBuildDir Condition="'$(Platform)'=='Win32' And '$(BabylonNativeDir)' != ''">$(BabylonNativeDir)\Build_uwp_x86\</BabylonNativeBuildDir>
-    <BabylonNativeBuildDir Condition="'$(Platform)'=='ARM' And '$(BabylonNativeDir)' != ''">$(BabylonNativeDir)\Build_uwp_arm\</BabylonNativeBuildDir>
-    <BabylonNativeBuildDir Condition="'$(Platform)'=='ARM64' And '$(BabylonNativeDir)' != ''">$(BabylonNativeDir)\Build_uwp_arm64\</BabylonNativeBuildDir>
+    <BabylonNativeDir Condition="Exists('$(BabylonReactNativeDir)\submodules\BabylonNative')">$(BabylonReactNativeDir)\Build</BabylonNativeDir>
+    <BabylonNativeBuildDir Condition="'$(Platform)'=='x64' And '$(BabylonNativeDir)' != ''">$(BabylonNativeDir)\uwp_x64\</BabylonNativeBuildDir>
+    <BabylonNativeBuildDir Condition="'$(Platform)'=='Win32' And '$(BabylonNativeDir)' != ''">$(BabylonNativeDir)\uwp_x86\</BabylonNativeBuildDir>
+    <BabylonNativeBuildDir Condition="'$(Platform)'=='ARM' And '$(BabylonNativeDir)' != ''">$(BabylonNativeDir)\uwp_arm\</BabylonNativeBuildDir>
+    <BabylonNativeBuildDir Condition="'$(Platform)'=='ARM64' And '$(BabylonNativeDir)' != ''">$(BabylonNativeDir)\uwp_arm64\</BabylonNativeBuildDir>
     <BabylonNativeLibsDir Condition="'$(Platform)'=='x64' And '$(BabylonNativeDir)' == ''">..\libs\x64\</BabylonNativeLibsDir>
     <BabylonNativeLibsDir Condition="'$(Platform)'=='Win32' And '$(BabylonNativeDir)' == ''">..\libs\x86\</BabylonNativeLibsDir>
     <BabylonNativeLibsDir Condition="'$(Platform)'=='ARM' And '$(BabylonNativeDir)' == ''">..\libs\arm\</BabylonNativeLibsDir>

--- a/Modules/@babylonjs/react-native-windows/windows/scripts/Build.ps1
+++ b/Modules/@babylonjs/react-native-windows/windows/scripts/Build.ps1
@@ -14,18 +14,18 @@ if ((!$Platform -And $Configuration) -Or
 }
 
 if (!$Platform -And !$Configuration) {
-    Compile-Solution -Platform "Win32" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_x86\ReactNativeBabylon.sln"
-    Compile-Solution -Platform "Win32" -Configuration "Release" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_x86\ReactNativeBabylon.sln"
-    Compile-Solution -Platform "x64" -Configuration "Release" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_x64\ReactNativeBabylon.sln"
-    Compile-Solution -Platform "x64" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_x64\ReactNativeBabylon.sln"
-    Compile-Solution -Platform "ARM" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_arm\ReactNativeBabylon.sln"
-    Compile-Solution -Platform "ARM" -Configuration "Release" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_arm\ReactNativeBabylon.sln"
-    Compile-Solution -Platform "ARM64" -Configuration "Release" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_arm64\ReactNativeBabylon.sln"
-    Compile-Solution -Platform "ARM64" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_arm64\ReactNativeBabylon.sln"
+    Compile-Solution -Platform "Win32" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_x86\ReactNativeBabylon.sln"
+    Compile-Solution -Platform "Win32" -Configuration "Release" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_x86\ReactNativeBabylon.sln"
+    Compile-Solution -Platform "x64" -Configuration "Release" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_x64\ReactNativeBabylon.sln"
+    Compile-Solution -Platform "x64" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_x64\ReactNativeBabylon.sln"
+    Compile-Solution -Platform "ARM" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_arm\ReactNativeBabylon.sln"
+    Compile-Solution -Platform "ARM" -Configuration "Release" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_arm\ReactNativeBabylon.sln"
+    Compile-Solution -Platform "ARM64" -Configuration "Release" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_arm64\ReactNativeBabylon.sln"
+    Compile-Solution -Platform "ARM64" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_arm64\ReactNativeBabylon.sln"
 }
 else {
-    $DirectoryMap = @{ "Win32"="Build_uwp_x86"; "x64" = "Build_uwp_x64"; "ARM"="Build_uwp_arm"; "ARM64"="Build_uwp_arm64"; };
+    $DirectoryMap = @{ "Win32"="uwp_x86"; "x64" = "uwp_x64"; "ARM"="uwp_arm"; "ARM64"="uwp_arm64"; };
     $Directory = $DirectoryMap[$Platform];
-    Compile-Solution -Platform $Platform -Configuration $Configuration -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\$Directory\ReactNativeBabylon.sln"
+    Compile-Solution -Platform $Platform -Configuration $Configuration -Solution "$PSScriptRoot\..\..\..\react-native\Build\$Directory\ReactNativeBabylon.sln"
 }
 

--- a/Modules/@babylonjs/react-native-windows/windows/scripts/PRBuild.ps1
+++ b/Modules/@babylonjs/react-native-windows/windows/scripts/PRBuild.ps1
@@ -1,5 +1,5 @@
 Import-Module $PSScriptRoot\Utils.psm1
 
-Compile-Solution -Platform "x64" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\submodules\BabylonNative\Build_uwp_x64\ReactNativeBabylon.sln"
+Compile-Solution -Platform "x64" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\react-native\Build\uwp_x64\ReactNativeBabylon.sln"
 nuget restore "$PSScriptRoot\..\..\..\..\..\Apps\Playground\windows\Playground.sln"
 Compile-Solution -Platform "x64" -Configuration "Debug" -Solution "$PSScriptRoot\..\..\..\..\..\Apps\Playground\windows\Playground.sln"

--- a/Modules/@babylonjs/react-native-windows/windows/scripts/Utils.psm1
+++ b/Modules/@babylonjs/react-native-windows/windows/scripts/Utils.psm1
@@ -36,7 +36,7 @@ function Restore-CMakeProject {
 
     Write-Host "Running cmake for $Platform dependencies" -ForegroundColor Cyan
 
-    $BuildDir = "$PSScriptRoot\..\..\submodules\BabylonNative\Build_uwp_$Platform"
+    $BuildDir = "$PSScriptRoot\..\..\Build\uwp_$Platform"
     if (!(Test-Path $BuildDir)) {
       mkdir $BuildDir
     }

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -53,23 +53,23 @@ const initializeSubmodulesWindowsAgent = async () => {
 }
 
 const makeUWPProjectx86 = async () => {
-  shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_x86');
-  exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI -A Win32 ./../../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_x86');
+  shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/Build/uwp_x86');
+  exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI -A Win32 ./../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/Build/uwp_x86');
 }
 
 const makeUWPProjectx64 = async () => {
-  shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_x64');
-  exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI ./../../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_x64');
+  shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/Build/uwp_x64');
+  exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI ./../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/Build/uwp_x64');
 }
 
 const makeUWPProjectARM = async () => {
-  shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_arm');
-  exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI -A arm ./../../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_arm');
+  shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/Build/uwp_arm');
+  exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI -A arm ./../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/Build/uwp_arm');
 }
 
 const makeUWPProjectARM64 = async () => {
-  shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_arm64');
-  exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI -A arm64 ./../../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_arm64');
+  shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/Build/uwp_arm64');
+  exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI -A arm64 ./../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/Build/uwp_arm64');
 }
 
 const makeUWPProject = gulp.parallel(
@@ -252,49 +252,49 @@ const copyCommonFilesUWP = () => {
 }
 
 const copyx86DebugUWPFiles = () => {
-  return gulp.src('../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_x86/**/Debug/**/*.{lib,pri}')
+  return gulp.src('../Modules/@babylonjs/react-native/Build/uwp_x86/**/Debug/**/*.{lib,pri}')
     .pipe(rename({ dirname: '' }))
     .pipe(gulp.dest('Assembled-Windows/windows/libs/x86/Debug'));
 }
 
 const copyx86ReleaseUWPFiles = () => {
-  return gulp.src('../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_x86/**/Release/**/*.{lib,pri}')
+  return gulp.src('../Modules/@babylonjs/react-native/Build/uwp_x86/**/Release/**/*.{lib,pri}')
     .pipe(rename({ dirname: '' }))
     .pipe(gulp.dest('Assembled-Windows/windows/libs/x86/Release'));
 }
 
 const copyx64DebugUWPFiles = () => {
-  return gulp.src('../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_x64/**/Debug/**/*.{lib,pri}')
+  return gulp.src('../Modules/@babylonjs/react-native/Build/uwp_x64/**/Debug/**/*.{lib,pri}')
     .pipe(rename({ dirname: '' }))
     .pipe(gulp.dest('Assembled-Windows/windows/libs/x64/Debug'));
 }
 
 const copyx64ReleaseUWPFiles = () => {
-  return gulp.src('../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_x64/**/Release/**/*.{lib,pri}')
+  return gulp.src('../Modules/@babylonjs/react-native/Build/uwp_x64/**/Release/**/*.{lib,pri}')
     .pipe(rename({ dirname: '' }))
     .pipe(gulp.dest('Assembled-Windows/windows/libs/x64/Release'));
 }
 
 const copyARMDebugUWPFiles = () => {
-  return gulp.src('../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_arm/**/Debug/**/*.{lib,pri}')
+  return gulp.src('../Modules/@babylonjs/react-native/Build/uwp_arm/**/Debug/**/*.{lib,pri}')
     .pipe(rename({ dirname: '' }))
     .pipe(gulp.dest('Assembled-Windows/windows/libs/arm/Debug'));
 }
 
 const copyARMReleaseUWPFiles = () => {
-  return gulp.src('../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_arm/**/Release/**/*.{lib,pri}')
+  return gulp.src('../Modules/@babylonjs/react-native/Build/uwp_arm/**/Release/**/*.{lib,pri}')
     .pipe(rename({ dirname: '' }))
     .pipe(gulp.dest('Assembled-Windows/windows/libs/arm/Release'));
 }
 
 const copyARM64DebugUWPFiles = () => {
-  return gulp.src('../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_arm64/**/Debug/**/*.{lib,pri}')
+  return gulp.src('../Modules/@babylonjs/react-native/Build/uwp_arm64/**/Debug/**/*.{lib,pri}')
     .pipe(rename({ dirname: '' }))
     .pipe(gulp.dest('Assembled-Windows/windows/libs/arm64/Debug'));
 }
 
 const copyARM64ReleaseUWPFiles = () => {
-  return gulp.src('../Modules/@babylonjs/react-native/submodules/BabylonNative/Build_uwp_arm64/**/Release/**/*.{lib,pri}')
+  return gulp.src('../Modules/@babylonjs/react-native/Build/uwp_arm64/**/Release/**/*.{lib,pri}')
     .pipe(rename({ dirname: '' }))
     .pipe(gulp.dest('Assembled-Windows/windows/libs/arm64/Release'));
 }


### PR DESCRIPTION
I was running into possible path length issues when making the UWP projects, this shortens the paths and moves the builds into a Build/ folder, which gets ignored by the .gitignore