### PR TITLE
Add support for RN 0.64+

### DIFF
--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@babylonjs/core": "^5.0.0-alpha.34",
-    "react": "^16.13.1",
-    "react-native": "^0.63.1",
+    "react": ">=16.13.1",
+    "react-native": ">=0.63.1",
     "react-native-permissions": "^2.1.4"
   },
   "devDependencies": {

--- a/Package/Android/build.gradle
+++ b/Package/Android/build.gradle
@@ -19,6 +19,10 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def reactProperties = new Properties()
+file("$projectDir/../../../react-native/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
+def REACT_VERSION = reactProperties.getProperty("VERSION_NAME").split("\\.")[1].toInteger()
+
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
@@ -57,6 +61,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+}
+
+// The full/real version of libturbomodulejsijni.so will be built and included in apps using React Native 0.64 or newer,
+// so exclude Babylon React Native's minimal version of these libs in this case.
+if (REACT_VERSION >= 64) {
+    android.packagingOptions.excludes += 'lib/armeabi-v7a/libturbomodulejsijni.so'
+    android.packagingOptions.excludes += 'lib/arm64-v8a/libturbomodulejsijni.so'
+    android.packagingOptions.excludes += 'lib/x86/libturbomodulejsijni.so'
 }
 
 repositories {


### PR DESCRIPTION
**Describe the change**

Babylon React Native previously did not work correctly with React Native 0.64 because we bundle a slimmed down version of `libturbomodulejsijni.so` to support our use of `CallInvoker`, and RN 0.64+ generates the full version of `libturbomodulejsijni.so` during the build, which results in a conflict. To solve this, the packaged `build.gradle` file will now check to see if Babylon React Native is being used in the context of an RN 0.64+ app, and if so, exclude BRN's customer version of `libturbomodulejsijni.so`. Additionally, I've updated the peer dependencies in `package.json` to allow for React 17+ and React Native 0.64+.

This change fixes #192.

**Screenshots**

N/A

**Documentation**

N/A

**Testing**

I tested these changes on Android (other platforms should not be affected).
