### PR TITLE
Add artifact URL to PR

### DIFF
--- a/.github/workflows/add_artifact_urls.yml
+++ b/.github/workflows/add_artifact_urls.yml
@@ -1,0 +1,21 @@
+name: add artifact links to pull request and related issues
+on:
+  workflow_run:
+    workflows: ['PR Build']
+    types: [completed]
+
+jobs:
+  artifacts-url-comments:
+    name: add artifact links to pull request and related issues job
+    runs-on: windows-2019
+    steps:
+      - name: add artifact links to pull request and related issues step
+        uses: tonyhallett/artifacts-url-comments@main
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+            prefix: Here are the build results
+            suffix: Artifacts will only be retained for 90 days.
+            format: name
+            addTo: pull
+        continue-on-error: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Version & Publish Package @babylonjs/react-native
         run: |
           npm version --no-git-tag-version 1.0.0
-          npm publish --access public
+          npm publish --access public --verbose
         working-directory: ./PackageUp
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -126,18 +126,18 @@ jobs:
     uses: ./.github/workflows/ios_android.yml
     with:
       react-native-version: 0.65
-      release-version: 0.0.0-${GITHUB_SHA::8}
+      release-version: 1.0.0-${GITHUB_SHA::8}
 
   build-windows-065:
     uses: ./.github/workflows/windows.yml
     with:
       react-native-version: 0.65
-      release-version: 0.0.0-${GITHUB_SHA::8}
+      release-version: 1.0.0-${GITHUB_SHA::8}
 
   build-typescript:
     uses: ./.github/workflows/typescript.yml
     with:
-      release-version: 0.0.0-${GITHUB_SHA::8}
+      release-version: 1.0.0-${GITHUB_SHA::8}
 
   package:
     needs: [build-typescript, build-android-ios-065, build-windows-065]
@@ -166,7 +166,7 @@ jobs:
           scope: '@babylonjs'
       - name: Version & Publish Package @babylonjs/react-native
         run: |
-          npm version --no-git-tag-version 0.0.0-${GITHUB_SHA::8}
+          npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
           npm publish --access public
         working-directory: ./Package/Assembled
         env:
@@ -174,7 +174,7 @@ jobs:
 
       - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
         run: |
-          npm version --no-git-tag-version 0.0.0-${GITHUB_SHA::8}
+          npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
           npm publish --access public
         working-directory: ./Package/Assembled-iOSAndroid0.65
         env:
@@ -182,7 +182,7 @@ jobs:
 
       - name: Version & Publish Package @babylonjs/react-native-windows-0-65
         run: |
-          npm version --no-git-tag-version 0.0.0-${GITHUB_SHA::8}
+          npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
           npm publish --access public
         working-directory: ./Package/Assembled-Windows0.65
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,6 @@ on:
       - master
 env:
   BRN_Version: 0.64
-  STAGING_Version: '0.0.0-${GITHUB_SHA::8}'
 
 jobs:
   build-android:
@@ -127,18 +126,18 @@ jobs:
     uses: ./.github/workflows/ios_android.yml
     with:
       react-native-version: 0.65
-      release-version: ${{ env.STAGING_Version }}
+      release-version: 0.0.0-${GITHUB_SHA::8}
 
   build-windows-065:
     uses: ./.github/workflows/windows.yml
     with:
       react-native-version: 0.65
-      release-version: ${{ env.STAGING_Version }}
+      release-version: 0.0.0-${GITHUB_SHA::8}
 
   build-typescript:
     uses: ./.github/workflows/typescript.yml
     with:
-      release-version: ${{ env.STAGING_Version }}
+      release-version: 0.0.0-${GITHUB_SHA::8}
 
   package:
     needs: [build-typescript, build-android-ios-065, build-windows-065]
@@ -167,7 +166,7 @@ jobs:
           scope: '@babylonjs'
       - name: Version & Publish Package @babylonjs/react-native
         run: |
-          npm version --no-git-tag-version ${{ env.STAGING_Version }}
+          npm version --no-git-tag-version 0.0.0-${GITHUB_SHA::8}
           npm publish --access public
         working-directory: ./Package/Assembled
         env:
