### PR TITLE
Update BabylonNative and Babylon.js to 5.0.0-alpha.37

### DIFF
--- a/Apps/PackageTest/0.63.1/package-lock.json
+++ b/Apps/PackageTest/0.63.1/package-lock.json
@@ -913,16 +913,16 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.34.tgz",
-      "integrity": "sha512-cBxaLT+HmkVRBPG5FewMfUtGKEsXwZzB9n/JTxnzA/ohuDR5vLzwQ9tR2hOlFYococDWsJHJok0WAq1FWfEt+Q==",
+      "version": "5.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.38.tgz",
+      "integrity": "sha512-3stjWgQs3GbPPcx7PAaztTzwmdThN1YVBFO/AQKXtK5WCgAO3uaEQcq6BcrjZGcMIV/HgF2wGHGMzc32+fLPpg==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@babylonjs/react-native": {
       "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-UdxBV+FjmayrEPEGOTRY84eL6Ut/VqfItccKmo4dmg+494wpNTMszKVIHh4j+50JlUtMU2Y8r12vuWANwyj4OA==",
+      "integrity": "sha512-s88RrPcfRqqW7MK3qnXvgoAFmqRGJVbSGyHYuF+KWAsgfEmsfBx4MRqv/IYcp/O7Qnk6ia+XLd3+/N3LfPnDqQ==",
       "requires": {
         "base-64": "^0.1.0",
         "semver": "^7.3.2"
@@ -11367,9 +11367,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/Apps/PackageTest/0.63.1/package.json
+++ b/Apps/PackageTest/0.63.1/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.34",
+    "@babylonjs/core": "^5.0.0-alpha.37",
     "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/PackageTest/0.64.0/package.json
+++ b/Apps/PackageTest/0.64.0/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.30",
+    "@babylonjs/core": "^5.0.0-alpha.37",
     "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "@babylonjs/react-native-windows": "file:../../../Package/Assembled-Windows/babylonjs-react-native-windows-0.0.1.tgz",
     "react": "^17.0.1",

--- a/Apps/Playground/ios/Podfile.lock
+++ b/Apps/Playground/ios/Podfile.lock
@@ -467,9 +467,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 5d6dbb11432863ed5cd10461d91baf60af966217
+  FBReactNativeSpec: 41c2862d3cf2b290d1e02d6e871a482e2979677b
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -477,7 +477,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   Permission-Camera: 358081c7b8210849958af181ce9ddeb11932aa82

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -886,20 +886,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.34.tgz",
-      "integrity": "sha512-cBxaLT+HmkVRBPG5FewMfUtGKEsXwZzB9n/JTxnzA/ohuDR5vLzwQ9tR2hOlFYococDWsJHJok0WAq1FWfEt+Q==",
+      "version": "5.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.37.tgz",
+      "integrity": "sha512-4F6EaG42VHzibZ7yq0lfy8LeC9GdcvaB7Wl4ghbm9oUbeT3E7GNjEJZUDGbsG6UkPwih6OyYYR6zbleyhajK3Q==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.34.tgz",
-      "integrity": "sha512-y/OWpykDO63WTPbPXylmT0R8XIGvZAG5fgtSE72LLDzF6M2LtTCnX3HiTEMVX1GPlyQzuslEFjtUsS3qgFYRFw==",
+      "version": "5.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.37.tgz",
+      "integrity": "sha512-kc0CCDXPiBCoyKfS0FiHJyEXXTMQ0SIkjZNR2KZt0omBAF5lHyR6rLUoOZp3iHx2bvHZ8SGNV7lazs+CMQ6nkw==",
       "requires": {
-        "@babylonjs/core": "5.0.0-alpha.34",
-        "babylonjs-gltf2interface": "5.0.0-alpha.34",
+        "@babylonjs/core": "5.0.0-alpha.37",
+        "babylonjs-gltf2interface": "5.0.0-alpha.37",
         "tslib": "^2.1.0"
       }
     },
@@ -4597,9 +4597,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.34.tgz",
-      "integrity": "sha512-BqcvLlTvVsPtQsCp/PtL0uIpNrJ1oas00N7kP1Lk7eDd+PUchIF1gvC/XvPR7QH6WABIvTcbi7Fr931OyIyxsw=="
+      "version": "5.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.37.tgz",
+      "integrity": "sha512-RZTavJcj6iePTdQ8kfthXMbtLRQO9UYyX4tCgdxmS6QqL3g8NhmtTDNjPw6EljLxstBTsAZEuV2M3pATmdOpyQ=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babylonjs/core": "^5.0.0-alpha.37",
-    "@babylonjs/loaders": "5.0.0-alpha.37",
+    "@babylonjs/loaders": "^5.0.0-alpha.37",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-windows": "file:../../Modules/@babylonjs/react-native-windows",
     "@react-native-community/slider": "4.0.0-rc.3",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.34",
-    "@babylonjs/loaders": "^5.0.0-alpha.34",
+    "@babylonjs/core": "^5.0.0-alpha.37",
+    "@babylonjs/loaders": "5.0.0-alpha.37",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-windows": "file:../../Modules/@babylonjs/react-native-windows",
     "@react-native-community/slider": "4.0.0-rc.3",

--- a/Modules/@babylonjs/react-native-windows/package.json
+++ b/Modules/@babylonjs/react-native-windows/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.34",
+    "@babylonjs/core": "^5.0.0-alpha.37",
     "@babylonjs/react-native":"version",
     "react": "^17.0.1",
     "react-native": "^0.64.0",

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -81,7 +81,8 @@ if (Platform.OS === "android" || Platform.OS === "ios") {
         return sessionManager;
     };
 
-    // Skip clearing render target texture back buffer for XR RTTs.
+    // TODO: https://github.com/BabylonJS/BabylonNative/issues/871
+    // Workaround to skip clearing render target texture back buffer for XR RTTs.
     const originalCreateRenderTargetTexture: (...args: any[]) => RenderTargetTexture = (WebXRSessionManager.prototype as any)._createRenderTargetTexture;
     (WebXRSessionManager.prototype as any)._createRenderTargetTexture = function (...args: any[]): RenderTargetTexture {
         const renderTargetTexture = originalCreateRenderTargetTexture.apply(this, args);

--- a/Modules/@babylonjs/react-native/package-lock.json
+++ b/Modules/@babylonjs/react-native/package-lock.json
@@ -756,9 +756,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.34",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.34.tgz",
-      "integrity": "sha512-cBxaLT+HmkVRBPG5FewMfUtGKEsXwZzB9n/JTxnzA/ohuDR5vLzwQ9tR2hOlFYococDWsJHJok0WAq1FWfEt+Q==",
+      "version": "5.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.37.tgz",
+      "integrity": "sha512-4F6EaG42VHzibZ7yq0lfy8LeC9GdcvaB7Wl4ghbm9oUbeT3E7GNjEJZUDGbsG6UkPwih6OyYYR6zbleyhajK3Q==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -3953,9 +3953,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
     "tsutils": {

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.34",
+    "@babylonjs/core": "^5.0.0-alpha.37",
     "react": ">=16.13.1",
     "react-native": ">=0.63.1",
     "react-native-permissions": "^2.1.4"
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "^5.0.0-alpha.34",
+    "@babylonjs/core": "^5.0.0-alpha.37",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",


### PR DESCRIPTION
**Describe the change**
Update to the latest BabylonNative and Babylon.js package versions which includes support for srgb buffers and Canvas font scaling.  This change also includes a temporary workaround for the XR camera feed render texture issue described here: https://github.com/BabylonJS/BabylonNative/issues/871

**Documentation**

N/A

**Testing**
I have tested on iOS android and non-XR based Windows