### PR TITLE
Don't render when graphics is disabled

### DIFF
--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -79,6 +79,7 @@ namespace Babylon
             }
 
             g_graphics->EnableRendering();
+            m_isRenderingEnabled = true;
 
             std::call_once(m_isGraphicsInitialized, [this]()
             {
@@ -97,7 +98,9 @@ namespace Babylon
 
         void RenderView()
         {
-            if (g_graphics)
+            // If rendering has not been explicitly enabled, or has been explicitly disabled, then don't try to render.
+            // Otherwise rendering can be implicitly enabled, which may not be desirable (e.g. after the engine is disposed).
+            if (g_graphics && m_isRenderingEnabled)
             {
                 g_graphics->StartRenderingCurrentFrame();
                 g_graphics->FinishRenderingCurrentFrame();
@@ -115,6 +118,8 @@ namespace Babylon
                     CreateInitPromise();
                 });
             }
+
+            m_isRenderingEnabled = false;
         }
 
         void SetMouseButtonState(uint32_t buttonId, bool isDown, uint32_t x, uint32_t y)
@@ -198,6 +203,7 @@ namespace Babylon
         Dispatcher m_jsDispatcher{};
 
         std::shared_ptr<bool> m_isRunning{};
+        bool m_isRenderingEnabled{};
         std::once_flag m_isGraphicsInitialized{};
         Plugins::NativeInput* m_nativeInput{};
         std::optional<Plugins::NativeXr> m_nativeXr{};


### PR DESCRIPTION
**Describe the change**

It is possible (observed in apps using Babylon React Native) for graphics to be re-enabled after being disabled while the engine instance and `EngineView` are being torn down. As far as I can tell, this is a timing issue that was probably introduced with the threading changes where rendering no longer happens on the JS thread. It seems to just depend on the timing of when React Native removes the view. The result of this is that if graphics is re-enabled, bgfx allocates a bunch of memory, and so a React Native app can end up with a lot of extra memory pressure even when Babylon is not in use.

The fix for this is to simply keep track of whether rendering has been explicitly enabled/disabled, and only allow the view to be rendered when rendering is enabled (attempting to render a frame will automatically enable rendering).

**Screenshots**

N/A

**Documentation**

N/A

**Testing**

I went through the tests on Android and iOS. I think it is unlikely that this would result in a regression on Windows.
