### PR TITLE
Update ARCore runtime to latest

### DIFF
--- a/Modules/@babylonjs/react-native/android/build.gradle
+++ b/Modules/@babylonjs/react-native/android/build.gradle
@@ -125,11 +125,11 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'com.google.ar:core:1.14.0'
+    implementation 'com.google.ar:core:1.27.0'
 
     api("com.facebook.fbjni:fbjni-java-only:0.0.3")
 
-    natives 'com.google.ar:core:1.14.0'
+    natives 'com.google.ar:core:1.27.0'
     fbjniHeaders 'com.facebook.fbjni:fbjni:0.0.2:headers'
     fbjniLibs 'com.facebook.fbjni:fbjni:0.0.2'
 }

--- a/Package/Android/build.gradle
+++ b/Package/Android/build.gradle
@@ -89,7 +89,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'com.google.ar:core:1.14.0'
+    implementation 'com.google.ar:core:1.27.0'
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
**Describe the change**

ARCore < 1.19 seems to have some compatibility issues with Android API level 30+. Also, newer versions of ARCore don't have any API breaking changes and bring performance improvements and bug fixes. So, updating to the latest. Note I'm not updating the ARCore submodule which contains the C API as there have been no breaking changes. If we want to use newer ARCore features, we can update the submodule at a later time.

**Screenshots**
N/A

**Documentation**

N/A

**Testing**

Only tested Android since this only affects Android.
