### PR TITLE
Bugfix/android morph target

### DIFF
--- a/Apps/PackageTest/0.63.1/package-lock.json
+++ b/Apps/PackageTest/0.63.1/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PackageTest",
       "version": "0.0.1",
       "dependencies": {
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@babylonjs/react-native": "^0.4.0-alpha.47",
         "react": "16.13.1",
         "react-native": "0.63.1",
@@ -1379,9 +1379,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -16380,9 +16380,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/Apps/PackageTest/0.63.1/package.json
+++ b/Apps/PackageTest/0.63.1/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "5.2.0",
+    "@babylonjs/core": "5.6.1",
     "@babylonjs/react-native": "^0.4.0-alpha.47",
     "react": "16.13.1",
     "react-native": "0.63.1",

--- a/Apps/PackageTest/0.64.0/package-lock.json
+++ b/Apps/PackageTest/0.64.0/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PackageTest",
       "version": "0.0.1",
       "dependencies": {
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@babylonjs/react-native": "^0.4.0-alpha.47",
         "@babylonjs/react-native-windows": "^0.4.0-alpha.47",
         "react": "^17.0.1",

--- a/Apps/PackageTest/0.64.0/package.json
+++ b/Apps/PackageTest/0.64.0/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@babylonjs/core": "5.2.0",
+    "@babylonjs/core": "5.6.1",
     "@babylonjs/react-native": "^0.4.0-alpha.47",
     "@babylonjs/react-native-windows": "^0.4.0-alpha.47",
     "react": "^17.0.1",

--- a/Apps/PackageTest/0.65.0/package-lock.json
+++ b/Apps/PackageTest/0.65.0/package-lock.json
@@ -8,7 +8,7 @@
       "name": "PackageTest",
       "version": "0.0.1",
       "dependencies": {
-        "@babylonjs/core": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
         "@babylonjs/packagetest-shared": "file:../packagetest-shared",
         "@babylonjs/react-native": "^1.0.1",
         "@babylonjs/react-native-iosandroid-0-65": "^1.0.1",
@@ -1846,9 +1846,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -16785,9 +16785,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/Apps/PackageTest/0.65.0/package.json
+++ b/Apps/PackageTest/0.65.0/package.json
@@ -11,7 +11,7 @@
     "windows": "react-native run-windows"
   },
   "dependencies": {
-    "@babylonjs/core": "^5.2.0",
+    "@babylonjs/core": "^5.6.1",
     "@babylonjs/react-native": "^1.0.1",
     "@babylonjs/react-native-iosandroid-0-65": "^1.0.1",
     "@babylonjs/react-native-windows-0-65": "^1.0.1",

--- a/Apps/Playground/0.64/package-lock.json
+++ b/Apps/Playground/0.64/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@babylonjs/core": "5.2.0",
-        "@babylonjs/loaders": "5.2.0",
+        "@babylonjs/core": "5.6.1",
+        "@babylonjs/loaders": "5.6.1",
         "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
         "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
@@ -56,7 +56,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -73,7 +73,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
         "react-native-permissions": "^3.0.0"
@@ -108,7 +108,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -126,7 +126,7 @@
         "typescript": "^3.8.3"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
         "@babylonjs/react-native": "version",
         "react": "^17.0.1",
         "react-native": "^0.64.0",
@@ -1272,9 +1272,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -1285,12 +1285,12 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.2.0.tgz",
-      "integrity": "sha512-JOk9dAbPBE3tCCgJacuS9yl8uBBo74Hh4ShnTIXRu5UElRF2nFAvf15YM4DdRZ1jk0rZXupYiaHRYkHNoMR94A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.6.1.tgz",
+      "integrity": "sha512-kl6P1EnnfYXF1re/DqocUPOo9ASRCt5jcpcClGe0n/mZpig/AzbgVC+kwCqOXH28LD7AfRkJ6enC1BUrH0b4IA==",
       "dependencies": {
-        "@babylonjs/core": "^5.2.0",
-        "babylonjs-gltf2interface": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
+        "babylonjs-gltf2interface": "^5.6.1",
         "tslib": "^2.3.1"
       }
     },
@@ -5871,9 +5871,9 @@
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.2.0.tgz",
-      "integrity": "sha512-mOD+FsV2fLHCMNI2+rhlN8tTBFrgCMzVfbuCd8x7hYcr73lEkBiH+BAJhBNe5L37n+rCTpC+i1zjoS62YyeFtA=="
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.6.1.tgz",
+      "integrity": "sha512-FS8aObh4lfDwmd9nlfu+7PiUtc+1fFKe5AAMqKkiUWU8MJc2P+4RkvijUArfMKsO1whh7ee6St5iuTxDi+ltKw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -17222,9 +17222,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "requires": {
         "tslib": "^2.3.1"
       },
@@ -17237,12 +17237,12 @@
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.2.0.tgz",
-      "integrity": "sha512-JOk9dAbPBE3tCCgJacuS9yl8uBBo74Hh4ShnTIXRu5UElRF2nFAvf15YM4DdRZ1jk0rZXupYiaHRYkHNoMR94A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.6.1.tgz",
+      "integrity": "sha512-kl6P1EnnfYXF1re/DqocUPOo9ASRCt5jcpcClGe0n/mZpig/AzbgVC+kwCqOXH28LD7AfRkJ6enC1BUrH0b4IA==",
       "requires": {
-        "@babylonjs/core": "^5.2.0",
-        "babylonjs-gltf2interface": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
+        "babylonjs-gltf2interface": "^5.6.1",
         "tslib": "^2.3.1"
       },
       "dependencies": {
@@ -17261,7 +17261,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -17327,7 +17327,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -21003,9 +21003,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.2.0.tgz",
-      "integrity": "sha512-mOD+FsV2fLHCMNI2+rhlN8tTBFrgCMzVfbuCd8x7hYcr73lEkBiH+BAJhBNe5L37n+rCTpC+i1zjoS62YyeFtA=="
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.6.1.tgz",
+      "integrity": "sha512-FS8aObh4lfDwmd9nlfu+7PiUtc+1fFKe5AAMqKkiUWU8MJc2P+4RkvijUArfMKsO1whh7ee6St5iuTxDi+ltKw=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/Apps/Playground/0.64/package.json
+++ b/Apps/Playground/0.64/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "5.2.0",
-    "@babylonjs/loaders": "5.2.0",
+    "@babylonjs/core": "5.6.1",
+    "@babylonjs/loaders": "5.6.1",
     "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
     "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",

--- a/Apps/Playground/0.65/package-lock.json
+++ b/Apps/Playground/0.65/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@babylonjs/core": "5.2.0",
-        "@babylonjs/loaders": "5.2.0",
+        "@babylonjs/core": "5.6.1",
+        "@babylonjs/loaders": "5.6.1",
         "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
         "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
@@ -50,7 +50,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -67,7 +67,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
         "react-native-permissions": "^3.0.0"
@@ -102,7 +102,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -120,7 +120,7 @@
         "typescript": "^3.8.3"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
         "@babylonjs/react-native": "version",
         "react": "^17.0.1",
         "react-native": "^0.64.0",
@@ -7035,20 +7035,20 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.2.0.tgz",
-      "integrity": "sha512-JOk9dAbPBE3tCCgJacuS9yl8uBBo74Hh4ShnTIXRu5UElRF2nFAvf15YM4DdRZ1jk0rZXupYiaHRYkHNoMR94A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.6.1.tgz",
+      "integrity": "sha512-kl6P1EnnfYXF1re/DqocUPOo9ASRCt5jcpcClGe0n/mZpig/AzbgVC+kwCqOXH28LD7AfRkJ6enC1BUrH0b4IA==",
       "dependencies": {
-        "@babylonjs/core": "^5.2.0",
-        "babylonjs-gltf2interface": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
+        "babylonjs-gltf2interface": "^5.6.1",
         "tslib": "^2.3.1"
       }
     },
@@ -9332,9 +9332,9 @@
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.2.0.tgz",
-      "integrity": "sha512-mOD+FsV2fLHCMNI2+rhlN8tTBFrgCMzVfbuCd8x7hYcr73lEkBiH+BAJhBNe5L37n+rCTpC+i1zjoS62YyeFtA=="
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.6.1.tgz",
+      "integrity": "sha512-FS8aObh4lfDwmd9nlfu+7PiUtc+1fFKe5AAMqKkiUWU8MJc2P+4RkvijUArfMKsO1whh7ee6St5iuTxDi+ltKw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -18449,20 +18449,20 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@babylonjs/loaders": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.2.0.tgz",
-      "integrity": "sha512-JOk9dAbPBE3tCCgJacuS9yl8uBBo74Hh4ShnTIXRu5UElRF2nFAvf15YM4DdRZ1jk0rZXupYiaHRYkHNoMR94A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.6.1.tgz",
+      "integrity": "sha512-kl6P1EnnfYXF1re/DqocUPOo9ASRCt5jcpcClGe0n/mZpig/AzbgVC+kwCqOXH28LD7AfRkJ6enC1BUrH0b4IA==",
       "requires": {
-        "@babylonjs/core": "^5.2.0",
-        "babylonjs-gltf2interface": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
+        "babylonjs-gltf2interface": "^5.6.1",
         "tslib": "^2.3.1"
       }
     },
