### PR TITLE
Integrate the NativePerformanceLogger BabylonNative lib

### DIFF
--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -144,6 +144,7 @@
         $(BabylonNativeBuildDir)\Plugins\NativeEngine\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeInput\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeOptimizations\$(Configuration);
+        $(BabylonNativeBuildDir)\Plugins\NativePerformanceLogger\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeXr\$(Configuration);
         $(BabylonNativeBuildDir)\Polyfills\Window\$(Configuration);
         $(BabylonNativeBuildDir)\Polyfills\XMLHttpRequest\$(Configuration);
@@ -191,6 +192,7 @@
         NativeEngine.lib;
         NativeInput.lib;
         NativeOptimizations.lib;
+        NativePerformanceLogger.lib;
         NativeXr.lib;
         nvtt.lib;
         OGLCompilerd.lib;
@@ -249,6 +251,7 @@
         NativeEngine.lib;
         NativeInput.lib;
         NativeOptimizations.lib;
+        NativePerformanceLogger.lib;
         NativeXr.lib;
         nvtt.lib;
         OGLCompiler.lib;

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -144,7 +144,7 @@
         $(BabylonNativeBuildDir)\Plugins\NativeEngine\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeInput\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeOptimizations\$(Configuration);
-        $(BabylonNativeBuildDir)\Plugins\NativePerformanceLogger\$(Configuration);
+        $(BabylonNativeBuildDir)\Plugins\NativeTracing\$(Configuration);
         $(BabylonNativeBuildDir)\Plugins\NativeXr\$(Configuration);
         $(BabylonNativeBuildDir)\Polyfills\Window\$(Configuration);
         $(BabylonNativeBuildDir)\Polyfills\XMLHttpRequest\$(Configuration);
@@ -192,7 +192,7 @@
         NativeEngine.lib;
         NativeInput.lib;
         NativeOptimizations.lib;
-        NativePerformanceLogger.lib;
+        NativeTracing.lib;
         NativeXr.lib;
         nvtt.lib;
         OGLCompilerd.lib;
@@ -251,7 +251,7 @@
         NativeEngine.lib;
         NativeInput.lib;
         NativeOptimizations.lib;
-        NativePerformanceLogger.lib;
+        NativeTracing.lib;
         NativeXr.lib;
         nvtt.lib;
         OGLCompiler.lib;

