### PR TITLE
Fix npm install reliability in github actions

### DIFF
--- a/.github/workflows/bn_master_commit.yml
+++ b/.github/workflows/bn_master_commit.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
@@ -40,6 +42,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: NPM Install (Playground)
         run: npm install
         working-directory: ./Apps/Playground
@@ -65,6 +69,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'true'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Setup NuGet

--- a/.github/workflows/bn_master_commit.yml
+++ b/.github/workflows/bn_master_commit.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Git (Update to BabylonNative ${{ github.event.client_payload.sha }})
         run: npx gulp initializeSubmodulesMostRecentBabylonNative --sha ${{ github.event.client_payload.sha }}
@@ -45,10 +45,10 @@ jobs:
       - name: Clean NPM Cache
         run: npm cache clean --force
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Git (Update to BabylonNative ${{ github.event.client_payload.sha }})
         run: npx gulp initializeSubmodulesMostRecentBabylonNative --sha ${{ github.event.client_payload.sha }}
@@ -78,10 +78,10 @@ jobs:
         with:
           nuget-version: '5.x'
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Git (Update to BabylonNative ${{ github.event.client_payload.sha }})
         run: npx gulp initializeSubmodulesMostRecentBabylonNative --sha ${{ github.event.client_payload.sha }} --windows

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,6 @@
 name: PR Build
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
@@ -35,6 +37,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: NPM Install (Playground)
         run: npm install
         working-directory: ./Apps/Playground
@@ -52,6 +56,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
@@ -79,6 +85,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'true'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Setup NuGet

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Gulp (Android)
         run: npx gulp buildAndroid
@@ -41,10 +41,10 @@ jobs:
       - name: Clean NPM Cache
         run: npm cache clean --force
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Gulp (iOS)
         run: npx gulp buildIOS
@@ -66,10 +66,10 @@ jobs:
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Gulp
         run: npx gulp
@@ -95,10 +95,10 @@ jobs:
         with:
           nuget-version: '5.x'
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Git (Windows)
         run: npx gulp initializeSubmodulesWindowsAgent

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Gulp
         run: npx gulp
@@ -50,10 +50,10 @@ jobs:
         with:
           nuget-version: '5.x'
       - name: NPM Install (Playground)
-        run: npm install
+        run: npm ci
         working-directory: ./Apps/Playground
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Git (Windows)
         run: npx gulp initializeSubmodulesWindowsAgent
@@ -76,7 +76,7 @@ jobs:
       - name: Clean NPM Cache
         run: npm cache clean --force
       - name: NPM Install (Binary Package)
-        run: npm install
+        run: npm ci
         working-directory: ./Package
       - name: Download Assembled Folder
         uses: actions/download-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
@@ -39,6 +41,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'true'
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Setup NuGet
@@ -69,6 +73,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2.3.3
+      - name: Clean NPM Cache
+        run: npm cache clean --force
       - name: NPM Install (Binary Package)
         run: npm install
         working-directory: ./Package


### PR DESCRIPTION
**Describe the change**

Adding steps to clear npm caches to see if it decreases how frequently we see the following error:

Run npm install
npm ERR! cb() never called!

npm ERR! This is an error with npm itself. Please report this error at:
npm ERR!     <https://npm.community>

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\npm\cache\_logs\2021-07-09T08_39_38_176Z-debug.log
Error: Process completed with exit code 1.

If this change addresses any issues, be sure to [link this PR to those issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue).

**Screenshots**

n/a

**Documentation**

n/a

**Testing**

opening pr to test this change
