### PR TITLE
Update to Babylon 5.0.0-alpha.44

### DIFF
--- a/Apps/PackageTest/0.63.1/package-lock.json
+++ b/Apps/PackageTest/0.63.1/package-lock.json
@@ -913,16 +913,17 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.38",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.38.tgz",
-      "integrity": "sha512-3stjWgQs3GbPPcx7PAaztTzwmdThN1YVBFO/AQKXtK5WCgAO3uaEQcq6BcrjZGcMIV/HgF2wGHGMzc32+fLPpg==",
+      "version": "5.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.45.tgz",
+      "integrity": "sha512-HLqoLtqMVDuUxiPBz+KC/igUi9hCtp04ecx4NVHKaMd2f1Wt4d/FIkxoQ08frPtEQptOgop/y4ac50Wrm+TyCw==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.1"
       }
     },
     "@babylonjs/react-native": {
-      "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-s88RrPcfRqqW7MK3qnXvgoAFmqRGJVbSGyHYuF+KWAsgfEmsfBx4MRqv/IYcp/O7Qnk6ia+XLd3+/N3LfPnDqQ==",
+      "version": "0.4.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@babylonjs/react-native/-/react-native-0.4.0-alpha.33.tgz",
+      "integrity": "sha512-gOK+8oI/SiCCez4zOv+SurULe/IropXXhhof/Yitd4JRt38++kHzEmc8YKC3soEOnygxM73W6SAsx2obPQnOdw==",
       "requires": {
         "base-64": "^0.1.0",
         "semver": "^7.3.2"

--- a/Apps/PackageTest/0.63.1/package.json
+++ b/Apps/PackageTest/0.63.1/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.37",
+    "@babylonjs/core": "^5.0.0-alpha.44",
     "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/PackageTest/0.63.1/package.json
+++ b/Apps/PackageTest/0.63.1/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@babylonjs/core": "^5.0.0-alpha.44",
-    "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
+    "@babylonjs/react-native": "^0.4.0-alpha.33",
     "react": "16.13.1",
     "react-native": "0.63.1",
     "react-native-permissions": "^2.1.5"

--- a/Apps/PackageTest/0.64.0/package-lock.json
+++ b/Apps/PackageTest/0.64.0/package-lock.json
@@ -934,16 +934,24 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.30.tgz",
-      "integrity": "sha512-qVbN5DqEbx3M+XXs8u7s8nzIkx8MyP5UtMFmzUQCDw1wFkhqVWjOAKpt5U7i6PtSZQCZIezalucrKeTP5lSTLQ==",
+      "version": "5.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.45.tgz",
+      "integrity": "sha512-HLqoLtqMVDuUxiPBz+KC/igUi9hCtp04ecx4NVHKaMd2f1Wt4d/FIkxoQ08frPtEQptOgop/y4ac50Wrm+TyCw==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "@babylonjs/react-native": {
-      "version": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
-      "integrity": "sha512-3TU50RJIYgYvee6cSkiJf5vDhUwLSRZWEyKWviSbPB+r+G8hiJPuPo3PWdM9JiMlh+XoDGiIuZu83lcGayfQ+g==",
+      "version": "0.4.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@babylonjs/react-native/-/react-native-0.4.0-alpha.33.tgz",
+      "integrity": "sha512-gOK+8oI/SiCCez4zOv+SurULe/IropXXhhof/Yitd4JRt38++kHzEmc8YKC3soEOnygxM73W6SAsx2obPQnOdw==",
       "requires": {
         "base-64": "^0.1.0",
         "semver": "^7.3.2"

--- a/Apps/PackageTest/0.64.0/package.json
+++ b/Apps/PackageTest/0.64.0/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babylonjs/core": "^5.0.0-alpha.44",
-    "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
+    "@babylonjs/react-native": "^0.4.0-alpha.33",
     "@babylonjs/react-native-windows": "file:../../../Package/Assembled-Windows/babylonjs-react-native-windows-0.0.1.tgz",
     "react": "^17.0.1",
     "react-native": "^0.64.0",

--- a/Apps/PackageTest/0.64.0/package.json
+++ b/Apps/PackageTest/0.64.0/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.37",
+    "@babylonjs/core": "^5.0.0-alpha.44",
     "@babylonjs/react-native": "file:../../../Package/Assembled/babylonjs-react-native-0.0.1.tgz",
     "@babylonjs/react-native-windows": "file:../../../Package/Assembled-Windows/babylonjs-react-native-windows-0.0.1.tgz",
     "react": "^17.0.1",

--- a/Apps/Playground/package-lock.json
+++ b/Apps/Playground/package-lock.json
@@ -886,21 +886,35 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.37.tgz",
-      "integrity": "sha512-4F6EaG42VHzibZ7yq0lfy8LeC9GdcvaB7Wl4ghbm9oUbeT3E7GNjEJZUDGbsG6UkPwih6OyYYR6zbleyhajK3Q==",
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-QrEh2mtzMxg5NHaE6TMXD84+/bSRkZnvdEihMCMYEzzwWdI7XTrOQ1FnAFcVecUwNJk7T3PqbwTzmyfWeLjlwg==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.37.tgz",
-      "integrity": "sha512-kc0CCDXPiBCoyKfS0FiHJyEXXTMQ0SIkjZNR2KZt0omBAF5lHyR6rLUoOZp3iHx2bvHZ8SGNV7lazs+CMQ6nkw==",
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-BVp924ShrQqqr1y3vPxiT0O4ON5WH7VsGPC3J7i/Fl3bcqTpXeF00Uutl+Fzi7C1UbOsFli/GwE9fiaf1fzQGg==",
       "requires": {
-        "@babylonjs/core": "5.0.0-alpha.37",
-        "babylonjs-gltf2interface": "5.0.0-alpha.37",
-        "tslib": "^2.1.0"
+        "@babylonjs/core": "5.0.0-alpha.44",
+        "babylonjs-gltf2interface": "5.0.0-alpha.44",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "@babylonjs/react-native": {
@@ -4597,9 +4611,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.37.tgz",
-      "integrity": "sha512-RZTavJcj6iePTdQ8kfthXMbtLRQO9UYyX4tCgdxmS6QqL3g8NhmtTDNjPw6EljLxstBTsAZEuV2M3pATmdOpyQ=="
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-t253Yf3SCTwcshXrXa2kYYBh24M7twx0IffKSJhmdtHA1zyZAQ+g8GScoh9cgmoDysQ6KoZ0xGuxJfj7axFT5w=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/package.json
+++ b/Apps/Playground/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.37",
-    "@babylonjs/loaders": "^5.0.0-alpha.37",
+    "@babylonjs/core": "^5.0.0-alpha.44",
+    "@babylonjs/loaders": "^5.0.0-alpha.44",
     "@babylonjs/react-native": "file:../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-windows": "file:../../Modules/@babylonjs/react-native-windows",
     "@react-native-community/slider": "4.0.0-rc.3",

--- a/Modules/@babylonjs/react-native-windows/package.json
+++ b/Modules/@babylonjs/react-native-windows/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.37",
+    "@babylonjs/core": "^5.0.0-alpha.44",
     "@babylonjs/react-native":"version",
     "react": "^17.0.1",
     "react-native": "^0.64.0",

--- a/Modules/@babylonjs/react-native/EngineHook.ts
+++ b/Modules/@babylonjs/react-native/EngineHook.ts
@@ -80,18 +80,6 @@ if (Platform.OS === "android" || Platform.OS === "ios") {
         });
         return sessionManager;
     };
-
-    // TODO: https://github.com/BabylonJS/BabylonNative/issues/871
-    // Workaround to skip clearing render target texture back buffer for XR RTTs.
-    const originalCreateRenderTargetTexture: (...args: any[]) => RenderTargetTexture = (WebXRSessionManager.prototype as any)._createRenderTargetTexture;
-    (WebXRSessionManager.prototype as any)._createRenderTargetTexture = function (...args: any[]): RenderTargetTexture {
-        const renderTargetTexture = originalCreateRenderTargetTexture.apply(this, args);
-        renderTargetTexture.onClearObservable.add((engine: ThinEngine) => {
-            // do nothing
-        });
-
-        return renderTargetTexture;
-    };
 } else if (Platform.OS === "windows") {
     const originalEnterXRAsync: (...args: any[]) => Promise<WebXRSessionManager> = WebXRExperienceHelper.prototype.enterXRAsync;
     WebXRExperienceHelper.prototype.enterXRAsync = async function (...args: any[]): Promise<WebXRSessionManager> {

--- a/Modules/@babylonjs/react-native/NativeCapture.ts
+++ b/Modules/@babylonjs/react-native/NativeCapture.ts
@@ -11,7 +11,7 @@ export type CapturedFrame = {
 export type CaptureCallback = (capture: CapturedFrame) => void;
 
 declare class NativeCapture {
-  public constructor(frameBuffer?: unknown | undefined);
+  public constructor(frameBuffer: unknown);
   public addCallback(onCaptureCallback: CaptureCallback): void;
   public dispose(): void;
 };
@@ -21,7 +21,8 @@ export class CaptureSession {
 
     public constructor(camera: Camera | undefined, onCaptureCallback: CaptureCallback) {
         console.warn(`CaptureSession is experimental and likely to change significantly.`);
-        this.nativeCapture = new NativeCapture(camera?.outputRenderTarget?.getInternalTexture()?._framebuffer);
+        // HACK: There is no exposed way to access the frame buffer from render target texture
+        this.nativeCapture = new NativeCapture((camera?.outputRenderTarget?.renderTarget as any)?._framebuffer);
         this.nativeCapture.addCallback(onCaptureCallback);
     }
 

--- a/Modules/@babylonjs/react-native/package-lock.json
+++ b/Modules/@babylonjs/react-native/package-lock.json
@@ -756,12 +756,12 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.37.tgz",
-      "integrity": "sha512-4F6EaG42VHzibZ7yq0lfy8LeC9GdcvaB7Wl4ghbm9oUbeT3E7GNjEJZUDGbsG6UkPwih6OyYYR6zbleyhajK3Q==",
+      "version": "5.0.0-alpha.44",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-alpha.44.tgz",
+      "integrity": "sha512-QrEh2mtzMxg5NHaE6TMXD84+/bSRkZnvdEihMCMYEzzwWdI7XTrOQ1FnAFcVecUwNJk7T3PqbwTzmyfWeLjlwg==",
       "dev": true,
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.3.1"
       }
     },
     "@eslint/eslintrc": {

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.37",
+    "@babylonjs/core": "^5.0.0-alpha.44",
     "react": ">=16.13.1",
     "react-native": ">=0.63.1",
     "react-native-permissions": "^2.1.4"
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "^5.0.0-alpha.37",
+    "@babylonjs/core": "^5.0.0-alpha.44",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",


### PR DESCRIPTION
This change updates Babylon to 5.0.0-alpha.44 to address issues with XR clearing. It also removes the workaround for removing the extra clear that should be no longer necessary.

See https://github.com/BabylonJS/BabylonNative/issues/871 for more context.

Additional changes:
- Changed PackageTest to point to public released npm packages.
- Updated NativeCapture to match changes to Babylon.js framebuffers.