@@ -175,7 +174,7 @@ jobs:
 
       - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
         run: |
-          npm version --no-git-tag-version ${{ env.STAGING_Version }}
+          npm version --no-git-tag-version 0.0.0-${GITHUB_SHA::8}
           npm publish --access public
         working-directory: ./Package/Assembled-iOSAndroid0.65
         env:
@@ -183,7 +182,7 @@ jobs:
 
       - name: Version & Publish Package @babylonjs/react-native-windows-0-65
         run: |
-          npm version --no-git-tag-version ${{ env.STAGING_Version }}
+          npm version --no-git-tag-version 0.0.0-${GITHUB_SHA::8}
           npm publish --access public
         working-directory: ./Package/Assembled-Windows0.65
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -140,7 +140,7 @@ jobs:
 #      release-version: 1.0.0-${GITHUB_SHA::8}
 
   package:
-    needs: [build-typescript] #, build-android-ios-065, build-windows-065]
+#    needs: [build-typescript] #, build-android-ios-065, build-windows-065]
     runs-on: ubuntu-latest
     steps:
 #      - name: Download Assembled Folder

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -172,8 +172,8 @@ jobs:
 
       - name: Version & Publish Package @babylonjs/react-native
         run: |
-          npm version --no-git-tag-version 0.0.0-${GITHUB_SHA::8}
-          npm publish
+          npm version --no-git-tag-version 1.0.0
+          npm publish --access public
         working-directory: ./PackageUp
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -120,3 +120,21 @@ jobs:
       - name: Gulp Build ${{ matrix.platform }} ${{ matrix.config }} Playground (Windows)
         run: npx gulp buildUWPPlayground${{ matrix.platform }}${{ matrix.config }}
         working-directory: ./Package
+
+# Test packages
+  build-android-ios-065:
+    uses: ./.github/workflows/ios_android.yml
+    with:
+      react-native-version: 0.65
+      release-version: 2.0.0 # dummy version
+
+  build-windows-065:
+    uses: ./.github/workflows/windows.yml
+    with:
+      react-native-version: 0.65
+      release-version: 2.0.0
+
+  build-typescript:
+    uses: ./.github/workflows/typescript.yml
+    with:
+      release-version: 2.0.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
       - master
 env:
   BRN_Version: 0.64
-  STAGING_Version: 0.0.0-${GITHUB_SHA::8}
+  STAGING_Version: '0.0.0-${GITHUB_SHA::8}'
 
 jobs:
   build-android:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -140,7 +140,7 @@ jobs:
       release-version: 1.0.0-${GITHUB_SHA::8}
 
   package:
-    needs: [build-typescript, build-android-ios-065, build-windows-065]
+    needs: [build-typescript] #, build-android-ios-065, build-windows-065]
     runs-on: macos-latest
     steps:
       - name: Download Assembled Folder
@@ -148,22 +148,22 @@ jobs:
         with:
           name: 'Assembled'
           path: Package/Assembled
-      - name: Download Assembled-iOSAndroid 0.65 Folder
-        uses: actions/download-artifact@v2
-        with:
-          name: 'Assembled-iOSAndroid0.65'
-          path: Package/Assembled-iOSAndroid0.65
-      - name: Download Assembled-Windows 0.65 Folder
-        uses: actions/download-artifact@v2
-        with:
-          name: 'Assembled-Windows0.65'
-          path: Package/Assembled-Windows0.65
+#      - name: Download Assembled-iOSAndroid 0.65 Folder
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: 'Assembled-iOSAndroid0.65'
+#          path: Package/Assembled-iOSAndroid0.65
+#      - name: Download Assembled-Windows 0.65 Folder
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: 'Assembled-Windows0.65'
+#          path: Package/Assembled-Windows0.65
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.2
         with:
           node-version: '12.x'
           registry-url: 'https://npm.pkg.github.com'
-          scope: '@babylonjs'
+
       - name: Version & Publish Package @babylonjs/react-native
         run: |
           npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
