### PR TITLE
Decreasing screenshot jpeg quality to 80%

### DIFF
--- a/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/EngineView.java
+++ b/Modules/@babylonjs/react-native/android/src/main/java/com/babylonreactnative/EngineView.java
@@ -125,7 +125,7 @@ public final class EngineView extends FrameLayout implements SurfaceHolder.Callb
             String encoded = "";
             if (copyResult == PixelCopy.SUCCESS) {
                 ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
-                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteArrayStream);
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 80, byteArrayStream);
                 byte[] byteArray = byteArrayStream.toByteArray();
                 bitmap.recycle();
                 encoded = Base64.encodeToString(byteArray, Base64.DEFAULT);

--- a/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
+++ b/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
@@ -80,7 +80,7 @@
         // Grab the image from the graphics context, and convert into a base64 encoded JPG.
         UIImage* capturedImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
-        NSData* jpgData = UIImageJPEGRepresentation(capturedImage, 1.0f);
+        NSData* jpgData = UIImageJPEGRepresentation(capturedImage, .8f);
         NSString* encodedData = [jpgData base64EncodedStringWithOptions:0];
         
         // Fire the onSnapshotDataReturned event if hooked up.


### PR DESCRIPTION
Decreasing the screenshot jpeg quality for both iOS and Android to 80% to optimize the returned image file size.  

- 80% jpeg quality is considered to be the recommended quality and the lowest quality setting that has minimal to no visible difference to 100%. 
- Tested on both Android and iOS 
- Attached two screenshots taken on Android at 80% and 100%. 100% = 105kb, 80% = 40kb

100% Quality
![100OnDevice](https://user-images.githubusercontent.com/60023064/118183349-d90c9180-b3ee-11eb-9be4-44e22dbbbd3a.jpg)

80% Quality
![80OnDevice](https://user-images.githubusercontent.com/60023064/118183322-d14ced00-b3ee-11eb-9fba-926b338e67f1.jpg)
