### PR TITLE
Add back ARCore

### DIFF
--- a/Package/Android/build.gradle
+++ b/Package/Android/build.gradle
@@ -77,6 +77,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
+    implementation 'com.google.ar:core:1.14.0'
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
**Describe the change**

This change adds back ARCore to the packages build.gradle file for Android. This *unfixes* https://github.com/BabylonJS/BabylonReactNative/issues/218 (we'll need to come up with a different solution), but fixes https://github.com/BabylonJS/BabylonReactNative/issues/264.

I'm not sure how this worked when I tested it before, because now when I test the current package in PackageTest (which doesn't even use XR) it crashes on launch with the missing so exception mentioned in #264. I did do a clean build and cleaned my npm cache, so maybe not having done so previously was somehow preventing this error when I previously tested, not sure. :/

**Screenshots**

N/A

**Documentation**

N/A

**Testing**

Tested on Android (the only platform affected by this change).