@@ -172,18 +172,18 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
-        run: |
-          npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
-          npm publish
-        working-directory: ./Package/Assembled-iOSAndroid0.65
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Version & Publish Package @babylonjs/react-native-windows-0-65
-        run: |
-          npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
-          npm publish
-        working-directory: ./Package/Assembled-Windows0.65
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
+#        run: |
+#          npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
+#          npm publish
+#        working-directory: ./Package/Assembled-iOSAndroid0.65
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Version & Publish Package @babylonjs/react-native-windows-0-65
+#        run: |
+#          npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
+#          npm publish
+#        working-directory: ./Package/Assembled-Windows0.65
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
       - master
 env:
   BRN_Version: 0.64
+  STAGING_Version: 0.0.0-${GITHUB_SHA::8}
 
 jobs:
   build-android:
@@ -126,15 +127,64 @@ jobs:
     uses: ./.github/workflows/ios_android.yml
     with:
       react-native-version: 0.65
-      release-version: 2.0.0 # dummy version
+      release-version: ${{ env.STAGING_Version }}
 
   build-windows-065:
     uses: ./.github/workflows/windows.yml
     with:
       react-native-version: 0.65
-      release-version: 2.0.0
+      release-version: ${{ env.STAGING_Version }}
 
   build-typescript:
     uses: ./.github/workflows/typescript.yml
     with:
-      release-version: 2.0.0
+      release-version: ${{ env.STAGING_Version }}
+
+  package:
+    needs: [build-typescript, build-android-ios-065, build-windows-065]
+    runs-on: macos-latest
+    steps:
+      - name: Download Assembled Folder
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Assembled'
+          path: Package/Assembled
+      - name: Download Assembled-iOSAndroid 0.65 Folder
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Assembled-iOSAndroid0.65'
+          path: Package/Assembled-iOSAndroid0.65
+      - name: Download Assembled-Windows 0.65 Folder
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Assembled-Windows0.65'
+          path: Package/Assembled-Windows0.65
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@babylonjs'
+      - name: Version & Publish Package @babylonjs/react-native
+        run: |
+          npm version --no-git-tag-version ${{ env.STAGING_Version }}
+          npm publish --access public
+        working-directory: ./Package/Assembled
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
+        run: |
+          npm version --no-git-tag-version ${{ env.STAGING_Version }}
+          npm publish --access public
+        working-directory: ./Package/Assembled-iOSAndroid0.65
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Version & Publish Package @babylonjs/react-native-windows-0-65
+        run: |
+          npm version --no-git-tag-version ${{ env.STAGING_Version }}
+          npm publish --access public
+        working-directory: ./Package/Assembled-Windows0.65
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -141,7 +141,7 @@ jobs:
 
   package:
     permissions:
-      packages: write
+      packages: read/write
 
 #    needs: [build-typescript] #, build-android-ios-065, build-windows-065]
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -158,6 +158,14 @@ jobs:
 #        with:
 #          name: 'Assembled-Windows0.65'
 #          path: Package/Assembled-Windows0.65
+
+# TEMP
+      - name: Checkout Repo
+        uses: actions/checkout@v2.3.3
+        with:
+          submodules: 'recursive'
+# TEMP
+
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,147 +7,147 @@ env:
   BRN_Version: 0.64
 
 jobs:
