### PR TITLE
Update Babylon.JS and BabylonNative to support new Vertex Buffer Types

### DIFF
--- a/Apps/PackageTest/0.63.1/package-lock.json
+++ b/Apps/PackageTest/0.63.1/package-lock.json
@@ -908,16 +908,23 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.9.tgz",
-      "integrity": "sha512-1xoYaq0CfJiKGLlsEAazK0oPR0DOzw1sl2JY3paeVi+Rh6muoHoKKgWAv+Pobq6rnQM1fQpj8uKbijtEeTLciw==",
+      "version": "5.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.22.tgz",
+      "integrity": "sha512-/yjSVcaT9ZfjIZ0QiaB33FntNy/iregK7nEfFwS5LIHEcb7ATPR18wc2OFtXpA2CX0wCsIRpMaTdF5K7aS+4zA==",
       "requires": {
-        "tslib": ">=1.10.0"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@babylonjs/react-native": {
       "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-pjoRv6RG7vuCyBS1HVbfeuf99aLTMGrvelJNmaseGWsW13xfEL+svFlGxA6XiVHGbdfKuDCizWJfyIvtfzJ/xQ==",
+      "integrity": "sha512-V0y1dXVt2x8G1oe37WO+FzMLRxE8ltXM4atL/lWG7OKEobSKTvU0FPZaFZtkk1rqITnD/p3sLGMvrqncWKrd9Q==",
       "requires": {
         "base-64": "^0.1.0",
         "semver": "^7.3.2"
@@ -9401,7 +9408,8 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.17.1",

--- a/Apps/PackageTest/0.63.1/package.json
+++ b/Apps/PackageTest/0.63.1/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.9",
+    "@babylonjs/core": "^5.0.0-alpha.22",
     "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/PackageTest/0.64.0/package-lock.json
+++ b/Apps/PackageTest/0.64.0/package-lock.json
@@ -1190,7 +1190,7 @@
     },
     "@babylonjs/react-native": {
       "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-pjoRv6RG7vuCyBS1HVbfeuf99aLTMGrvelJNmaseGWsW13xfEL+svFlGxA6XiVHGbdfKuDCizWJfyIvtfzJ/xQ==",
+      "integrity": "sha512-V0y1dXVt2x8G1oe37WO+FzMLRxE8ltXM4atL/lWG7OKEobSKTvU0FPZaFZtkk1rqITnD/p3sLGMvrqncWKrd9Q==",
       "requires": {
         "base-64": "^0.1.0",
         "semver": "^7.3.2"

--- a/Apps/PackageTest/0.64.0/package-lock.json
+++ b/Apps/PackageTest/0.64.0/package-lock.json
@@ -1181,20 +1181,23 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.9.tgz",
-      "integrity": "sha512-1xoYaq0CfJiKGLlsEAazK0oPR0DOzw1sl2JY3paeVi+Rh6muoHoKKgWAv+Pobq6rnQM1fQpj8uKbijtEeTLciw==",
+      "version": "5.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.22.tgz",
+      "integrity": "sha512-/yjSVcaT9ZfjIZ0QiaB33FntNy/iregK7nEfFwS5LIHEcb7ATPR18wc2OFtXpA2CX0wCsIRpMaTdF5K7aS+4zA==",
       "requires": {
-        "tslib": ">=1.10.0"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@babylonjs/react-native": {
       "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-V0y1dXVt2x8G1oe37WO+FzMLRxE8ltXM4atL/lWG7OKEobSKTvU0FPZaFZtkk1rqITnD/p3sLGMvrqncWKrd9Q==",
-      "requires": {
-        "base-64": "^0.1.0",
-        "semver": "^7.3.2"
-      },
+      "integrity": "sha512-9ZZjbcsgiE50Pi6ICR19am3jPgJhZoSB8hXc/EL8jGhqBOphQa+uFqN0qFNp1TaxBDJeJ1ZFYM3CVIv4VfErHQ==",
       "dependencies": {
         "semver": {
           "version": "7.3.4",
@@ -1208,7 +1211,7 @@
     },
     "@babylonjs/react-native-windows": {
       "version": "file:../../../Package/Assembled-Windows/babylonjs-react-native-windows-0.0.1.tgz",
-      "integrity": "sha512-I0JZNDjKnGm5z2SMPsfmKb5LNV3whhLhB2uS53TsWEZ6cWwEc5rW9XzEKYDYd4Lg7NrlOxeBhpd/QxPsXsZciw=="
+      "integrity": "sha512-9ZZjbcsgiE50Pi6ICR19am3jPgJhZoSB8hXc/EL8jGhqBOphQa+uFqN0qFNp1TaxBDJeJ1ZFYM3CVIv4VfErHQ=="
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -3233,11 +3236,6 @@
           }
         }
       }
-    },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -11983,7 +11981,8 @@
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.17.1",

--- a/Apps/PackageTest/0.64.0/package.json
+++ b/Apps/PackageTest/0.64.0/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.9",
+    "@babylonjs/core": "^5.0.0-alpha.22",
     "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "@babylonjs/react-native-windows": "file:../../../Package/Assembled-Windows/babylonjs-react-native-windows-0.0.1.tgz",
     "react": "^17.0.1",

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -886,20 +886,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.13.tgz",
-      "integrity": "sha512-7lVp+/EymXDyGyyy6/UjLmECs4JKHEiiWs+Tv+3EjqpUenxjPPmFi7Y+oy3n9g44A4WjMbNoqJxNbeuSRtelfg==",
+      "version": "5.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.22.tgz",
+      "integrity": "sha512-/yjSVcaT9ZfjIZ0QiaB33FntNy/iregK7nEfFwS5LIHEcb7ATPR18wc2OFtXpA2CX0wCsIRpMaTdF5K7aS+4zA==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.13.tgz",
-      "integrity": "sha512-7kuJYsAsF1jJ7f1ODnRD+NNMO9ERvl/bBdfhEZqSTKxhc7cNHFkRbRwwCE7Zj4FFwKo8hNiJd09HJlr87+v1TA==",
+      "version": "5.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.22.tgz",
+      "integrity": "sha512-YkfttdmKHKl0m+vMSGyJbDvdRP3BPDlyKdidpszWG3rspcZ4IQPxszJZVfvVmJ/dnsIBWmuM/qd/ecN/Ab5Otw==",
       "requires": {
-        "@babylonjs/core": "5.0.0-alpha.13",
-        "babylonjs-gltf2interface": "5.0.0-alpha.13",
+        "@babylonjs/core": "5.0.0-alpha.22",
+        "babylonjs-gltf2interface": "5.0.0-alpha.22",
         "tslib": "^2.1.0"
       }
     },
@@ -4268,9 +4268,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.13.tgz",
-      "integrity": "sha512-nHnJBPRmxEu9OhNoVaW7waQcP0V10IEUwiMUtpNMUfQYaO/lbU+xMbaps/ryjDLuBviuTpq0QqHQKI6Ys/rokA=="
+      "version": "5.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.22.tgz",
+      "integrity": "sha512-3JsZjMNxwimfcw/02Z912/zsOz//GB+llC0BFSGDJD4w2pWdvyri+rx31XwWiJk1hJk8rPziEy6G6d+nWQeaQA=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -13,8 +13,8 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.13",
-    "@babylonjs/loaders": "^5.0.0-alpha.13",
+    "@babylonjs/core": "^5.0.0-alpha.22",
+    "@babylonjs/loaders": "^5.0.0-alpha.22",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-windows": "file:../../Modules/@babylonjs/react-native-windows",
     "@react-native-community/slider": "4.0.0-rc.3",

--- a/Modules/@babylonjs/react-native-windows/package.json
+++ b/Modules/@babylonjs/react-native-windows/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.9",
+    "@babylonjs/core": "^5.0.0-alpha.22",
     "@babylonjs/react-native":"version",
     "react": "^17.0.1",
     "react-native": "^0.64.0",

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.13",
+    "@babylonjs/core": "^5.0.0-alpha.22",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
     "react-native-permissions": "^2.1.4"


### PR DESCRIPTION
This PR brings in the latest versions of Babylon.js, and BabylonNative to widen support for additional vertex buffer attribute types as detailed in: https://github.com/BabylonJS/BabylonNative/issues/729