### PR TITLE
deps: lock @babylonjs/core version #354

### DIFF
--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-alpha.65",
+    "@babylonjs/core": "5.0.0-beta.11",
     "react": ">=16.13.1",
     "react-native": ">=0.63.1",
     "react-native-permissions": "^2.1.4"
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "5.0.0-alpha.65",
+    "@babylonjs/core": "5.0.0-beta.11",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",


### PR DESCRIPTION
**Describe the change**

Locks the last version of @bablonjs/core that works with this package. Fixes #354.