-  build-android:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2.3.3
-        with:
-          submodules: 'recursive'
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.8
-        with:
-          cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
-      - name: Setup Ninja
-        run: brew install ninja
-      - name: NPM Install (Playground)
-        run: npm install
-        working-directory: ./Apps/Playground
-      - name: NPM Install (React Native ${{ env.BRN_Version }})
-        run: npm run select ${{ env.BRN_Version }}
-        working-directory: ./Apps/Playground
-      - name: NPM Install (Binary Package)
-        run: npm install
-        working-directory: ./Package
-      - name: Gulp (Android)
-        run: npx gulp buildAndroid
-        working-directory: ./Package
-
-  build-iOS:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2.3.3
-        with:
-          submodules: 'recursive'
-      - name: NPM Install (Playground)
-        run: npm install
-        working-directory: ./Apps/Playground
-      - name: NPM Install (React Native ${{ env.BRN_Version }})
-        run: npm run select --reactNative ${{ env.BRN_Version }}
-        working-directory: ./Apps/Playground
-      - name: NPM Install (Binary Package)
-        run: npm install
-        working-directory: ./Package
-      - name: Gulp (iOS)
-        run: npx gulp buildIOS
-        working-directory: ./Package
-
-  test-publish-android-ios:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2.3.3
-        with:
-          submodules: 'recursive'
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.8
-        with:
-          cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
-      - name: Setup Ninja
-        run: brew install ninja
-      - name: NPM Install (Playground)
-        run: npm install
-        working-directory: ./Apps/Playground
-      - name: NPM Install (React Native ${{ env.BRN_Version }})
-        run: npm run select --reactNative ${{ env.BRN_Version }}
-        working-directory: ./Apps/Playground
-      - name: NPM Install (Binary Package)
-        run: npm install
-        working-directory: ./Package
-      - name: Gulp
-        run: npx gulp
-        working-directory: ./Package
-
-  build-windows:
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        platform: [x86, x64, ARM64]
-        config: [Debug, Release]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2.3.3
-        with:
-          submodules: 'true'
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.0.2
-      - name: Setup NuGet
-        uses: nuget/setup-nuget@v1
-        with:
-          nuget-version: '5.x'
-      - name: NPM Install (Playground)
-        run: npm install
-        working-directory: ./Apps/Playground
-      - name: NPM Install (React Native ${{ env.BRN_Version }})
-        run: npm run select ${{ env.BRN_Version }}
-        working-directory: ./Apps/Playground
-      - name: NPM Install (Binary Package)
-        run: npm install
-        working-directory: ./Package
-      - name: Git (Windows)
-        run: npx gulp initializeSubmodulesWindowsAgent
-        working-directory: ./Package
-      - name: Gulp Setup Project ${{ matrix.platform }} (Windows)
-        run: npx gulp makeUWPProject${{ matrix.platform }}
-        working-directory: ./Package
-      - name: Gulp Build ${{ matrix.platform }} ${{ matrix.config }} (Windows)
-        run: npx gulp buildUWP${{ matrix.platform }}${{ matrix.config }}
-        working-directory: ./Package
-      - name: Gulp NuGet Restore Playground
-        run: npx gulp nugetRestoreUWPPlayground
-        working-directory: ./Package
-      - name: Gulp Build ${{ matrix.platform }} ${{ matrix.config }} Playground (Windows)
-        run: npx gulp buildUWPPlayground${{ matrix.platform }}${{ matrix.config }}
-        working-directory: ./Package
-
+#  build-android:
+#    runs-on: macos-latest
+#    steps:
+#      - name: Checkout Repo
+#        uses: actions/checkout@v2.3.3
+#        with:
+#          submodules: 'recursive'
+#      - name: Setup CMake
+#        uses: jwlawson/actions-setup-cmake@v1.8
+#        with:
+#          cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
+#      - name: Setup Ninja
+#        run: brew install ninja
+#      - name: NPM Install (Playground)
+#        run: npm install
+#        working-directory: ./Apps/Playground
+#      - name: NPM Install (React Native ${{ env.BRN_Version }})
+#        run: npm run select ${{ env.BRN_Version }}
+#        working-directory: ./Apps/Playground
+#      - name: NPM Install (Binary Package)
+#        run: npm install
+#        working-directory: ./Package
+#      - name: Gulp (Android)
+#        run: npx gulp buildAndroid
+#        working-directory: ./Package
+#
+#  build-iOS:
+#    runs-on: macos-latest
+#    steps:
+#      - name: Checkout Repo
+#        uses: actions/checkout@v2.3.3
+#        with:
+#          submodules: 'recursive'
+#      - name: NPM Install (Playground)
+#        run: npm install
+#        working-directory: ./Apps/Playground
+#      - name: NPM Install (React Native ${{ env.BRN_Version }})
+#        run: npm run select --reactNative ${{ env.BRN_Version }}
+#        working-directory: ./Apps/Playground
+#      - name: NPM Install (Binary Package)
+#        run: npm install
+#        working-directory: ./Package
+#      - name: Gulp (iOS)
+#        run: npx gulp buildIOS
+#        working-directory: ./Package
+#
+#  test-publish-android-ios:
+#    runs-on: macos-latest
+#    steps:
+#      - name: Checkout Repo
+#        uses: actions/checkout@v2.3.3
+#        with:
+#          submodules: 'recursive'
+#      - name: Setup CMake
+#        uses: jwlawson/actions-setup-cmake@v1.8
+#        with:
+#          cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
+#      - name: Setup Ninja
+#        run: brew install ninja
+#      - name: NPM Install (Playground)
+#        run: npm install
+#        working-directory: ./Apps/Playground
+#      - name: NPM Install (React Native ${{ env.BRN_Version }})
+#        run: npm run select --reactNative ${{ env.BRN_Version }}
+#        working-directory: ./Apps/Playground
+#      - name: NPM Install (Binary Package)
+#        run: npm install
+#        working-directory: ./Package
+#      - name: Gulp
+#        run: npx gulp
+#        working-directory: ./Package
+#
+#  build-windows:
+#    runs-on: windows-2019
+#    strategy:
+#      matrix:
+#        platform: [x86, x64, ARM64]
+#        config: [Debug, Release]
+#    steps:
+#      - name: Checkout Repo
+#        uses: actions/checkout@v2.3.3
+#        with:
+#          submodules: 'true'
+#      - name: Setup MSBuild
+#        uses: microsoft/setup-msbuild@v1.0.2
+#      - name: Setup NuGet
+#        uses: nuget/setup-nuget@v1
+#        with:
+#          nuget-version: '5.x'
+#      - name: NPM Install (Playground)
+#        run: npm install
+#        working-directory: ./Apps/Playground
+#      - name: NPM Install (React Native ${{ env.BRN_Version }})
+#        run: npm run select ${{ env.BRN_Version }}
+#        working-directory: ./Apps/Playground
+#      - name: NPM Install (Binary Package)
+#        run: npm install
+#        working-directory: ./Package
+#      - name: Git (Windows)
+#        run: npx gulp initializeSubmodulesWindowsAgent
+#        working-directory: ./Package
+#      - name: Gulp Setup Project ${{ matrix.platform }} (Windows)
+#        run: npx gulp makeUWPProject${{ matrix.platform }}
+#        working-directory: ./Package
+#      - name: Gulp Build ${{ matrix.platform }} ${{ matrix.config }} (Windows)
+#        run: npx gulp buildUWP${{ matrix.platform }}${{ matrix.config }}
+#        working-directory: ./Package
+#      - name: Gulp NuGet Restore Playground
+#        run: npx gulp nugetRestoreUWPPlayground
+#        working-directory: ./Package
+#      - name: Gulp Build ${{ matrix.platform }} ${{ matrix.config }} Playground (Windows)
+#        run: npx gulp buildUWPPlayground${{ matrix.platform }}${{ matrix.config }}
+#        working-directory: ./Package
+#
 # Test packages
