### PR TITLE
Update to rc.12

### DIFF
--- a/Apps/PackageTest/0.63.1/package-lock.json
+++ b/Apps/PackageTest/0.63.1/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PackageTest",
       "version": "0.0.1",
       "dependencies": {
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@babylonjs/react-native": "^0.4.0-alpha.47",
         "react": "16.13.1",
         "react-native": "0.63.1",
@@ -1379,14 +1379,11 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "dependencies": {
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.x"
       }
     },
     "node_modules/@babylonjs/react-native": {
@@ -16383,9 +16380,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/Apps/PackageTest/0.63.1/package.json
+++ b/Apps/PackageTest/0.63.1/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "5.0.0-rc.4",
+    "@babylonjs/core": "5.0.0-rc.12",
     "@babylonjs/react-native": "^0.4.0-alpha.47",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/PackageTest/0.64.0/package-lock.json
+++ b/Apps/PackageTest/0.64.0/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PackageTest",
       "version": "0.0.1",
       "dependencies": {
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@babylonjs/react-native": "^0.4.0-alpha.47",
         "@babylonjs/react-native-windows": "^0.4.0-alpha.47",
         "react": "^17.0.1",
@@ -1415,14 +1415,11 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "dependencies": {
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.x"
       }
     },
     "node_modules/@babylonjs/core/node_modules/tslib": {
@@ -18044,9 +18041,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "requires": {
         "tslib": "^2.3.1"
       },

--- a/Apps/PackageTest/0.64.0/package.json
+++ b/Apps/PackageTest/0.64.0/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "5.0.0-rc.4",
+    "@babylonjs/core": "5.0.0-rc.12",
     "@babylonjs/react-native": "^0.4.0-alpha.47",
     "@babylonjs/react-native-windows": "^0.4.0-alpha.47",
     "react": "^17.0.1",

--- a/Apps/Playground/0.64/package-lock.json
+++ b/Apps/Playground/0.64/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@babylonjs/core": "5.0.0-rc.4",
-        "@babylonjs/loaders": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
+        "@babylonjs/loaders": "5.0.0-rc.12",
         "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
+        "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
         "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",
         "@react-native-community/slider": "4.0.0-rc.3",
         "logkitty": "^0.7.1",
@@ -55,7 +56,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -72,10 +73,33 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
-        "react-native-permissions": "^2.1.4"
+        "react-native-permissions": "^3.0.0"
+      }
+    },
+    "../../../Modules/@babylonjs/react-native-iosandroid": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "semver": "^7.3.2"
+      },
+      "devDependencies": {
+        "@rnw-scripts/eslint-config": "0.1.6",
+        "@rnw-scripts/ts-config": "0.1.0",
+        "eslint": "7.12.0",
+        "just-scripts": "^0.44.7",
+        "metro-react-native-babel-preset": "^0.56.0",
+        "prettier": "1.19.1",
+        "typescript": "^4.3.5"
+      },
+      "peerDependencies": {
+        "@babylonjs/react-native": "version",
+        "react": ">=16.13.1",
+        "react-native": ">=0.63.1",
+        "react-native-permissions": "^3.0.0"
       }
     },
     "../../../Modules/@babylonjs/react-native-windows": {
@@ -84,7 +108,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -102,7 +126,7 @@
         "typescript": "^3.8.3"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
         "@babylonjs/react-native": "version",
         "react": "^17.0.1",
         "react-native": "^0.64.0",
@@ -1248,14 +1272,11 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "dependencies": {
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.x"
       }
     },
     "node_modules/@babylonjs/core/node_modules/tslib": {
@@ -1264,16 +1285,13 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-rc.4.tgz",
-      "integrity": "sha512-bJ6o2FujmbzthZ0cnedoqO+0871bc72f40qdQaxNqRiDnl3dPKKpKALQHXLA4oBwpOAKa+YhYI8eDCjJbiiBug==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-rc.12.tgz",
+      "integrity": "sha512-ffnjDjTnJo8QeUgS7+QAkCF3DMUcG+ziGyVr8bxOVR5lWRl+pJdrwRkQp4+BMKi8BQe12/seH+fSe7ZaYFOarA==",
       "dependencies": {
-        "@babylonjs/core": "5.0.0-rc.4",
-        "babylonjs-gltf2interface": "5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
+        "babylonjs-gltf2interface": "^5.0.0-rc.12",
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@babylonjs/loaders/node_modules/tslib": {
@@ -1287,6 +1305,10 @@
     },
     "node_modules/@babylonjs/react-native": {
       "resolved": "../../../Modules/@babylonjs/react-native",
+      "link": true
+    },
+    "node_modules/@babylonjs/react-native-iosandroid": {
+      "resolved": "../../../Modules/@babylonjs/react-native-iosandroid",
       "link": true
     },
     "node_modules/@babylonjs/react-native-windows": {
@@ -5849,12 +5871,9 @@
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-rc.4.tgz",
-      "integrity": "sha512-nnfPAkH/MsYRgfFfmHqyZ1I/GH5/lSZcJB8YsNTjgeeXBrT5Ti9KsNunFs6c//xwLVN9JgwGQTIAPNRuOX5qVw==",
-      "engines": {
-        "node": "*"
-      }
+      "version": "5.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-rc.13.tgz",
+      "integrity": "sha512-Ljibp/V3pbmHDYFLK+8QnZ5gegAucaJigreQPKKbLIgXbdmQDKqo5ik7uBBGQO01ahl3s/+6rbZbGglL+D5VuA=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -17203,9 +17222,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "requires": {
         "tslib": "^2.3.1"
       },
@@ -17218,12 +17237,12 @@
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-rc.4.tgz",
-      "integrity": "sha512-bJ6o2FujmbzthZ0cnedoqO+0871bc72f40qdQaxNqRiDnl3dPKKpKALQHXLA4oBwpOAKa+YhYI8eDCjJbiiBug==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-rc.12.tgz",
+      "integrity": "sha512-ffnjDjTnJo8QeUgS7+QAkCF3DMUcG+ziGyVr8bxOVR5lWRl+pJdrwRkQp4+BMKi8BQe12/seH+fSe7ZaYFOarA==",
       "requires": {
-        "@babylonjs/core": "5.0.0-rc.4",
-        "babylonjs-gltf2interface": "5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
+        "babylonjs-gltf2interface": "^5.0.0-rc.12",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -17242,7 +17261,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -17289,12 +17308,26 @@
         }
       }
     },
