### PR TITLE
Add NativeOptimizations plugin

### DIFF
--- a/Apps/PackageTest/0.63.1/ios/Podfile.lock
+++ b/Apps/PackageTest/0.63.1/ios/Podfile.lock
@@ -68,7 +68,7 @@ PODS:
   - glog (0.3.5)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.180)
-  - Permission-Camera (2.1.5):
+  - Permission-Camera (2.2.2):
     - RNPermissions
   - RCTRequired (0.63.1)
   - RCTTypeSafety (0.63.1):
@@ -298,8 +298,8 @@ PODS:
     - React-Core (= 0.63.1)
     - React-cxxreact (= 0.63.1)
     - React-jsi (= 0.63.1)
-  - RNPermissions (2.1.5):
-    - React
+  - RNPermissions (2.2.2):
+    - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -449,7 +449,7 @@ SPEC CHECKSUMS:
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
-  Permission-Camera: 53d46bd722aea28d796e20f05fb3cbe6cde6ccb6
+  Permission-Camera: 375576c57ea625c88137d2cc52ba6dfeb21db036
   RCTRequired: d9b1a9e6fa097744ca3ede59f86a35096df7202b
   RCTTypeSafety: c227cd061983e9e964115afbc4e8730d6a6f1395
   React: 86e972a20967ee4137aa19dc48319405927c2e94
@@ -471,7 +471,7 @@ SPEC CHECKSUMS:
   React-RCTText: 4f95d322b7e6da72817284abf8a2cdcec18b9cd8
   React-RCTVibration: f3a9123c244f35c40d3c9f3ec3f0b9e5717bb292
   ReactCommon: 2905859f84a94a381bb0d8dd3921ccb1a0047cb8
-  RNPermissions: 1888705aebcc81714efa5dbff94351e4388ae012
+  RNPermissions: 067727df624665d4a6c8e2cffcc172ba608b96ed
   Yoga: d5bd05a2b6b94c52323745c2c2b64557c8c66f64
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/Apps/PackageTest/0.63.1/package-lock.json
+++ b/Apps/PackageTest/0.63.1/package-lock.json
@@ -913,16 +913,16 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-qVbN5DqEbx3M+XXs8u7s8nzIkx8MyP5UtMFmzUQCDw1wFkhqVWjOAKpt5U7i6PtSZQCZIezalucrKeTP5lSTLQ==",
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-cBxaLT+HmkVRBPG5FewMfUtGKEsXwZzB9n/JTxnzA/ohuDR5vLzwQ9tR2hOlFYococDWsJHJok0WAq1FWfEt+Q==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@babylonjs/react-native": {
       "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-3TU50RJIYgYvee6cSkiJf5vDhUwLSRZWEyKWviSbPB+r+G8hiJPuPo3PWdM9JiMlh+XoDGiIuZu83lcGayfQ+g==",