-  build-android-ios-065:
-    uses: ./.github/workflows/ios_android.yml
-    with:
-      react-native-version: 0.65
-      release-version: 1.0.0-${GITHUB_SHA::8}
+#  build-android-ios-065:
+#    uses: ./.github/workflows/ios_android.yml
+#    with:
+#      react-native-version: 0.65
+#      release-version: 1.0.0-${GITHUB_SHA::8}
+#
+#  build-windows-065:
+#    uses: ./.github/workflows/windows.yml
+#    with:
+#      react-native-version: 0.65
+#      release-version: 1.0.0-${GITHUB_SHA::8}
 
-  build-windows-065:
-    uses: ./.github/workflows/windows.yml
-    with:
-      react-native-version: 0.65
-      release-version: 1.0.0-${GITHUB_SHA::8}
-
-  build-typescript:
-    uses: ./.github/workflows/typescript.yml
-    with:
-      release-version: 1.0.0-${GITHUB_SHA::8}
+#  build-typescript:
+#    uses: ./.github/workflows/typescript.yml
+#    with:
+#      release-version: 1.0.0-${GITHUB_SHA::8}
 
   package:
     needs: [build-typescript] #, build-android-ios-065, build-windows-065]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
-      - name: Download Assembled Folder
-        uses: actions/download-artifact@v2
-        with:
-          name: 'Assembled'
-          path: Package/Assembled
+#      - name: Download Assembled Folder
+#        uses: actions/download-artifact@v2
+#        with:
+#          name: 'Assembled'
+#          path: Package/Assembled
 #      - name: Download Assembled-iOSAndroid 0.65 Folder
 #        uses: actions/download-artifact@v2
 #        with:
