### PR TITLE
Update BabylonNative to the latest, and bump Babylon.js to version 5.2.0

### DIFF
--- a/Apps/PackageTest/0.63.1/package-lock.json
+++ b/Apps/PackageTest/0.63.1/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PackageTest",
       "version": "0.0.1",
       "dependencies": {
-        "@babylonjs/core": "5.0.0-rc.12",
+        "@babylonjs/core": "5.2.0",
         "@babylonjs/react-native": "^0.4.0-alpha.47",
         "react": "16.13.1",
         "react-native": "0.63.1",
@@ -1379,9 +1379,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
-      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -16380,9 +16380,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
-      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/Apps/PackageTest/0.63.1/package.json
+++ b/Apps/PackageTest/0.63.1/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "5.0.0",
+    "@babylonjs/core": "5.2.0",
     "@babylonjs/react-native": "^0.4.0-alpha.47",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/PackageTest/0.64.0/package-lock.json
+++ b/Apps/PackageTest/0.64.0/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PackageTest",
       "version": "0.0.1",
       "dependencies": {
-        "@babylonjs/core": "5.0.0-rc.12",
+        "@babylonjs/core": "5.2.0",
         "@babylonjs/react-native": "^0.4.0-alpha.47",
         "@babylonjs/react-native-windows": "^0.4.0-alpha.47",
         "react": "^17.0.1",
@@ -1415,9 +1415,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
-      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -18041,9 +18041,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.12.tgz",
-      "integrity": "sha512-Ge398LeC929KMVfflZLN98sVQQzEVUSIMlUDkDgU2/AD97QWMq/AwxtzgUAt2ARZv620vLIMBwspiBBPE5FRDQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "requires": {
         "tslib": "^2.3.1"
       },

--- a/Apps/PackageTest/0.64.0/package.json
+++ b/Apps/PackageTest/0.64.0/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "5.0.0",
+    "@babylonjs/core": "5.2.0",
     "@babylonjs/react-native": "^0.4.0-alpha.47",
     "@babylonjs/react-native-windows": "^0.4.0-alpha.47",
     "react": "^17.0.1",

--- a/Apps/PackageTest/0.65.0/package-lock.json
+++ b/Apps/PackageTest/0.65.0/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PackageTest",
       "version": "0.0.1",
       "dependencies": {
-        "@babylonjs/core": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
         "@babylonjs/packagetest-shared": "file:../packagetest-shared",
         "@babylonjs/react-native": "^1.0.1",
         "@babylonjs/react-native-iosandroid-0-65": "^1.0.1",
@@ -31,7 +31,6 @@
       }
     },
     "../packagetest-shared": {
-      "name": "packagetest-shared",
       "version": "0.0.1",
       "license": "MIT"
     },
@@ -1847,9 +1846,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.1.0.tgz",
-      "integrity": "sha512-yHC+k2pbpjcFOkhAFcXYLLv/WbXLZlPTVdOcC3/ExC+WlnsrmiulT26AhU8ghzZCcTpil3WsyTxqB0GYMtvwcA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -16786,9 +16785,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.1.0.tgz",
-      "integrity": "sha512-yHC+k2pbpjcFOkhAFcXYLLv/WbXLZlPTVdOcC3/ExC+WlnsrmiulT26AhU8ghzZCcTpil3WsyTxqB0GYMtvwcA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/Apps/PackageTest/0.65.0/package.json
+++ b/Apps/PackageTest/0.65.0/package.json
@@ -11,7 +11,7 @@
     "windows": "react-native run-windows"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.0.0",
+    "@babylonjs/core": "^5.2.0",
     "@babylonjs/react-native": "^1.0.1",
     "@babylonjs/react-native-iosandroid-0-65": "^1.0.1",
     "@babylonjs/react-native-windows-0-65": "^1.0.1",

--- a/Apps/Playground/0.64/ios/Podfile.lock
+++ b/Apps/Playground/0.64/ios/Podfile.lock
@@ -366,7 +366,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
-  - "react-native-babylon (from `../../../../Modules/@babylonjs/react-native`)"
+  - "react-native-babylon (from `../../../../Modules/@babylonjs/react-native-iosandroid`)"
   - "react-native-slider (from `../node_modules/@react-native-community/slider`)"
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -432,7 +432,7 @@ EXTERNAL SOURCES:
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-babylon:
-    :path: "../../../../Modules/@babylonjs/react-native"
+    :path: "../../../../Modules/@babylonjs/react-native-iosandroid"
   react-native-slider:
     :path: "../node_modules/@react-native-community/slider"
   React-perflogger:
@@ -469,7 +469,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 4306a04f6bbd042a5f1fb7e885c366da7257689d
+  FBReactNativeSpec: bac127a452d4bf9a618ecca4bb6137bf50a020e1
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -512,4 +512,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6b5a8feda09816950d2c787ef58c08eea3c22840
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/Apps/Playground/0.64/package-lock.json
+++ b/Apps/Playground/0.64/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@babylonjs/core": "5.0.0",
-        "@babylonjs/loaders": "5.0.0",
+        "@babylonjs/core": "5.2.0",
+        "@babylonjs/loaders": "5.2.0",
         "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
         "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