+      "integrity": "sha512-UdxBV+FjmayrEPEGOTRY84eL6Ut/VqfItccKmo4dmg+494wpNTMszKVIHh4j+50JlUtMU2Y8r12vuWANwyj4OA==",
       "requires": {
         "base-64": "^0.1.0",
         "semver": "^7.3.2"

--- a/Apps/PackageTest/0.63.1/package.json
+++ b/Apps/PackageTest/0.63.1/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.30",
+    "@babylonjs/core": "^5.0.0-alpha.34",
     "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/Playground/ios/Podfile.lock
+++ b/Apps/Playground/ios/Podfile.lock
@@ -492,7 +492,7 @@ SPEC CHECKSUMS:
   React-jsi: 5de8204706bd872b78ea646aee5d2561ca1214b6
   React-jsiexecutor: 124e8f99992490d0d13e0649d950d3e1aae06fe9
   React-jsinspector: 500a59626037be5b3b3d89c5151bc3baa9abf1a9
-  react-native-babylon: 67b39de846123d0846b28ce0e38671c7e3c4e04f
+  react-native-babylon: 47ed99257b75b4b899f1aba39966b34904c5704f
   react-native-slider: e45c8376012e5ace012e5eef62e9c85c68e50a0f
   React-perflogger: aad6d4b4a267936b3667260d1f649b6f6069a675
   React-RCTActionSheet: fc376be462c9c8d6ad82c0905442fd77f82a9d2a

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -886,20 +886,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-qVbN5DqEbx3M+XXs8u7s8nzIkx8MyP5UtMFmzUQCDw1wFkhqVWjOAKpt5U7i6PtSZQCZIezalucrKeTP5lSTLQ==",
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-cBxaLT+HmkVRBPG5FewMfUtGKEsXwZzB9n/JTxnzA/ohuDR5vLzwQ9tR2hOlFYococDWsJHJok0WAq1FWfEt+Q==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-EgryjcNDbiL18XTXLpuKJSzBYTzBrMteLpRxzL4lGIz4E31zwEDl3+VezrjFX2bgsdfQO7ty7D3ELZMJAfF4nA==",
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-y/OWpykDO63WTPbPXylmT0R8XIGvZAG5fgtSE72LLDzF6M2LtTCnX3HiTEMVX1GPlyQzuslEFjtUsS3qgFYRFw==",
       "requires": {
-        "@babylonjs/core": "5.0.0-alpha.30",
-        "babylonjs-gltf2interface": "5.0.0-alpha.30",
+        "@babylonjs/core": "5.0.0-alpha.34",
+        "babylonjs-gltf2interface": "5.0.0-alpha.34",
         "tslib": "^2.1.0"
       }
     },
@@ -4597,9 +4597,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-HO8ezRQ0s4//x4CEACszcVdbotKO0/DzkWJAVbZBGZ/QaMLibYfCQoKCWBP1gIBADIe+cjn3TubM0oIMovDhwQ=="
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-BqcvLlTvVsPtQsCp/PtL0uIpNrJ1oas00N7kP1Lk7eDd+PUchIF1gvC/XvPR7QH6WABIvTcbi7Fr931OyIyxsw=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.30",
-    "@babylonjs/loaders": "^5.0.0-alpha.30",
+    "@babylonjs/core": "^5.0.0-alpha.34",
+    "@babylonjs/loaders": "^5.0.0-alpha.34",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-windows": "file:../../Modules/@babylonjs/react-native-windows",
     "@react-native-community/slider": "4.0.0-rc.3",

--- a/Modules/@babylonjs/react-native-windows/package.json
+++ b/Modules/@babylonjs/react-native-windows/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.30",
+    "@babylonjs/core": "^5.0.0-alpha.34",
     "@babylonjs/react-native":"version",
     "react": "^17.0.1",
     "react-native": "^0.64.0",

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -145,6 +145,7 @@
         $(BabylonNativeBuildDir)\Plugins\NativeCapture\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeEngine\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeInput\$(Configuration);
+        $(BabylonNativeBuildDir)\Plugins\NativeOptimizations\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeXr\$(Configuration);
         $(BabylonNativeBuildDir)\Polyfills\Window\$(Configuration);
         $(BabylonNativeBuildDir)\Polyfills\XMLHttpRequest\$(Configuration);
@@ -191,6 +192,7 @@
         NativeCapture.lib;
         NativeEngine.lib;
         NativeInput.lib;
+        NativeOptimizations.lib;
         NativeXr.lib;
         nvtt.lib;
         OGLCompilerd.lib;
@@ -248,6 +250,7 @@
         NativeCapture.lib;
         NativeEngine.lib;
         NativeInput.lib;
+        NativeOptimizations.lib;
         NativeXr.lib;
         nvtt.lib;
         OGLCompiler.lib;

