### PR TITLE
Update BabylonNative submodule

### DIFF
--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -195,9 +195,9 @@
         openxr_loaderd.lib;
         OSDependentd.lib;
         pvrtc.lib;
-        spirv-cross-core.lib;
-        spirv-cross-glsl.lib;
-        spirv-cross-hlsl.lib;
+        spirv-cross-cored.lib;
+        spirv-cross-glsld.lib;
+        spirv-cross-hlsld.lib;
         SPIRVd.lib;
         squish.lib;
         UrlLib.lib;

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.13.2)
 project(ReactNativeBabylon)
-
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/CMakeLists.txt)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.13.2)
 project(ReactNativeBabylon)
+
+add_definitions(-DENABLE_PCH=OFF)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/CMakeLists.txt)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.13.2)
 project(ReactNativeBabylon)
 
-add_definitions(-DENABLE_PCH=OFF)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/CMakeLists.txt)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -63,18 +63,18 @@ namespace Babylon
 
         void UpdateView(void* windowPtr, size_t width, size_t height)
         {
-            GraphicsConfiguration graphicsConfig{};
-            graphicsConfig.WindowPtr = reinterpret_cast<WindowType>(windowPtr);
-            graphicsConfig.Width = width;
-            graphicsConfig.Height = height;
+            WindowConfiguration windowConfig{};
+            windowConfig.WindowPtr = reinterpret_cast<WindowType>(windowPtr);
+            windowConfig.Width = width;
+            windowConfig.Height = height;
 
             if (!g_graphics)
             {
-                g_graphics = Graphics::CreateGraphics(graphicsConfig);
+                g_graphics = Graphics::CreateGraphics(windowConfig);
             }
             else
             {
-                g_graphics->UpdateWindow(graphicsConfig);
+                g_graphics->UpdateWindow(windowConfig);
                 g_graphics->UpdateSize(width, height);
             }
 

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -29,7 +29,7 @@ const clean = async () => {
 
 const makeXCodeProj = async () => {
   shelljs.mkdir('-p', 'iOS/Build');
-  exec('cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=../../../Apps/Playground/node_modules/@babylonjs/react-native/submodules/BabylonNative/Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DENABLE_BITCODE=1 -DDEPLOYMENT_TARGET=12 -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF ..', 'iOS/Build');
+  exec('cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=../../../Apps/Playground/node_modules/@babylonjs/react-native/submodules/BabylonNative/Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DENABLE_BITCODE=1 -DDEPLOYMENT_TARGET=12 -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF -DENABLE_PCH=OFF ..', 'iOS/Build');
 };
 
 const buildIphoneOS = async () => {

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ iOS can only be built on a Mac. Additionally, `CMake` must manually be run to ge
 
 ```
 pushd Apps/Playground/node_modules/@babylonjs/react-native/ios
-cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=../submodules/BabylonNative/Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DENABLE_BITCODE=1 -DDEPLOYMENT_TARGET=12 -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF .
+cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=../submodules/BabylonNative/Dependencies/ios-cmake/ios.toolchain.cmake -DPLATFORM=OS64COMBINED -DENABLE_ARC=0 -DENABLE_BITCODE=1 -DDEPLOYMENT_TARGET=12 -DENABLE_GLSLANG_BINARIES=OFF -DSPIRV_CROSS_CLI=OFF -DENABLE_PCH=OFF .
 popd
 
 cd Apps/Playground


### PR DESCRIPTION
- Update BabylonNative subrepo
- Changed Graphics contract
- Disabled PCH for glslang `-DENABLE_PCH=OFF` . This was already done some time ago for Android. 
- Updated documentation for PCH/iOS
- spirv libraries names Debug suffix for BabylonReactNative Windows