### PR TITLE
remove * for github checkout

### DIFF
--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -93,7 +93,7 @@ const initializeSubmodulesMostRecentBabylonNative = async () => {
   }
   else
   {
-    exec('git submodule update --init --recursive *', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
+    exec('git submodule update --init --recursive', './../Modules/@babylonjs/react-native/submodules/BabylonNative');
   }
 
   exec('git status');


### PR DESCRIPTION
**Describe the change**

We are seeing submodule checkout failures on mac for one of our github action test passes. This change removes the '*' from the command which seems to allow the submodule initialization to succeed.

**Screenshots**

n/a

**Documentation**

n/a

**Testing**

I was able to repro the checkout failure locally on mac. This change seems to have fixed things.
