### PR TITLE
Update babylon native downgrade arcore

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,8 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
           cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
+      - name: Setup npm
+        run: npm install -g npm@6.13
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
@@ -35,6 +37,8 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
+      - name: Setup npm
+        run: npm install -g npm@6.13
       - name: NPM Install (Playground)
         run: npm install
         working-directory: ./Apps/Playground
@@ -56,6 +60,8 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
           cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
+      - name: Setup npm
+        run: npm install -g npm@6.13
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
@@ -85,6 +91,8 @@ jobs:
         uses: nuget/setup-nuget@v1
         with:
           nuget-version: '5.x'
+      - name: Setup npm
+        run: npm install -g npm@6.13
       - name: NPM Install (Playground)
         run: npm install
         working-directory: ./Apps/Playground

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,8 +16,6 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
           cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
-      - name: Setup npm
-        run: npm install -g npm@6.13
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
@@ -37,8 +35,6 @@ jobs:
         uses: actions/checkout@v2.3.3
         with:
           submodules: 'recursive'
-      - name: Setup npm
-        run: npm install -g npm@6.13
       - name: NPM Install (Playground)
         run: npm install
         working-directory: ./Apps/Playground
@@ -60,8 +56,6 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
           cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
-      - name: Setup npm
-        run: npm install -g npm@6.13
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
@@ -91,8 +85,6 @@ jobs:
         uses: nuget/setup-nuget@v1
         with:
           nuget-version: '5.x'
-      - name: Setup npm
-        run: npm install -g npm@6.13
       - name: NPM Install (Playground)
         run: npm install
         working-directory: ./Apps/Playground

--- a/Apps/Playground/scripts/tools.js
+++ b/Apps/Playground/scripts/tools.js
@@ -10,8 +10,8 @@ function iosCmake() {
 function postInstall() {
   const version = shelljs.exec('npm --version', {silent: true});
 
-  if (!version.trim().match(/8\.\d+\.\d+/g)) {
-    throw `Error: BabylonReactNative Playground development requires npm version 8.*, Your current npm version is ${version}. Run npm install -g npm@8 to update your npm version.`;
+  if (!version.trim().match(/6\.\d+\.\d+/g)) {
+    throw `Error: BabylonReactNative Playground development requires npm version 6.13.*, Your current npm version is ${version}. Run npm install -g npm@6.13 to update your npm version.`;
   }
 
   console.log(chalk.black.bgCyan('Installing Babylon React Native npm packages...'));

--- a/Apps/Playground/scripts/tools.js
+++ b/Apps/Playground/scripts/tools.js
@@ -10,8 +10,8 @@ function iosCmake() {
 function postInstall() {
   const version = shelljs.exec('npm --version', {silent: true});
 
-  if (!version.trim().match(/6\.\d+\.\d+/g)) {
-    throw `Error: BabylonReactNative Playground development requires npm version 6.13.*, Your current npm version is ${version}. Run npm install -g npm@6.13 to update your npm version.`;
+  if (!version.trim().match(/8\.\d+\.\d+/g)) {
+    throw `Error: BabylonReactNative Playground development requires npm version 8.*, Your current npm version is ${version}. Run npm install -g npm@8 to update your npm version.`;
   }
 
   console.log(chalk.black.bgCyan('Installing Babylon React Native npm packages...'));

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -175,6 +175,7 @@
         BabylonNative.lib;
         bgfx.lib;
         bimg.lib;
+        tinyexr.lib;
         bx.lib;
         Canvas.lib;
         edtaa3.lib;
@@ -234,6 +235,7 @@
         BabylonNative.lib;
         bgfx.lib;
         bimg.lib;
+        tinyexr.lib;
         bx.lib;
         Canvas.lib;
         edtaa3.lib;

--- a/Modules/@babylonjs/react-native/android/build.gradle
+++ b/Modules/@babylonjs/react-native/android/build.gradle
@@ -125,11 +125,11 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'com.google.ar:core:1.27.0'
+    implementation 'com.google.ar:core:1.22.0'
 
     api("com.facebook.fbjni:fbjni-java-only:0.0.3")
 
-    natives 'com.google.ar:core:1.27.0'
+    natives 'com.google.ar:core:1.22.0'
     fbjniHeaders 'com.facebook.fbjni:fbjni:0.0.2:headers'
     fbjniLibs 'com.facebook.fbjni:fbjni:0.0.2'
 }

--- a/Package/Android/build.gradle
+++ b/Package/Android/build.gradle
@@ -89,7 +89,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'com.google.ar:core:1.27.0'
+    implementation 'com.google.ar:core:1.22.0'
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
Update BabylonNative to include ARCore auto-focus fix ([#937](https://github.com/BabylonJS/BabylonNative/pull/937)).
Requires downgrading ARCore to v1.22 (breaking auto focus change noticed in v1.23 and above) 

**Testing**

- [x] Pixel 4