+    "@babylonjs/react-native-iosandroid": {
+      "version": "file:../../../Modules/@babylonjs/react-native-iosandroid",
+      "requires": {
+        "@rnw-scripts/eslint-config": "0.1.6",
+        "@rnw-scripts/ts-config": "0.1.0",
+        "base-64": "^0.1.0",
+        "eslint": "7.12.0",
+        "just-scripts": "^0.44.7",
+        "metro-react-native-babel-preset": "^0.56.0",
+        "prettier": "1.19.1",
+        "semver": "^7.3.2",
+        "typescript": "^4.3.5"
+      }
+    },
     "@babylonjs/react-native-windows": {
       "version": "file:../../../Modules/@babylonjs/react-native-windows",
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -20970,9 +21003,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-rc.4.tgz",
-      "integrity": "sha512-nnfPAkH/MsYRgfFfmHqyZ1I/GH5/lSZcJB8YsNTjgeeXBrT5Ti9KsNunFs6c//xwLVN9JgwGQTIAPNRuOX5qVw=="
+      "version": "5.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-rc.13.tgz",
+      "integrity": "sha512-Ljibp/V3pbmHDYFLK+8QnZ5gegAucaJigreQPKKbLIgXbdmQDKqo5ik7uBBGQO01ahl3s/+6rbZbGglL+D5VuA=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/0.64/package.json
+++ b/Apps/Playground/0.64/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "5.0.0-rc.4",
-    "@babylonjs/loaders": "5.0.0-rc.4",
+    "@babylonjs/core": "5.0.0-rc.12",
+    "@babylonjs/loaders": "5.0.0-rc.12",
     "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
     "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",

--- a/Apps/Playground/0.65/package-lock.json
+++ b/Apps/Playground/0.65/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@babylonjs/core": "5.0.0-rc.4",
-        "@babylonjs/loaders": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
+        "@babylonjs/loaders": "5.0.0-rc.12",
         "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
+        "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
         "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",
         "@react-native-community/slider": "^4.0.0-rc.3",
         "react": "17.0.2",
@@ -49,7 +50,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -66,10 +67,33 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
-        "react-native-permissions": "^2.1.4"
+        "react-native-permissions": "^3.0.0"
+      }
+    },
+    "../../../Modules/@babylonjs/react-native-iosandroid": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "semver": "^7.3.2"
+      },
+      "devDependencies": {
+        "@rnw-scripts/eslint-config": "0.1.6",
+        "@rnw-scripts/ts-config": "0.1.0",
+        "eslint": "7.12.0",
+        "just-scripts": "^0.44.7",
+        "metro-react-native-babel-preset": "^0.56.0",
+        "prettier": "1.19.1",
+        "typescript": "^4.3.5"
+      },
+      "peerDependencies": {
+        "@babylonjs/react-native": "version",
+        "react": ">=16.13.1",
+        "react-native": ">=0.63.1",
+        "react-native-permissions": "^3.0.0"
       }
     },
     "../../../Modules/@babylonjs/react-native-windows": {
@@ -78,7 +102,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -96,7 +120,7 @@
         "typescript": "^3.8.3"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
         "@babylonjs/react-native": "version",
         "react": "^17.0.1",
         "react-native": "^0.64.0",
@@ -7011,27 +7035,21 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "dependencies": {
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.x"
       }
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-rc.4.tgz",
-      "integrity": "sha512-bJ6o2FujmbzthZ0cnedoqO+0871bc72f40qdQaxNqRiDnl3dPKKpKALQHXLA4oBwpOAKa+YhYI8eDCjJbiiBug==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-rc.12.tgz",
+      "integrity": "sha512-ffnjDjTnJo8QeUgS7+QAkCF3DMUcG+ziGyVr8bxOVR5lWRl+pJdrwRkQp4+BMKi8BQe12/seH+fSe7ZaYFOarA==",
       "dependencies": {
-        "@babylonjs/core": "5.0.0-rc.4",
-        "babylonjs-gltf2interface": "5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
+        "babylonjs-gltf2interface": "^5.0.0-rc.12",
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@babylonjs/playground-shared": {
@@ -7040,6 +7058,10 @@
     },
     "node_modules/@babylonjs/react-native": {
       "resolved": "../../../Modules/@babylonjs/react-native",
+      "link": true
+    },
+    "node_modules/@babylonjs/react-native-iosandroid": {
+      "resolved": "../../../Modules/@babylonjs/react-native-iosandroid",
       "link": true
     },
     "node_modules/@babylonjs/react-native-windows": {
@@ -9310,12 +9332,9 @@
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-rc.4.tgz",
-      "integrity": "sha512-nnfPAkH/MsYRgfFfmHqyZ1I/GH5/lSZcJB8YsNTjgeeXBrT5Ti9KsNunFs6c//xwLVN9JgwGQTIAPNRuOX5qVw==",
-      "engines": {
-        "node": "*"
-      }
+      "version": "5.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-rc.13.tgz",
+      "integrity": "sha512-Ljibp/V3pbmHDYFLK+8QnZ5gegAucaJigreQPKKbLIgXbdmQDKqo5ik7uBBGQO01ahl3s/+6rbZbGglL+D5VuA=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -18430,20 +18449,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-rc.4.tgz",
-      "integrity": "sha512-bJ6o2FujmbzthZ0cnedoqO+0871bc72f40qdQaxNqRiDnl3dPKKpKALQHXLA4oBwpOAKa+YhYI8eDCjJbiiBug==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0-rc.12.tgz",
+      "integrity": "sha512-ffnjDjTnJo8QeUgS7+QAkCF3DMUcG+ziGyVr8bxOVR5lWRl+pJdrwRkQp4+BMKi8BQe12/seH+fSe7ZaYFOarA==",
       "requires": {
-        "@babylonjs/core": "5.0.0-rc.4",
-        "babylonjs-gltf2interface": "5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
+        "babylonjs-gltf2interface": "^5.0.0-rc.12",
         "tslib": "^2.3.1"
       }
     },
@@ -18455,7 +18474,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -21776,12 +21795,26 @@
         }
       }
     },
