### PR TITLE
Preview release with tagged npm packages

### DIFF
--- a/.github/workflows/ios_android_tag.yml
+++ b/.github/workflows/ios_android_tag.yml
@@ -1,0 +1,43 @@
+name: 'build ios-android'
+
+on:
+  workflow_call:
+    inputs:
+      react-native-version:
+        required: true
+        type: string
+      release-version:
+        required: true
+        type: string
+
+jobs:
+  Build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.3.3
+        with:
+          submodules: 'recursive'
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.8
+        with:
+          cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
+      - name: Setup Ninja
+        run: brew install ninja
+      - name: NPM Install (Playground)
+        run: npm install
+        working-directory: ./Apps/Playground
+      - name: Select React Native Version ${{ inputs.react-native-version }}
+        run: npm run select --reactNative ${{ inputs.react-native-version }}
+        working-directory: ./Apps/Playground
+      - name: NPM Install (Binary Package)
+        run: npm install
+        working-directory: ./Package
+      - name: Gulp
+        run: npx gulp --reactNative ${{ inputs.react-native-version }} --releaseVersion ${{ inputs.release-version }}
+        working-directory: ./Package
+      - name: Upload Assembled iOS Android Folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'Assembled-iOSAndroid${{ inputs.react-native-version }}'
+          path: Package/Assembled-iOSAndroid

--- a/.github/workflows/publish_preview.yml
+++ b/.github/workflows/publish_preview.yml
@@ -1,0 +1,124 @@
+name: Publish Package For Preview
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'NPM Release Version'
+        required: true 
+        type: string
+        default: 0.0.1
+      NPM_tag:
+        description: 'NPM Tag'
+        required: true 
+        type: string
+        default: preview
+
+jobs:
+  build-android-ios-064:
+    uses: ./.github/workflows/ios_android_tag.yml
+    with:
+      react-native-version: 0.64
+      release-version: ${{ github.event.inputs.release_version }}
+
+  build-android-ios-065:
+    uses: ./.github/workflows/ios_android_tag.yml
+    with:
+      react-native-version: 0.65
+      release-version: ${{ github.event.inputs.release_version }}
+
+  build-windows-064:
+    uses: ./.github/workflows/windows_tag.yml
+    with:
+      react-native-version: 0.64
+      release-version: ${{ github.event.inputs.release_version }}
+
+  build-windows-065:
+    uses: ./.github/workflows/windows_tag.yml
+    with:
+      react-native-version: 0.65
+      release-version: ${{ github.event.inputs.release_version }}
+
+  build-typescript:
+    uses: ./.github/workflows/typescript_tag.yml
+    with:
+      release-version: ${{ github.event.inputs.release_version }}
+
+  package:
+    needs: [build-typescript, build-android-ios-064, build-android-ios-065, build-windows-064, build-windows-065]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.3.3
+      - name: NPM Install (Binary Package)
+        run: npm install
+        working-directory: ./Package
+      - name: Download Assembled Folder
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Assembled'
+          path: Package/Assembled
+      - name: Download Assembled-iOSAndroid 0.64 Folder
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Assembled-iOSAndroid0.64'
+          path: Package/Assembled-iOSAndroid0.64
+      - name: Download Assembled-iOSAndroid 0.65 Folder
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Assembled-iOSAndroid0.65'
+          path: Package/Assembled-iOSAndroid0.65
+      - name: Download Assembled-Windows 0.64 Folder
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Assembled-Windows0.64'
+          path: Package/Assembled-Windows0.64
+      - name: Download Assembled-Windows 0.65 Folder
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Assembled-Windows0.65'
+          path: Package/Assembled-Windows0.65
+      - name: Display structure of downloaded Assembled and Assembled-Windows folders
+        run: ls -R
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@babylonjs'
+      - name: Version & Publish Package @babylonjs/react-native
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public --tag ${{ github.event.inputs.NPM_tag }}
+        working-directory: ./Package/Assembled
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-64
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public --tag ${{ github.event.inputs.NPM_tag }}
+        working-directory: ./Package/Assembled-iOSAndroid0.64
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public --tag ${{ github.event.inputs.NPM_tag }}
+        working-directory: ./Package/Assembled-iOSAndroid0.65
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Version & Publish Package @babylonjs/react-native-windows-0-64
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public --tag ${{ github.event.inputs.NPM_tag }}
+        working-directory: ./Package/Assembled-Windows0.64
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Version & Publish Package @babylonjs/react-native-windows-0-65
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public --tag ${{ github.event.inputs.NPM_tag }}
+        working-directory: ./Package/Assembled-Windows0.64
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/typescript_tag.yml
+++ b/.github/workflows/typescript_tag.yml
@@ -1,0 +1,33 @@
+name: 'build Typescript'
+
+on:
+  workflow_call:
+    inputs:
+      release-version:
+        required: true
+        type: string
+jobs:
+  Build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.3.3
+        with:
+          submodules: 'recursive'
+      - name: NPM Install (Playground)
+        run: npm install
+        working-directory: ./Apps/Playground
+      - name: Select React Native Version 
+        run: npm run select 0.64
+        working-directory: ./Apps/Playground
+      - name: NPM Install (Binary Package)
+        run: npm install
+        working-directory: ./Package
+      - name: Gulp
+        run: npx gulp buildTS --releaseVersion ${{ inputs.release-version }}
+        working-directory: ./Package
+      - name: Upload Assembled Folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'Assembled'
+          path: Package/Assembled

--- a/.github/workflows/windows_tag.yml
+++ b/.github/workflows/windows_tag.yml
@@ -1,0 +1,46 @@
+name: 'build windows'
+
+on:
+  workflow_call:
+    inputs:
+      react-native-version:
+        required: true
+        type: string
+      release-version:
+        required: true
+        type: string
+
+jobs:
+  Build:
+    runs-on: windows-2019
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2.3.3
+        with:
+          submodules: 'true'
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+      - name: NPM Install (Playground)
+        run: npm install
+        working-directory: ./Apps/Playground
+      - name: NPM Install (React Native ${{ inputs.react-native-version }})
+        run: npm run select --reactNative ${{ inputs.react-native-version }}
+        working-directory: ./Apps/Playground
+      - name: NPM Install (Binary Package)
+        run: npm install
+        working-directory: ./Package
+      - name: Git (Windows)
+        run: npx gulp initializeSubmodulesWindowsAgent --reactNative ${{ inputs.react-native-version }} --releaseVersion ${{ inputs.release-version }}
+        working-directory: ./Package
+      - name: Gulp (Windows)
+        run: npx gulp buildUWPPublish
+        working-directory: ./Package
+      - name: Upload Assembled-Windows Folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'Assembled-Windows${{ inputs.react-native-version }}'
+          path: Package/Assembled-Windows


### PR DESCRIPTION
To consolidate later. iosandroid/windows and typescript build steps should be refactored to be the same as 'standard' release.