@@ -56,7 +56,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -73,7 +73,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
         "react-native-permissions": "^3.0.0"
@@ -108,7 +108,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -126,7 +126,7 @@
         "typescript": "^3.8.3"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
         "@babylonjs/react-native": "version",
         "react": "^17.0.1",
         "react-native": "^0.64.0",
@@ -1272,9 +1272,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-AYzyQmVp7TjtNWYlLxQp5aVO+NooGWsSKHoTbYyBiizRLjYOpedQjx2nBVzJCxSiZQMD/yaXwSTwFaEd1/k+Nw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -1285,12 +1285,12 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0.tgz",
-      "integrity": "sha512-vyScGr2iz2DGjP9ni+HlLB+/LbwBwSEc7lz9bTdc9MWKExfNxH4ZSBL/dgqEz0s+NVPAl9YfplCsv0dCX0qtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.2.0.tgz",
+      "integrity": "sha512-JOk9dAbPBE3tCCgJacuS9yl8uBBo74Hh4ShnTIXRu5UElRF2nFAvf15YM4DdRZ1jk0rZXupYiaHRYkHNoMR94A==",
       "dependencies": {
-        "@babylonjs/core": "^5.0.0",
-        "babylonjs-gltf2interface": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
+        "babylonjs-gltf2interface": "^5.2.0",
         "tslib": "^2.3.1"
       }
     },
@@ -5871,9 +5871,9 @@
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0.tgz",
-      "integrity": "sha512-y2TaMzVx5wIY9k+VBwBC4iLZKq5SNdKeO2NkiMNi4lx+fg8GqV6wCdSYqIM7cGKNRtOiDCcuGad1ULco6KebvA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.2.0.tgz",
+      "integrity": "sha512-mOD+FsV2fLHCMNI2+rhlN8tTBFrgCMzVfbuCd8x7hYcr73lEkBiH+BAJhBNe5L37n+rCTpC+i1zjoS62YyeFtA=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -17222,9 +17222,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-AYzyQmVp7TjtNWYlLxQp5aVO+NooGWsSKHoTbYyBiizRLjYOpedQjx2nBVzJCxSiZQMD/yaXwSTwFaEd1/k+Nw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "requires": {
         "tslib": "^2.3.1"
       },
@@ -17237,12 +17237,12 @@
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0.tgz",
-      "integrity": "sha512-vyScGr2iz2DGjP9ni+HlLB+/LbwBwSEc7lz9bTdc9MWKExfNxH4ZSBL/dgqEz0s+NVPAl9YfplCsv0dCX0qtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.2.0.tgz",
+      "integrity": "sha512-JOk9dAbPBE3tCCgJacuS9yl8uBBo74Hh4ShnTIXRu5UElRF2nFAvf15YM4DdRZ1jk0rZXupYiaHRYkHNoMR94A==",
       "requires": {
-        "@babylonjs/core": "^5.0.0",
-        "babylonjs-gltf2interface": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
+        "babylonjs-gltf2interface": "^5.2.0",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -17261,7 +17261,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -17327,7 +17327,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -21003,9 +21003,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0.tgz",
-      "integrity": "sha512-y2TaMzVx5wIY9k+VBwBC4iLZKq5SNdKeO2NkiMNi4lx+fg8GqV6wCdSYqIM7cGKNRtOiDCcuGad1ULco6KebvA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.2.0.tgz",
+      "integrity": "sha512-mOD+FsV2fLHCMNI2+rhlN8tTBFrgCMzVfbuCd8x7hYcr73lEkBiH+BAJhBNe5L37n+rCTpC+i1zjoS62YyeFtA=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/0.64/package.json
+++ b/Apps/Playground/0.64/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "5.0.0",
-    "@babylonjs/loaders": "5.0.0",
+    "@babylonjs/core": "5.2.0",
+    "@babylonjs/loaders": "5.2.0",
     "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
     "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",

--- a/Apps/Playground/0.65/package-lock.json
+++ b/Apps/Playground/0.65/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@babylonjs/core": "5.0.0",
-        "@babylonjs/loaders": "5.0.0",
+        "@babylonjs/core": "5.2.0",
+        "@babylonjs/loaders": "5.2.0",
         "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
         "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
@@ -50,7 +50,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -67,7 +67,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
         "react-native-permissions": "^3.0.0"
@@ -102,7 +102,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -120,7 +120,7 @@
         "typescript": "^3.8.3"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
         "@babylonjs/react-native": "version",
         "react": "^17.0.1",
         "react-native": "^0.64.0",
@@ -7035,20 +7035,20 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-AYzyQmVp7TjtNWYlLxQp5aVO+NooGWsSKHoTbYyBiizRLjYOpedQjx2nBVzJCxSiZQMD/yaXwSTwFaEd1/k+Nw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0.tgz",
-      "integrity": "sha512-vyScGr2iz2DGjP9ni+HlLB+/LbwBwSEc7lz9bTdc9MWKExfNxH4ZSBL/dgqEz0s+NVPAl9YfplCsv0dCX0qtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.2.0.tgz",
+      "integrity": "sha512-JOk9dAbPBE3tCCgJacuS9yl8uBBo74Hh4ShnTIXRu5UElRF2nFAvf15YM4DdRZ1jk0rZXupYiaHRYkHNoMR94A==",
       "dependencies": {
-        "@babylonjs/core": "^5.0.0",
-        "babylonjs-gltf2interface": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
+        "babylonjs-gltf2interface": "^5.2.0",
         "tslib": "^2.3.1"
       }
     },