@@ -18474,7 +18474,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -21814,7 +21814,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -23403,9 +23403,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.2.0.tgz",
-      "integrity": "sha512-mOD+FsV2fLHCMNI2+rhlN8tTBFrgCMzVfbuCd8x7hYcr73lEkBiH+BAJhBNe5L37n+rCTpC+i1zjoS62YyeFtA=="
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.6.1.tgz",
+      "integrity": "sha512-FS8aObh4lfDwmd9nlfu+7PiUtc+1fFKe5AAMqKkiUWU8MJc2P+4RkvijUArfMKsO1whh7ee6St5iuTxDi+ltKw=="
     },
     "balanced-match": {
       "version": "1.0.2"

--- a/Apps/Playground/0.65/package.json
+++ b/Apps/Playground/0.65/package.json
@@ -14,8 +14,8 @@
     "iosCmake": "node scripts/tools.js iosCMake"
   },
   "dependencies": {
-    "@babylonjs/core": "5.2.0",
-    "@babylonjs/loaders": "5.2.0",
+    "@babylonjs/core": "5.6.1",
+    "@babylonjs/loaders": "5.6.1",
     "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
     "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
     "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",

--- a/Modules/@babylonjs/react-native-windows/package-lock.json
+++ b/Modules/@babylonjs/react-native-windows/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.0.0-rc.1",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -29,7 +29,7 @@
         "typescript": "^3.8.3"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.0.0-rc.1",
+        "@babylonjs/core": "^5.6.1",
         "react": "^17.0.1",
         "react-native": "^0.64.0",
         "react-native-permissions": "^3.0.0",
@@ -1840,15 +1840,12 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.1.tgz",
-      "integrity": "sha512-34a5+Xq+b4UoYriaVoLgt27W0bWiVxJm0TXHtyWGBKLU9/40FPQLVE99fvMQQLwjML2ztx0i+LCMEBjnx17wlg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.x"
       }
     },
     "node_modules/@babylonjs/core/node_modules/tslib": {
@@ -14816,9 +14813,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.0.0-rc.1.tgz",
-      "integrity": "sha512-34a5+Xq+b4UoYriaVoLgt27W0bWiVxJm0TXHtyWGBKLU9/40FPQLVE99fvMQQLwjML2ztx0i+LCMEBjnx17wlg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"

--- a/Modules/@babylonjs/react-native-windows/package.json
+++ b/Modules/@babylonjs/react-native-windows/package.json
@@ -24,7 +24,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "@babylonjs/core": "^5.2.0",
+    "@babylonjs/core": "^5.6.1",
     "@babylonjs/react-native": "version",
     "react": "^17.0.1",
     "react-native": "^0.64.0",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "5.2.0",
+    "@babylonjs/core": "5.6.1",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",

--- a/Modules/@babylonjs/react-native/package-lock.json
+++ b/Modules/@babylonjs/react-native/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.2.0",
+        "@babylonjs/core": "5.6.1",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -32,7 +32,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "^5.2.0",
+        "@babylonjs/core": "^5.6.1",
         "react": ">=16.13.1",
         "react-native": ">=0.63.1",
         "react-native-permissions": "^3.0.0"
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.1"
@@ -6468,9 +6468,9 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-xWxYUBx++9nkoJaYchEK1x6ht5JJ8MIvtSKxGZMZJzCmAn4CU6qfux9TWUqmw7jdEt9YlRFdbZn7nCQVLUa/ew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.6.1.tgz",
+      "integrity": "sha512-kWXMK+C8IAlhpOIS+WEpA1FHuizrK+nKHCHxc0bnrSQ7ePCIL2Xfxjx+ZE5C2WGB4og135O6+E3msdtp9cETFA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"

--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -28,7 +28,7 @@
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@babylonjs/core": "^5.2.0",
+    "@babylonjs/core": "^5.6.1",
     "react": ">=16.13.1",
     "react-native": ">=0.63.1",
     "react-native-permissions": "^3.0.0"
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@babylonjs/core": "5.2.0",
+    "@babylonjs/core": "5.6.1",
     "@rnw-scripts/eslint-config": "0.1.6",
     "@rnw-scripts/ts-config": "0.1.0",
     "@types/base-64": "^0.1.3",


### PR DESCRIPTION
## Overiview

Sync with latest version of BabylonNative to get the changes that fix morph targets on Android. Also updated babylon.js packages used in the project to version 5.6.1 to get the fix from the js side and also to match PROTOCOL_VERSION (which has been increased to 6).

@babylonjs/react-native generated from this PR forward will only work with @babylonjs/core@5.6.1 or higher due to the change in PROTOCOL_VERSION

- Fixes #1049 