+    "@babylonjs/react-native-iosandroid": {
+      "version": "file:../../../Modules/@babylonjs/react-native-iosandroid",
+      "requires": {
+        "@rnw-scripts/eslint-config": "0.1.6",
+        "@rnw-scripts/ts-config": "0.1.0",
+        "base-64": "^0.1.0",
+        "eslint": "7.12.0",
+        "just-scripts": "^0.44.7",
+        "metro-react-native-babel-preset": "^0.56.0",
+        "prettier": "1.19.1",
+        "semver": "^7.3.2",
+        "typescript": "^4.3.5"
+      }
+    },
     "@babylonjs/react-native-windows": {
       "version": "file:../../../Modules/@babylonjs/react-native-windows",
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -23370,9 +23403,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-rc.4.tgz",
-      "integrity": "sha512-nnfPAkH/MsYRgfFfmHqyZ1I/GH5/lSZcJB8YsNTjgeeXBrT5Ti9KsNunFs6c//xwLVN9JgwGQTIAPNRuOX5qVw=="
+      "version": "5.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0-rc.13.tgz",
+      "integrity": "sha512-Ljibp/V3pbmHDYFLK+8QnZ5gegAucaJigreQPKKbLIgXbdmQDKqo5ik7uBBGQO01ahl3s/+6rbZbGglL+D5VuA=="
     },
     "balanced-match": {
       "version": "1.0.2"

--- a/Apps/Playground/0.65/package.json
+++ b/Apps/Playground/0.65/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "5.0.0-rc.4",
-    "@babylonjs/loaders": "5.0.0-rc.4",
+    "@babylonjs/core": "5.0.0-rc.12",
+    "@babylonjs/loaders": "5.0.0-rc.12",
     "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
     "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",

--- a/Modules/@babylonjs/react-native-windows/package.json
+++ b/Modules/@babylonjs/react-native-windows/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-rc.4",
+    "@babylonjs/core": "^5.0.0-rc.12",
     "@babylonjs/react-native": "version",
     "react": "^17.0.1",
     "react-native": "^0.64.0",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "5.0.0-rc.4",
+    "@babylonjs/core": "5.0.0-rc.12",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",

--- a/Modules/@babylonjs/react-native/package-lock.json
+++ b/Modules/@babylonjs/react-native/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.4",
+        "@babylonjs/core": "5.0.0-rc.12",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -32,10 +32,10 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0-rc.4",
+        "@babylonjs/core": "^5.0.0-rc.12",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
-        "react-native-permissions": "^2.1.4"
+        "react-native-permissions": "^3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -296,13 +296,13 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.17.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
-      "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "@babel/template": "^7.16.7",
@@ -362,11 +362,11 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.17.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1244,13 +1244,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
-      "integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.8.tgz",
+      "integrity": "sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==",
       "peer": true,
       "dependencies": {
         "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.17.7",
         "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
@@ -1883,15 +1883,12 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.x"
       }
     },
     "node_modules/@cnakazawa/watch": {
@@ -3164,9 +3161,9 @@
       "dev": true
     },
     "node_modules/@sideway/address": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