--- a/Modules/@babylonjs/react-native-windows/windows/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native-windows/windows/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(BabylonNative
     NativeEngine
     NativeInput
     NativeOptimizations
+    NativePerformanceLogger
     NativeXr
     Window
     XMLHttpRequest

--- a/Modules/@babylonjs/react-native-windows/windows/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native-windows/windows/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(BabylonNative
     NativeEngine
     NativeInput
     NativeOptimizations
-    NativePerformanceLogger
+    NativeTracing
     NativeXr
     Window
     XMLHttpRequest

--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -79,6 +79,7 @@ target_link_libraries(BabylonNative
     NativeEngine
     NativeInput
     NativeOptimizations
+    NativePerformanceLogger
     NativeXr
     Window
     XMLHttpRequest

--- a/Modules/@babylonjs/react-native/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/android/CMakeLists.txt
@@ -79,7 +79,7 @@ target_link_libraries(BabylonNative
     NativeEngine
     NativeInput
     NativeOptimizations
-    NativePerformanceLogger
+    NativeTracing
     NativeXr
     Window
     XMLHttpRequest

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(BabylonNative
     NativeEngine
     NativeInput
     NativeOptimizations
-    NativePerformanceLogger
+    NativeTracing
     NativeXr
     Window
     XMLHttpRequest

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(BabylonNative
     NativeEngine
     NativeInput
     NativeOptimizations
+    NativePerformanceLogger
     NativeXr
     Window
     XMLHttpRequest

--- a/Modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
                 'NativeEngine',
                 'NativeInput',
                 'NativeOptimizations',
-                'NativePerformanceLogger',
+                'NativeTracing',
                 'NativeXR',
                 'SPIRV',
                 'spirv-cross-core',

--- a/Modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
                 'NativeEngine',
                 'NativeInput',
                 'NativeOptimizations',
+                'NativePerformanceLogger',
                 'NativeXR',
                 'SPIRV',
                 'spirv-cross-core',

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -6,6 +6,7 @@
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/NativeInput.h>
 #include <Babylon/Plugins/NativeOptimizations.h>
+#include <Babylon/Plugins/NativePerformanceLogger.h>
 #include <Babylon/Plugins/NativeXr.h>
 #include <Babylon/Polyfills/Window.h>
 #include <Babylon/Polyfills/XMLHttpRequest.h>
@@ -50,6 +51,7 @@ namespace Babylon
             Plugins::NativeCapture::Initialize(m_env);
             m_nativeInput = &Plugins::NativeInput::CreateForJavaScript(m_env);
             Plugins::NativeOptimizations::Initialize(m_env);
+            Plugins::NativePerformanceLogger::Initialize(m_env);
 
             // Initialize Babylon Native polyfills
             Polyfills::Window::Initialize(m_env);

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -6,7 +6,7 @@
 #include <Babylon/Plugins/NativeEngine.h>
 #include <Babylon/Plugins/NativeInput.h>
 #include <Babylon/Plugins/NativeOptimizations.h>
-#include <Babylon/Plugins/NativePerformanceLogger.h>
+#include <Babylon/Plugins/NativeTracing.h>
 #include <Babylon/Plugins/NativeXr.h>
 #include <Babylon/Polyfills/Window.h>
 #include <Babylon/Polyfills/XMLHttpRequest.h>
@@ -51,7 +51,7 @@ namespace Babylon
             Plugins::NativeCapture::Initialize(m_env);
             m_nativeInput = &Plugins::NativeInput::CreateForJavaScript(m_env);
             Plugins::NativeOptimizations::Initialize(m_env);
-            Plugins::NativePerformanceLogger::Initialize(m_env);
+            Plugins::NativeTracing::Initialize(m_env);
 
             // Initialize Babylon Native polyfills
             Polyfills::Window::Initialize(m_env);

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -473,7 +473,7 @@ const validate = async () => {
     'Assembled/ios/libs/libNativeEngine.a',
     'Assembled/ios/libs/libNativeInput.a',
     'Assembled/ios/libs/libNativeOptimizations.a',
-    'Assembled/ios/libs/libNativePerformanceLogger.a',
+    'Assembled/ios/libs/libNativeTracing.a',
     'Assembled/ios/libs/libNativeXr.a',
     'Assembled/ios/libs/libOGLCompiler.a',
     'Assembled/ios/libs/libOSDependent.a',

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -473,6 +473,7 @@ const validate = async () => {
     'Assembled/ios/libs/libNativeEngine.a',
     'Assembled/ios/libs/libNativeInput.a',
     'Assembled/ios/libs/libNativeOptimizations.a',
+    'Assembled/ios/libs/libNativePerformanceLogger.a',
     'Assembled/ios/libs/libNativeXr.a',
     'Assembled/ios/libs/libOGLCompiler.a',
     'Assembled/ios/libs/libOSDependent.a',

--- a/Package/iOS/CMakeLists.txt
+++ b/Package/iOS/CMakeLists.txt
@@ -21,7 +21,7 @@ set(PACKAGED_LIBS
     NativeEngine
     NativeInput
     NativeOptimizations
-    NativePerformanceLogger
+    NativeTracing
     NativeXr
     SPIRV
     spirv-cross-core

--- a/Package/iOS/CMakeLists.txt
+++ b/Package/iOS/CMakeLists.txt
@@ -21,6 +21,7 @@ set(PACKAGED_LIBS
     NativeEngine
     NativeInput
     NativeOptimizations
+    NativePerformanceLogger
     NativeXr
     SPIRV
     spirv-cross-core


### PR DESCRIPTION
**Describe the change**

This change pulls in the `NativePerformanceLogger` plugin to make performance profiling easier.

**Screenshots**

See: https://github.com/BabylonJS/BabylonNative/pull/944

**Documentation**

No, this is a "private API" for now. Ideally it should be exposed through Babylon.js, probably `Tools.StartPerformanceCounter`/`Tools.EndPerformanceCounter`/`Tools.PerformanceLogLevel`, but that will be a bit more work.

**Testing**

So far I've only tested on iOS. I will do more testing and update this comment before merging.
