### PR TITLE
Release xrView related memory when xr session stops (iOS)

### DIFF
--- a/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
+++ b/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
@@ -69,6 +69,10 @@
     [BabylonNativeInterop renderView];
 }
 
+-(void)dealloc {
+    [BabylonNativeInterop updateXRView:nil];
+}
+
 - (void)takeSnapshot {
     // We must take the screenshot on the main thread otherwise we might fail to get a valid handle on the view's image.
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
+++ b/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
@@ -26,13 +26,6 @@
         super.translatesAutoresizingMaskIntoConstraints = false;
         super.colorPixelFormat = MTLPixelFormatBGRA8Unorm_sRGB;
         super.depthStencilPixelFormat = MTLPixelFormatDepth32Float;
-
-        xrView = [[MTKView alloc] initWithFrame:self.bounds device:self.device];
-        xrView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        xrView.userInteractionEnabled = false;
-        xrView.hidden = true;
-        [self addSubview:xrView];
-        [BabylonNativeInterop updateXRView:xrView];
     }
     return self;
 }
@@ -60,9 +53,17 @@
 
 - (void)drawRect:(CGRect)rect {
     if ([BabylonNativeInterop isXRActive]) {
-        xrView.hidden = false;
-    } else {
-        xrView.hidden = true;
+        if (!xrView) {
+            xrView = [[MTKView alloc] initWithFrame:self.bounds device:self.device];
+            xrView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+            xrView.userInteractionEnabled = false;
+            [self addSubview:xrView];
+            [BabylonNativeInterop updateXRView:xrView];
+        }
+    } else if (xrView) {
+        [BabylonNativeInterop updateXRView:nil];
+        [xrView removeFromSuperview];
+        xrView = nil;
     }
 
     [BabylonNativeInterop renderView];


### PR DESCRIPTION
**Describe the change**

The native `EngineView` creates a second `MTKView` for xr rendering and passes along a pointer to that view. Later `xr.mm` calls `[metalLayer nextDrawable]` when it draws each frame. Metal rendering related resources are created lazily from this and cached in a resource pool. Those resources stay alive as long as the `MTKView` stays alive. This results in about ~25mb of memory being allocated when entering XR that is not released until the `EngineView` itself is released.

With this change, the `xrView` is created when XR starts and destroyed when XR stops, which releases the ~25mb of memory.

**Documentation**

Have you updated the [documentation](../README.md) to reflect your changes? N/A

**Testing**

Have you [tested](../README.md#testing-in-the-playground-app) the final iteration of your changes? Yes for iOS (does not affect other platforms).