-      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
       "peer": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
@@ -4906,19 +4903,23 @@
       "peer": true
     },
     "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "peer": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "peer": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
     },
     "node_modules/diff-match-patch": {
       "version": "1.0.4",
@@ -6410,19 +6411,28 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "peer": true,
       "dependencies": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/ignore": {
@@ -9135,13 +9145,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "peer": true,
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -10004,9 +10014,9 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.4.tgz",
-      "integrity": "sha512-ksrr8y9+nXOxQB2osVNqrgvX/XQPOXaU4BQMKjYq8PvaY1U18mo+fKgBSwzK+luSyinOuPae956lSVcBwxlAMg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
       "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1",
@@ -10248,9 +10258,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-native": {
-      "version": "0.67.3",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.67.3.tgz",
-      "integrity": "sha512-epMVRMRH7dLCis97+YwiV4dmTVZO6qKmQgwcTNcxVt/kEMxAa+OYK7h81+99/n7XCeMFk/U2zYOBuQqc7c5Amg==",
+      "version": "0.67.4",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.67.4.tgz",
+      "integrity": "sha512-NA9d9lNJu9TViEJu2uZxWXUP+QNUilGGA5tdMbVFedNroOH1lnQ3n/FAVoGK1gqGarCgNTtheBxUpEa979Cu8w==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
@@ -10306,12 +10316,18 @@
       }
     },
     "node_modules/react-native-permissions": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-2.2.2.tgz",