@@ -166,9 +166,9 @@ jobs:
 
       - name: Version & Publish Package @babylonjs/react-native
         run: |
-          npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
+          npm version --no-git-tag-version 0.0.0-${GITHUB_SHA::8}
           npm publish
-        working-directory: ./Package/Assembled
+        working-directory: ./PackageUp
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Version & Publish Package @babylonjs/react-native
         run: |
           npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
-          npm publish --access public
+          npm publish
         working-directory: ./Package/Assembled
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -175,7 +175,7 @@ jobs:
       - name: Version & Publish Package @babylonjs/react-native-iosandroid-0-65
         run: |
           npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
-          npm publish --access public
+          npm publish
         working-directory: ./Package/Assembled-iOSAndroid0.65
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
       - name: Version & Publish Package @babylonjs/react-native-windows-0-65
         run: |
           npm version --no-git-tag-version 1.0.0-${GITHUB_SHA::8}
-          npm publish --access public
+          npm publish
         working-directory: ./Package/Assembled-Windows0.65
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -140,6 +140,9 @@ jobs:
 #      release-version: 1.0.0-${GITHUB_SHA::8}
 
   package:
+    permissions:
+      packages: write
+
 #    needs: [build-typescript] #, build-android-ios-065, build-windows-065]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -162,8 +162,6 @@ jobs:
 # TEMP
       - name: Checkout Repo
         uses: actions/checkout@v2.3.3
-        with:
-          submodules: 'recursive'
 # TEMP
 
       - name: Setup Node.js

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,8 @@ on:
 env:
   BRN_Version: 0.64
 
+permissions: write-all
+
 jobs:
 #  build-android:
 #    runs-on: macos-latest
@@ -140,9 +142,6 @@ jobs:
 #      release-version: 1.0.0-${GITHUB_SHA::8}
 
   package:
-    permissions:
-      packages: read/write
-
 #    needs: [build-typescript] #, build-android-ios-065, build-windows-065]
     runs-on: ubuntu-latest
     steps:

--- a/PackageUp/package.json
+++ b/PackageUp/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@cedricguillemet/garegex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/PackageUp/package.json
+++ b/PackageUp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babylonjs/babylonreactnative",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/PackageUp/package.json
+++ b/PackageUp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@babylonjs/dummypackage",
+  "name": "@babylonjs/babylonreactnative",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/PackageUp/package.json
+++ b/PackageUp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cedricguillemet/garegex",
+  "name": "@babylonjs/dummyPackage",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/PackageUp/package.json
+++ b/PackageUp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@babylonjs/dummyPackage",
+  "name": "@babylonjs/dummypackage",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
- Add parallel build jobs for building 0.65 & upload artifacts
- Github Action bot that pushes artifact URL as PR comment

![image](https://user-images.githubusercontent.com/1312968/176434105-7d259fb8-f56e-4c9b-9a22-f9376a7d30e1.png)

This PR addresses 2 issues related to testing:
- when doing a change, you don't have to build other platforms. The CI does it for you and you can test the artifact packages
- when doing fixes/features for partners, they have to wait for a new NPM package or build on their side.

As 0.65 build is done in parallel, it doesn't slow down the global build time.