### PR TITLE
Add tinyexr to list of libs to link for iOS

### DIFF
--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -43,6 +43,7 @@
     "@types/jest": "^25.2.1",
     "@types/react": "^16.9.32",
     "@types/react-native": "^0.63.1",
+    "@types/react-native-permissions": "^2.0.0",
     "@types/react-test-renderer": "^16.9.2",
     "@types/semver": "^7.3.4",
     "eslint": "7.12.0",

--- a/Modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
                 'spirv-cross-glsl',
                 'spirv-cross-hlsl',
                 'spirv-cross-msl',
+                'tinyexr',
                 'UrlLib',
                 'Window',
                 'XMLHttpRequest',

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -482,6 +482,7 @@ const validate = async () => {
     'Assembled/ios/libs/libspirv-cross-hlsl.a',
     'Assembled/ios/libs/libspirv-cross-msl.a',
     'Assembled/ios/libs/libSPIRV.a',
+    'Assembled/ios/libs/libtinyexr.a',
     'Assembled/ios/libs/libUrlLib.a',
     'Assembled/ios/libs/libWindow.a',
     'Assembled/ios/libs/libXMLHttpRequest.a',

--- a/Package/iOS/CMakeLists.txt
+++ b/Package/iOS/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PACKAGED_LIBS
     spirv-cross-glsl
     spirv-cross-hlsl
     spirv-cross-msl
+    tinyexr
     UrlLib
     Window
     XMLHttpRequest


### PR DESCRIPTION
**Describe the change**

With a recent update to bgfx a new dependency (tinyexr) was introduced. This dependency got added for Windows, but not for iOS. This change just adds this new dependency to fix Playground and the BRN NPM package.

**Screenshots**

N/A

**Documentation**

N/A

**Testing**

Tested iOS (the only platform affected by these changes).