-      "integrity": "sha512-ihf4shQDSX5Oo9ChQXb9kr13mmyyNem5MaEvOpr3dCjhBOBWyEMztXm9/uPK1Qg5PsNpaYLa1KpcPZDCw87LXg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.3.1.tgz",
+      "integrity": "sha512-Ap9nVWBWJ7lyU6Ye3Qltm2V+Ut6XjDcs+6ZBmK1UUxcCoSSGx/mQg2GbMJLjlnoVtUgVHR3IhyZ0mN9DlMPRFQ==",
       "peerDependencies": {
-        "react": ">=16.8.6",
-        "react-native": ">=0.60.0"
+        "react": ">=16.13.1",
+        "react-native": ">=0.63.3",
+        "react-native-windows": ">=0.62.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native/node_modules/@jest/types": {
@@ -10954,24 +10970,24 @@
       }
     },
     "node_modules/send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "peer": true,
       "dependencies": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "statuses": "2.0.1"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -11010,6 +11026,27 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "peer": true
     },
+    "node_modules/send/node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
@@ -11020,15 +11057,15 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "peer": true,
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "send": "0.18.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -12247,15 +12284,12 @@
       }
     },
     "node_modules/use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.6.0.tgz",
+      "integrity": "sha512-0Y/cTLlZfw547tJhJMoRA16OUbVqRm6DmvGpiGbmLST6BIA5KU5cKlvlz8DVMrACnWpyEjCkgmhLatthP4jUbA==",
       "peer": true,
-      "dependencies": {
-        "object-assign": "^4.1.1"
-      },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
+        "react": "^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -12834,13 +12868,13 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.17.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
-      "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
       "requires": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "@babel/template": "^7.16.7",
@@ -12885,11 +12919,11 @@
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.17.0"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -13452,13 +13486,13 @@
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
-      "integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.8.tgz",
+      "integrity": "sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==",
       "peer": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.17.7",
         "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
@@ -13900,9 +13934,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.4.tgz",
-      "integrity": "sha512-KJjx+mNbiPjyXor21ykRJEYkuiZ3P9Zz3B2MlwemdKS4TNEDiH3VM3B0LqqKlRiDiX9AF3EFs7moTHbeIII9uQ==",
+      "version": "5.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
+      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
@@ -14922,9 +14956,9 @@
       "dev": true
     },
     "@sideway/address": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
