### PR TITLE
Windows unity build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,41 +75,40 @@ jobs:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@babylonjs'
-      #- name: Version & Publish Package @babylonjs/react-native
-      #  run: |
-      #    npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-      #    npm publish --access public
-      #  working-directory: ./Package/Assembled
-      #  env:
-      #    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-#
-      #- name: Version & Publish Package @babylonjs/react-native-iosandroid-0-64
-      #  run: |
-      #    npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-      #    npm publish --access public
-      #  working-directory: ./Package/Assembled-iOSAndroid0.64
-      #  env:
-      #    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      #- name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
-      #  run: |
-      #    npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-      #    npm publish --access public
-      #  working-directory: ./Package/Assembled-iOSAndroid0.65
-      #  env:
-      #    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Version & Publish Package @babylonjs/react-native
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public
+        working-directory: ./Package/Assembled
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Temporarily disable Windows publish due to https://github.com/BabylonJS/BabylonNative/issues/1062
-      # - name: Version & Publish Package @babylonjs/react-native-windows-0-64
-      #   run: |
-      #     npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-      #     npm publish --access public
-      #   working-directory: ./Package/Assembled-Windows0.64
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      # - name: Version & Publish Package @babylonjs/react-native-windows-0-65
-      #   run: |
-      #     npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-      #     npm publish --access public
-      #   working-directory: ./Package/Assembled-Windows0.65
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-64
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public
+        working-directory: ./Package/Assembled-iOSAndroid0.64
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public
+        working-directory: ./Package/Assembled-iOSAndroid0.65
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Version & Publish Package @babylonjs/react-native-windows-0-64
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public
+        working-directory: ./Package/Assembled-Windows0.64
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Version & Publish Package @babylonjs/react-native-windows-0-65
+        run: |
+          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+          npm publish --access public
+        working-directory: ./Package/Assembled-Windows0.65
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,28 +75,28 @@ jobs:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@babylonjs'
-      - name: Version & Publish Package @babylonjs/react-native
-        run: |
-          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-          npm publish --access public
-        working-directory: ./Package/Assembled
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-64
-        run: |
-          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-          npm publish --access public
-        working-directory: ./Package/Assembled-iOSAndroid0.64
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
-        run: |
-          npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
-          npm publish --access public
-        working-directory: ./Package/Assembled-iOSAndroid0.65
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #- name: Version & Publish Package @babylonjs/react-native
+      #  run: |
+      #    npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+      #    npm publish --access public
+      #  working-directory: ./Package/Assembled
+      #  env:
+      #    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+#
+      #- name: Version & Publish Package @babylonjs/react-native-iosandroid-0-64
+      #  run: |
+      #    npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+      #    npm publish --access public
+      #  working-directory: ./Package/Assembled-iOSAndroid0.64
+      #  env:
+      #    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #- name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
+      #  run: |
+      #    npm version --no-git-tag-version ${GITHUB_REF/refs\/tags\//}
+      #    npm publish --access public
+      #  working-directory: ./Package/Assembled-iOSAndroid0.65
+      #  env:
+      #    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Temporarily disable Windows publish due to https://github.com/BabylonJS/BabylonNative/issues/1062
       # - name: Version & Publish Package @babylonjs/react-native-windows-0-64

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -124,7 +124,7 @@ const initializeSubmodulesMostRecentBabylonNative = async () => {
 
 const makeUWPProjectPlatform = async (name, arch) => {
   shelljs.mkdir('-p', `./../Modules/@babylonjs/react-native/Build/uwp_${name}`);
-  exec(`cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -A ${arch} ./../../../react-native-windows/windows`, `./../Modules/@babylonjs/react-native/Build/uwp_${name}`);
+  exec(`cmake -D CMAKE_SYSTEM_NAME=WindowsStore -D CMAKE_SYSTEM_VERSION=10.0 -DCMAKE_UNITY_BUILD=true -A ${arch} ./../../../react-native-windows/windows`, `./../Modules/@babylonjs/react-native/Build/uwp_${name}`);
 };
 
 const makeUWPProjectx86 = async () => makeUWPProjectPlatform('x86', 'Win32');

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -83,7 +83,7 @@ const buildIphoneSimulator = async () => {
 const buildIOS = gulp.series(makeXCodeProj, buildIphoneOS, buildIphoneSimulator);
 
 const buildAndroid = async () => {
-  exec('./gradlew babylonjs_react-native:assembleRelease -PUNITY_BUILD=true --stacktrace --info', '../Apps/Playground/Playground/android');
+  exec('./gradlew babylonjs_react-native:assembleRelease --stacktrace --info', '../Apps/Playground/Playground/android');
 };
 
 const initializeSubmodulesWindowsAgent = async () => {

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -83,7 +83,7 @@ const buildIphoneSimulator = async () => {
 const buildIOS = gulp.series(makeXCodeProj, buildIphoneOS, buildIphoneSimulator);
 
 const buildAndroid = async () => {
-  exec('./gradlew babylonjs_react-native:assembleRelease --stacktrace --info', '../Apps/Playground/Playground/android');
+  exec('./gradlew babylonjs_react-native:assembleRelease -PUNITY_BUILD=true --stacktrace --info', '../Apps/Playground/Playground/android');
 };
 
 const initializeSubmodulesWindowsAgent = async () => {


### PR DESCRIPTION
- Update BN submodule with this PR https://github.com/BabylonJS/BabylonNative/pull/1085
- Enable unity build for Windows

Artifacts now 24% smaller (154Mb Vs 201Mb) 
1.0.1 NPM Windows package size was 188Mb.

Tested OK with RN 0.65