### PR TITLE
Try changing Windows to use older build pool with 10.0.18362 SDK

### DIFF
--- a/.github/workflows/bn_master_commit.yml
+++ b/.github/workflows/bn_master_commit.yml
@@ -64,7 +64,7 @@ jobs:
 
   build-windows:
     name: Build Windows ${{ matrix.platform }} ${{ matrix.config }} - BabylonNative ${{ github.event.client_payload.sha }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         platform: [x86, x64, ARM, ARM64]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,7 +80,7 @@ jobs:
         working-directory: ./Package
 
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         platform: [x86, x64, ARM64]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           path: Package/Assembled
 
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: select-react-native-version
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
**Describe the change**

Windows builds are currently failing due to the 10.0.18362.0 SDK not being available. A recent change to the Windows agents removed this SDK. This change tries to switch us to using an older build agent that still has the SDK available while we work on migrating the projects to use a newer version of the WinSDK.
