### PR TITLE
Alpha premultiplied backbuffer Windows

### DIFF
--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
@@ -183,7 +183,7 @@ namespace winrt::BabylonReactNative::implementation {
             if (propertyName == "isTransparent")
             {
                 bool isTransparent = propertyValue.AsBoolean();
-                this->CompositeMode(isTransparent ? ElementCompositeMode::MinBlend : ElementCompositeMode::Inherit);
+                BabylonNative::UpdateAlphaPremultiplied(isTransparent);
             } else if (propertyName == "antiAliasing")
             {
                 auto value = propertyValue.AsUInt8();

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -89,6 +89,7 @@ namespace BabylonNative
                 g_graphics->UpdateSize(width, height);
             }
             g_graphics->UpdateMSAA(mMSAAValue);
+            g_graphics->UpdateAlphaPremultiplied(mAlphaPremultiplied);
 
             g_graphics->EnableRendering();
             m_isRenderingEnabled = true;
@@ -114,6 +115,15 @@ namespace BabylonNative
             if (g_graphics)
             {
                 g_graphics->UpdateMSAA(value);
+            }
+        }
+
+        void UpdateAlphaPremultiplied(bool enabled)
+        {
+            mAlphaPremultiplied = enabled;
+            if (g_graphics)
+            {
+                g_graphics->UpdateAlphaPremultiplied(enabled);
             }
         }
 
@@ -236,6 +246,7 @@ namespace BabylonNative
 
         std::shared_ptr<bool> m_isXRActive{};
         uint8_t mMSAAValue{};
+        bool mAlphaPremultiplied{};
     };
 
     namespace
@@ -281,6 +292,18 @@ namespace BabylonNative
         else
         {
             throw std::runtime_error{ "UpdateMSAA must not be called before Initialize." };
+        }
+    }
+
+    void UpdateAlphaPremultiplied(bool enabled)
+    {
+        if (auto nativeModule{ g_nativeModule.lock() })
+        {
+            nativeModule->UpdateAlphaPremultiplied(enabled);
+        }
+        else
+        {
+            throw std::runtime_error{ "UpdateAlphaPremultiplied must not be called before Initialize." };
         }
     }
 

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.h
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.h
@@ -29,6 +29,7 @@ namespace BabylonNative
 
     void UpdateView(WindowType window, size_t width, size_t height);
     void UpdateMSAA(uint8_t value);
+    void UpdateAlphaPremultiplied(bool enabled);
 
     void RenderView();
     void ResetView();


### PR DESCRIPTION
follow up to https://github.com/BabylonJS/BabylonNative/pull/1100
Change alpha premultiplied back buffer depending on transparency settings. 
`isTopMost` property not implemented as it's not mandatory for our partner and it seems like it needs deeper understanding and (a lot) more work.
PR will be updated with submodule update when BabylonNative PR is merged.