--- a/Modules/@babylonjs/react-native-windows/windows/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native-windows/windows/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(BabylonNative
     NativeCapture
     NativeEngine
     NativeInput
+    NativeOptimizations
     NativeXr
     Window
     XMLHttpRequest

--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(BabylonNative
     NativeCapture
     NativeEngine
     NativeInput
+    NativeOptimizations
     NativeXr
     Window
     XMLHttpRequest)

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(BabylonNative
     NativeCapture
     NativeEngine
     NativeInput
+    NativeOptimizations
     NativeXr
     Window
     XMLHttpRequest)

--- a/Modules/@babylonjs/react-native/package-lock.json
+++ b/Modules/@babylonjs/react-native/package-lock.json
@@ -756,9 +756,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-qVbN5DqEbx3M+XXs8u7s8nzIkx8MyP5UtMFmzUQCDw1wFkhqVWjOAKpt5U7i6PtSZQCZIezalucrKeTP5lSTLQ==",
+      "version": "5.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.34.tgz",
+      "integrity": "sha512-cBxaLT+HmkVRBPG5FewMfUtGKEsXwZzB9n/JTxnzA/ohuDR5vLzwQ9tR2hOlFYococDWsJHJok0WAq1FWfEt+Q==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.30",
+    "@babylonjs/core": "^5.0.0-alpha.34",
     "react": "^16.13.1",
     "react-native": "^0.63.1",
     "react-native-permissions": "^2.1.4"
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "^5.0.0-alpha.30",
+    "@babylonjs/core": "^5.0.0-alpha.34",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",

--- a/Modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -33,6 +33,7 @@ Pod::Spec.new do |s|
                 'NativeCapture',
                 'NativeEngine',
                 'NativeInput',
+                'NativeOptimizations',
                 'NativeXR',
                 'SPIRV',
                 'spirv-cross-core',

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -5,6 +5,7 @@
 #include <Babylon/Plugins/NativeCapture.h>
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/NativeInput.h>
+#include <Babylon/Plugins/NativeOptimizations.h>
 #include <Babylon/Plugins/NativeXr.h>
 #include <Babylon/Polyfills/Window.h>
 #include <Babylon/Polyfills/XMLHttpRequest.h>
@@ -46,6 +47,7 @@ namespace Babylon
             m_nativeXr->SetSessionStateChangedCallback([isXRActive{ m_isXRActive }](bool isSessionActive) { *isXRActive = isSessionActive; });
             Plugins::NativeCapture::Initialize(m_env);
             m_nativeInput = &Plugins::NativeInput::CreateForJavaScript(m_env);
+            Plugins::NativeOptimizations::Initialize(m_env);
 
             // Initialize Babylon Native polyfills
             Polyfills::Window::Initialize(m_env);

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -413,6 +413,7 @@ Assembled/ios/libs/libNativeXr.a
 Assembled/ios/libs/libNativeCapture.a
 Assembled/ios/libs/libspirv-cross-glsl.a
 Assembled/ios/libs/libNativeInput.a
+Assembled/ios/libs/libNativeOptimizations.a
 Assembled/ios/libs/libJsRuntime.a
 Assembled/ios/libs/libGraphics.a
 Assembled/ios/libs/libOSDependent.a

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -472,6 +472,7 @@ const validate = async () => {
     'Assembled/ios/libs/libNativeCapture.a',
     'Assembled/ios/libs/libNativeEngine.a',
     'Assembled/ios/libs/libNativeInput.a',
+    'Assembled/ios/libs/libNativeOptimizations.a',
     'Assembled/ios/libs/libNativeXr.a',
     'Assembled/ios/libs/libOGLCompiler.a',
     'Assembled/ios/libs/libOSDependent.a',

--- a/Package/iOS/CMakeLists.txt
+++ b/Package/iOS/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PACKAGED_LIBS
     NativeCapture
     NativeEngine
     NativeInput
+    NativeOptimizations
     NativeXr
     SPIRV
     spirv-cross-core


### PR DESCRIPTION
**Describe the change**

This change adds the NativeOptimizations plugin to Babylon React Native. For now, this is primarily to improve MergeMeshes perf (about 9x).

**Screenshots**

*Before*:
![MergeMeshesOptimizationBefore](https://user-images.githubusercontent.com/5084643/126826161-1797910a-ad2a-4b43-b72f-d2af321892ca.gif)

*After*:
![MergeMeshesOptimizationAfter](https://user-images.githubusercontent.com/5084643/126826184-1d7e6bcd-6cc8-4417-a58b-02e45887a944.gif)

**Documentation**

N/A

**Testing**

I did all the tests for iOS and Android. I'm not setup to test Windows (it does compile though!).
