### PR TITLE
Add github action to run when BabylonNative is updated

### DIFF
--- a/.github/workflows/bn_master_commit.yml
+++ b/.github/workflows/bn_master_commit.yml
@@ -75,7 +75,7 @@ jobs:
         run: npm install
         working-directory: ./Package
       - name: Git (Update to BabylonNative master)
-        run: npx gulp initializeSubmodulesMostRecentBabylonNative
+        run: npx gulp initializeSubmodulesMostRecentBabylonNativeWindowsAgent
         working-directory: ./Package
       - name: Gulp Setup Project ${{ matrix.platform }} (Windows)
         run: npx gulp makeUWPProject${{ matrix.platform }}

--- a/.github/workflows/bn_master_commit.yml
+++ b/.github/workflows/bn_master_commit.yml
@@ -1,0 +1,99 @@
+name: BabylonNative master branch update
+
+on:
+  repository_dispatch:
+    types: [babylonnative-master-update]
+
+jobs:
+  details:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.ref }}
+      - run: echo ${{ github.event.client_payload.sha }}
+      
+  build-android:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.3.3
+        with:
+          submodules: 'recursive'
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.8
+        with:
+          cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
+      - name: Setup Ninja
+        run: brew install ninja
+      - name: NPM Install (Playground)
+        run: npm install
+        working-directory: ./Apps/Playground
+      - name: NPM Install (Binary Package)
+        run: npm install
+        working-directory: ./Package
+      - name: Git (Update to BabylonNative master)
+        run: npx gulp initializeSubmodulesMostRecentBabylonNative
+        working-directory: ./Package
+      - name: Gulp (Android)
+        run: npx gulp buildAndroid
+        working-directory: ./Package
+
+  build-iOS:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.3.3
+        with:
+          submodules: 'recursive'
+      - name: NPM Install (Playground)
+        run: npm install
+        working-directory: ./Apps/Playground
+      - name: NPM Install (Binary Package)
+        run: npm install
+        working-directory: ./Package
+      - name: Git (Update to BabylonNative master)
+        run: npx gulp initializeSubmodulesMostRecentBabylonNative
+        working-directory: ./Package
+      - name: Gulp (iOS)
+        run: npx gulp buildIOS
+        working-directory: ./Package
+
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform: [x86, x64, ARM, ARM64]
+        config: [Debug, Release]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.3.3
+        with:
+          submodules: 'true'
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+      - name: NPM Install (Playground)
+        run: npm install
+        working-directory: ./Apps/Playground
+      - name: NPM Install (Binary Package)
+        run: npm install
+        working-directory: ./Package
+      - name: Git (Update to BabylonNative master)
+        run: npx gulp initializeSubmodulesMostRecentBabylonNative
+        working-directory: ./Package
+      - name: Gulp Setup Project ${{ matrix.platform }} (Windows)
+        run: npx gulp makeUWPProject${{ matrix.platform }}
+        working-directory: ./Package
+      - name: Gulp Build ${{ matrix.platform }} ${{ matrix.config }} (Windows)
+        run: npx gulp buildUWP${{ matrix.platform }}${{ matrix.config }}
+        working-directory: ./Package
+      - name: Gulp NuGet Restore Playground
+        run: npx gulp nugetRestoreUWPPlayground
+        working-directory: ./Package
+      - name: Gulp Build ${{ matrix.platform }} ${{ matrix.config }} Playground (Windows)
+        run: npx gulp buildUWPPlayground${{ matrix.platform }}${{ matrix.config }}
+        working-directory: ./Package

--- a/.github/workflows/bn_master_commit.yml
+++ b/.github/workflows/bn_master_commit.yml
@@ -5,14 +5,6 @@ on:
     types: [babylonnative-master-update]
 
 jobs:
-  details:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.client_payload.ref }}
-      - run: echo ${{ github.event.client_payload.sha }}
-      
   build-android:
     runs-on: macos-latest
     steps:

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -52,6 +52,12 @@ const initializeSubmodulesWindowsAgent = async () => {
   exec('git -c submodule."Dependencies/xr/Dependencies/arcore-android-sdk".update=none submodule update --init --recursive "./../Modules/@babylonjs/react-native/submodules/BabylonNative');
 }
 
+const initializeSubmodulesMostRecentBabylonNative = async () => {
+  exec('git submodule init ./../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git pull origin master', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git submodule update --init --recursive *', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+}
+
 const makeUWPProjectx86 = async () => {
   shelljs.mkdir('-p', './../Modules/@babylonjs/react-native/Build/uwp_x86');
   exec('cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -D NAPI_JAVASCRIPT_ENGINE=JSI -A Win32 ./../../../react-native-windows/windows', './../Modules/@babylonjs/react-native/Build/uwp_x86');
@@ -498,5 +504,7 @@ exports.buildUWPPublish = buildUWPPublish;
 exports.copyUWPFiles = copyUWPFiles;
 exports.packUWP = packUWP;
 exports.packUWPNoBuild = packUWPNoBuild;
+
+exports.initializeSubmodulesMostRecentBabylonNative = initializeSubmodulesMostRecentBabylonNative;
 
 exports.default = build;

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -58,6 +58,18 @@ const initializeSubmodulesMostRecentBabylonNative = async () => {
   exec('git checkout origin/master', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
   exec('git rev-parse HEAD', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
   exec('git submodule update --init --recursive *', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git rev-parse HEAD', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+}
+
+const initializeSubmodulesMostRecentBabylonNativeWindowsAgent = async () => {
+  exec('git submodule init ./../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git fetch origin master', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git checkout origin/master', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git add ./../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git commit -m "update to master"');
+  exec('git rev-parse HEAD', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git -c submodule."Dependencies/xr/Dependencies/arcore-android-sdk".update=none submodule update --init --recursive "./../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git rev-parse HEAD', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
 }
 
 const makeUWPProjectx86 = async () => {
@@ -508,5 +520,6 @@ exports.packUWP = packUWP;
 exports.packUWPNoBuild = packUWPNoBuild;
 
 exports.initializeSubmodulesMostRecentBabylonNative = initializeSubmodulesMostRecentBabylonNative;
+exports.initializeSubmodulesMostRecentBabylonNativeWindowsAgent = initializeSubmodulesMostRecentBabylonNativeWindowsAgent;
 
 exports.default = build;

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -54,7 +54,9 @@ const initializeSubmodulesWindowsAgent = async () => {
 
 const initializeSubmodulesMostRecentBabylonNative = async () => {
   exec('git submodule init ./../Modules/@babylonjs/react-native/submodules/BabylonNative');
-  exec('git pull origin master', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git fetch origin master', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git checkout origin/master', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+  exec('git rev-parse HEAD', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
   exec('git submodule update --init --recursive *', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
 }
 


### PR DESCRIPTION
This github action will check out the most recent commit in babylonnative and attempt a build. It should allow us to monitor incoming changes.

once this change has been proven out, we can have additional ci to look into merging the babylonnative master branch on successful build.

Note: we will need the following change for these jobs to start running: https://github.com/BabylonJS/BabylonNative/pull/714