### PR TITLE
Remove extra clear in EngineHook workaround

### DIFF
--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -87,7 +87,7 @@ if (Platform.OS === "android" || Platform.OS === "ios") {
     (WebXRSessionManager.prototype as any)._createRenderTargetTexture = function (...args: any[]): RenderTargetTexture {
         const renderTargetTexture = originalCreateRenderTargetTexture.apply(this, args);
         renderTargetTexture.onClearObservable.add((engine: ThinEngine) => {
-            engine.clear(renderTargetTexture.clearColor, false, true, true);
+            // do nothing
         });
 
         return renderTargetTexture;


### PR DESCRIPTION
**Describe the change**

This change removes the extra clear of depth and stencil in the EngineHook workaround for running XR on Android. The updated submodule for Babylon Native will do this clear instead for Android. Apple XR implementation already does this. We still need the workaround in EngineHook to override Babylon.js to do nothing. This still needs to be fixed in Babylon.js before we can remove the workaround completely.

See https://github.com/BabylonJS/BabylonNative/issues/871 for context.

**Screenshots**

N/A

**Documentation**

N/A

**Testing**

- [X] Android XR
- [X] iOS XR
