### PR TITLE
fix Windows deployment

### DIFF
--- a/Apps/Playground/0.64/windows/Playground/Playground.vcxproj
+++ b/Apps/Playground/0.64/windows/Playground/Playground.vcxproj
@@ -26,6 +26,10 @@
   <PropertyGroup Label="UserMacros">
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)..\..\0.64\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
+  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>

--- a/Apps/Playground/0.64/windows/Playground/Playground.vcxproj
+++ b/Apps/Playground/0.64/windows/Playground/Playground.vcxproj
@@ -26,7 +26,13 @@
   <PropertyGroup Label="UserMacros">
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)..\..\0.64\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)..\..\0.64\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)..\..\0.64\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
@@ -104,11 +110,23 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Link>
+      <AllowIsolation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</AllowIsolation>
+    </Link>
+    <Link>
+      <UACUIAccess Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</UACUIAccess>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Link>
+      <AllowIsolation Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</AllowIsolation>
+    </Link>
+    <Link>
+      <UACUIAccess Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</UACUIAccess>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="MainPage.h">

--- a/Apps/Playground/0.64/windows/Playground/Playground.vcxproj
+++ b/Apps/Playground/0.64/windows/Playground/Playground.vcxproj
@@ -26,7 +26,6 @@
   <PropertyGroup Label="UserMacros">
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
-  </PropertyGroup>
   <PropertyGroup>
     <OutDir>$(SolutionDir)..\..\0.64\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>

--- a/Apps/Playground/0.64/windows/Playground/Playground.vcxproj
+++ b/Apps/Playground/0.64/windows/Playground/Playground.vcxproj
@@ -110,23 +110,11 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
-    <Link>
-      <AllowIsolation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</AllowIsolation>
-    </Link>
-    <Link>
-      <UACUIAccess Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</UACUIAccess>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
-    <Link>
-      <AllowIsolation Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</AllowIsolation>
-    </Link>
-    <Link>
-      <UACUIAccess Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</UACUIAccess>
-    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="MainPage.h">

--- a/Apps/Playground/0.65/windows/playground/playground.vcxproj
+++ b/Apps/Playground/0.65/windows/playground/playground.vcxproj
@@ -79,7 +79,13 @@
   <PropertyGroup Label="UserMacros">
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)..\..\0.65\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)..\..\0.65\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)..\..\0.65\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/Apps/Playground/0.65/windows/playground/playground.vcxproj
+++ b/Apps/Playground/0.65/windows/playground/playground.vcxproj
@@ -79,6 +79,9 @@
   <PropertyGroup Label="UserMacros">
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
   </PropertyGroup>
+  <PropertyGroup>
+    <OutDir>$(SolutionDir)..\..\0.65\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\</OutDir>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/Apps/Playground/README.md
+++ b/Apps/Playground/README.md
@@ -98,6 +98,12 @@ Disable use of webDebugger in `Apps.cpp` because BabylonReactNative accesses the
 InstanceSettings().UseWebDebugger(false);
 ```
 
+Because of a symlink, deployment is not allowed for UWP. Change the output directory to the effective folder instead. This can be done in the Project properties->General->Output directory.
+For example, it is for React Native 0.65:
+```
+$(SolutionDir)..\..\0.65\windows\$(Platform)\$(Configuration)\$(MSBuildProjectName)\
+```
+
 ## Update toolchain scripts
 
 Build tools must be updated to reflect new version of React Native support (or removal).


### PR DESCRIPTION
fixes #347 
deployment output directory must not contain a symlink. To fix it, the output directory is changed to be the effective one.
Documentation on how to add a new React Native has been updated.

Build and run/debug works in VS2019. 