### PR TITLE
Fix a few minor build related issues

### DIFF
--- a/Apps/Playground/0.64/ios/Podfile.lock
+++ b/Apps/Playground/0.64/ios/Podfile.lock
@@ -366,7 +366,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
-  - "react-native-babylon (from `../../../Modules/@babylonjs/react-native`)"
+  - "react-native-babylon (from `../../../../Modules/@babylonjs/react-native`)"
   - "react-native-slider (from `../node_modules/@react-native-community/slider`)"
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -432,7 +432,7 @@ EXTERNAL SOURCES:
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-babylon:
-    :path: "../../../Modules/@babylonjs/react-native"
+    :path: "../../../../Modules/@babylonjs/react-native"
   react-native-slider:
     :path: "../node_modules/@react-native-community/slider"
   React-perflogger:
@@ -469,7 +469,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 1bd5828a2fe244ae5237884ef2d1b7cca26d1599
+  FBReactNativeSpec: 4306a04f6bbd042a5f1fb7e885c366da7257689d
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -492,7 +492,7 @@ SPEC CHECKSUMS:
   React-jsi: 5de8204706bd872b78ea646aee5d2561ca1214b6
   React-jsiexecutor: 124e8f99992490d0d13e0649d950d3e1aae06fe9
   React-jsinspector: 500a59626037be5b3b3d89c5151bc3baa9abf1a9
-  react-native-babylon: b5496ddaa5c53c76791a34ce50751802153e1b5e
+  react-native-babylon: 018c7aab746addac3f3549cd95bb78ca81e824f3
   react-native-slider: ae891b9fca8c9b4a99691f6d45731f0ef2bb1866
   React-perflogger: aad6d4b4a267936b3667260d1f649b6f6069a675
   React-RCTActionSheet: fc376be462c9c8d6ad82c0905442fd77f82a9d2a

--- a/Apps/Playground/0.64/package-lock.json
+++ b/Apps/Playground/0.64/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@babylonjs/core": "5.0.0-alpha.65",
         "@babylonjs/loaders": "5.0.0-alpha.65",
+        "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
         "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",
-        "@babylonjs/playground-shared": "file:../playground-shared",
         "@react-native-community/slider": "4.0.0-rc.3",
         "logkitty": "^0.7.1",
         "react": "^17.0.1",
@@ -44,10 +44,6 @@
         "shelljs": "^0.8.4",
         "typescript": "^4.3.5"
       }
-    },
-    "../playground-shared": {
-      "version": "0.0.1",
-      "license": "MIT"
     },
     "../../../Modules/@babylonjs/react-native": {
       "version": "0.0.1",
@@ -147,6 +143,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "../playground-shared": {
+      "version": "0.0.1",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -1279,6 +1279,10 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@babylonjs/playground-shared": {
+      "resolved": "../playground-shared",
+      "link": true
     },
     "node_modules/@babylonjs/react-native": {
       "resolved": "../../../Modules/@babylonjs/react-native",
@@ -17228,6 +17232,9 @@
           "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
+    },
+    "@babylonjs/playground-shared": {
+      "version": "file:../playground-shared"
     },
     "@babylonjs/react-native": {
       "version": "file:../../../Modules/@babylonjs/react-native",

--- a/Modules/@babylonjs/react-native/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native/react-native-babylon.podspec
@@ -40,7 +40,6 @@ Pod::Spec.new do |s|
                 'SPIRV',
                 'spirv-cross-core',
                 'spirv-cross-glsl',
-                'spirv-cross-hlsl',
                 'spirv-cross-msl',
                 'tinyexr',
                 'UrlLib',


### PR DESCRIPTION
**Describe the change**

A few minor issues snuck in with some recent changes:
1. Podfile.lock had the wrong relative path to pull in the BRN module. It is auto-updated by the `pod install` command, but then you have a pending change in the lock file, so I'm just checking it in with the right path.
2. package-lock.json had a few minor things that changed with a clean `npm install`, so also just checking these in.
3. spirv-cross-hlsl was removed, but was missed in the podspec, which causes a linker error on a clean build of the Playground, so removing it.

**Screenshots**

N/A

**Documentation**

N/A

**Testing**

Only iOS should be affected, and I did a quick smoke test on iOS (not thorough testing since the changes are really minimal).