@@ -9332,9 +9332,9 @@
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0.tgz",
-      "integrity": "sha512-y2TaMzVx5wIY9k+VBwBC4iLZKq5SNdKeO2NkiMNi4lx+fg8GqV6wCdSYqIM7cGKNRtOiDCcuGad1ULco6KebvA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.2.0.tgz",
+      "integrity": "sha512-mOD+FsV2fLHCMNI2+rhlN8tTBFrgCMzVfbuCd8x7hYcr73lEkBiH+BAJhBNe5L37n+rCTpC+i1zjoS62YyeFtA=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -18449,20 +18449,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-AYzyQmVp7TjtNWYlLxQp5aVO+NooGWsSKHoTbYyBiizRLjYOpedQjx2nBVzJCxSiZQMD/yaXwSTwFaEd1/k+Nw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.0.0.tgz",
-      "integrity": "sha512-vyScGr2iz2DGjP9ni+HlLB+/LbwBwSEc7lz9bTdc9MWKExfNxH4ZSBL/dgqEz0s+NVPAl9YfplCsv0dCX0qtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.2.0.tgz",
+      "integrity": "sha512-JOk9dAbPBE3tCCgJacuS9yl8uBBo74Hh4ShnTIXRu5UElRF2nFAvf15YM4DdRZ1jk0rZXupYiaHRYkHNoMR94A==",
       "requires": {
-        "@babylonjs/core": "^5.0.0",
-        "babylonjs-gltf2interface": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
+        "babylonjs-gltf2interface": "^5.2.0",
         "tslib": "^2.3.1"
       }
     },
@@ -18474,7 +18474,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -21814,7 +21814,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -23403,9 +23403,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.0.0.tgz",
-      "integrity": "sha512-y2TaMzVx5wIY9k+VBwBC4iLZKq5SNdKeO2NkiMNi4lx+fg8GqV6wCdSYqIM7cGKNRtOiDCcuGad1ULco6KebvA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.2.0.tgz",
+      "integrity": "sha512-mOD+FsV2fLHCMNI2+rhlN8tTBFrgCMzVfbuCd8x7hYcr73lEkBiH+BAJhBNe5L37n+rCTpC+i1zjoS62YyeFtA=="
     },
     "balanced-match": {
       "version": "1.0.2"

--- a/Apps/Playground/0.65/package.json
+++ b/Apps/Playground/0.65/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "5.0.0",
-    "@babylonjs/loaders": "5.0.0",
+    "@babylonjs/core": "5.2.0",
+    "@babylonjs/loaders": "5.2.0",
     "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
     "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",

--- a/Modules/@babylonjs/react-native-windows/package.json
+++ b/Modules/@babylonjs/react-native-windows/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0",
+    "@babylonjs/core": "^5.2.0",
     "@babylonjs/react-native": "version",
     "react": "^17.0.1",
     "react-native": "^0.64.0",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "5.0.0",
+    "@babylonjs/core": "5.2.0",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",

--- a/Modules/@babylonjs/react-native/package-lock.json
+++ b/Modules/@babylonjs/react-native/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0",
+        "@babylonjs/core": "5.2.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -32,7 +32,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0",
+        "@babylonjs/core": "^5.2.0",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
         "react-native-permissions": "^3.0.0"
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-AYzyQmVp7TjtNWYlLxQp5aVO+NooGWsSKHoTbYyBiizRLjYOpedQjx2nBVzJCxSiZQMD/yaXwSTwFaEd1/k+Nw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -6468,9 +6468,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0.tgz",
-      "integrity": "sha512-AYzyQmVp7TjtNWYlLxQp5aVO+NooGWsSKHoTbYyBiizRLjYOpedQjx2nBVzJCxSiZQMD/yaXwSTwFaEd1/k+Nw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.0.0",
+    "@babylonjs/core": "^5.2.0",
     "react": ">=16.13.1",
     "react-native": ">=0.63.1",
     "react-native-permissions": "^3.0.0"
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "5.0.0",
+    "@babylonjs/core": "5.2.0",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",


### PR DESCRIPTION
**Describe the change**

This PR updates the BabylonNative submodule to the latest version, and bumps the Babylon.js version to 5.2.0.  The primary changes this brings in are:

1. WebXR Image tracking is now supported on iOS and Android
2. Improve color handling for native canvases
3. Improved pointer support
4. Updated to GSL 4

**Testing**

Tested on device on iOS and Android