-      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
       "peer": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
@@ -16295,15 +16329,15 @@
       "peer": true
     },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "peer": true
     },
     "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "peer": true
     },
     "diff-match-patch": {
@@ -17463,16 +17497,24 @@
       }
     },
     "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "peer": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "peer": true
+        }
       }
     },
     "ignore": {
@@ -19666,13 +19708,13 @@
       }
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "peer": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime": {
@@ -20319,9 +20361,9 @@
       }
     },
     "plist": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.4.tgz",
-      "integrity": "sha512-ksrr8y9+nXOxQB2osVNqrgvX/XQPOXaU4BQMKjYq8PvaY1U18mo+fKgBSwzK+luSyinOuPae956lSVcBwxlAMg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==",
       "peer": true,
       "requires": {
         "base64-js": "^1.5.1",
@@ -20494,9 +20536,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-native": {
-      "version": "0.67.3",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.67.3.tgz",
-      "integrity": "sha512-epMVRMRH7dLCis97+YwiV4dmTVZO6qKmQgwcTNcxVt/kEMxAa+OYK7h81+99/n7XCeMFk/U2zYOBuQqc7c5Amg==",
+      "version": "0.67.4",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.67.4.tgz",
+      "integrity": "sha512-NA9d9lNJu9TViEJu2uZxWXUP+QNUilGGA5tdMbVFedNroOH1lnQ3n/FAVoGK1gqGarCgNTtheBxUpEa979Cu8w==",
       "peer": true,
       "requires": {
         "@jest/create-cache-key-function": "^27.0.1",
@@ -20634,9 +20676,9 @@
       }
     },
     "react-native-permissions": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-2.2.2.tgz",
-      "integrity": "sha512-ihf4shQDSX5Oo9ChQXb9kr13mmyyNem5MaEvOpr3dCjhBOBWyEMztXm9/uPK1Qg5PsNpaYLa1KpcPZDCw87LXg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.3.1.tgz",
+      "integrity": "sha512-Ap9nVWBWJ7lyU6Ye3Qltm2V+Ut6XjDcs+6ZBmK1UUxcCoSSGx/mQg2GbMJLjlnoVtUgVHR3IhyZ0mN9DlMPRFQ==",
       "requires": {}
     },
     "react-refresh": {
@@ -21054,24 +21096,24 @@
       }
     },
     "send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "peer": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "statuses": "2.0.1"
       },
       "dependencies": {
         "debug": {
@@ -21102,6 +21144,21 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "peer": true
+        },
+        "on-finished": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+          "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+          "peer": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "peer": true
         }
       }
     },
@@ -21112,15 +21169,15 @@
       "peer": true
     },
     "serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "peer": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "send": "0.18.0"
       }
     },
     "set-blocking": {
@@ -22109,13 +22166,11 @@
       "peer": true
     },
     "use-subscription": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.5.1.tgz",
-      "integrity": "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.6.0.tgz",
+      "integrity": "sha512-0Y/cTLlZfw547tJhJMoRA16OUbVqRm6DmvGpiGbmLST6BIA5KU5cKlvlz8DVMrACnWpyEjCkgmhLatthP4jUbA==",
       "peer": true,
-      "requires": {
-        "object-assign": "^4.1.1"
-      }
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0-rc.4",
+    "@babylonjs/core": "^5.0.0-rc.12",
     "react": ">=16.13.1",
     "react-native": ">=0.63.1",
     "react-native-permissions": "^3.0.0"
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "5.0.0-rc.4",
+    "@babylonjs/core": "5.0.0-rc.12",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",


### PR DESCRIPTION
This PR updates BabylonReactNative from using Babylon.js 5.0.0-rc.4 to 5.0.0-rc.12. The purpose of this update is to allow us to keep as up to date with the latest RCs as possible.