### PR TITLE
Bump Android SDK versions + compatibility fixes

### DIFF
--- a/Apps/PackageTest/0.63.1/android/app/build.gradle
+++ b/Apps/PackageTest/0.63.1/android/app/build.gradle
@@ -121,6 +121,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    ndkVersion rootProject.ext.ndkVersion
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
@@ -159,6 +161,10 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
+
+            // Caution! In production, you probably don't want it to be debuggable.
+            debuggable true
+
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
@@ -177,6 +183,13 @@ android {
             }
 
         }
+    }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 }
 

--- a/Apps/PackageTest/0.63.1/android/build.gradle
+++ b/Apps/PackageTest/0.63.1/android/build.gradle
@@ -2,17 +2,18 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
-        minSdkVersion = 18
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        buildToolsVersion = "30.0.2"
+        minSdkVersion = 23
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        ndkVersion = "23.2.8568313"
     }
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.4")
+        classpath("com.android.tools.build:gradle:4.2.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/PackageTest/0.63.1/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.63.1/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/PackageTest/0.64.0/android/app/build.gradle
+++ b/Apps/PackageTest/0.64.0/android/app/build.gradle
@@ -121,6 +121,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    ndkVersion rootProject.ext.ndkVersion
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
@@ -159,6 +161,10 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
+
+            // Caution! In production, you probably don't want it to be debuggable.
+            debuggable true
+
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
@@ -177,6 +183,13 @@ android {
             }
 
         }
+    }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 }
 

--- a/Apps/PackageTest/0.64.0/android/build.gradle
+++ b/Apps/PackageTest/0.64.0/android/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
-        minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        buildToolsVersion = "30.0.2"
+        minSdkVersion = 23
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        ndkVersion = "23.2.8568313"
     }
     repositories {
         google()

--- a/Apps/PackageTest/0.64.0/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.64.0/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/PackageTest/0.65.0/android/app/build.gradle
+++ b/Apps/PackageTest/0.65.0/android/app/build.gradle
@@ -156,6 +156,10 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
+
+            // Caution! In production, you probably don't want it to be debuggable.
+            debuggable true
+
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
@@ -175,6 +179,13 @@ android {
             }
 
         }
+    }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 }
 

--- a/Apps/PackageTest/0.65.0/android/build.gradle
+++ b/Apps/PackageTest/0.65.0/android/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
     ext {
         buildToolsVersion = "30.0.2"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 30
         targetSdkVersion = 30
-        ndkVersion = "20.1.5948944"
+        ndkVersion = "23.2.8568313"
     }
     repositories {
         google()

--- a/Apps/PackageTest/0.69.0/android/app/build.gradle
+++ b/Apps/PackageTest/0.69.0/android/app/build.gradle
@@ -233,6 +233,10 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
+
+            // Caution! In production, you probably don't want it to be debuggable.
+            debuggable true
+
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
@@ -252,6 +256,13 @@ android {
             }
 
         }
+    }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 }
 

--- a/Apps/PackageTest/0.69.0/android/build.gradle
+++ b/Apps/PackageTest/0.69.0/android/build.gradle
@@ -5,15 +5,14 @@ import org.apache.tools.ant.taskdefs.condition.Os
 buildscript {
     ext {
         buildToolsVersion = "30.0.2"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 31
         targetSdkVersion = 31
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"
         } else {
-            // Otherwise we default to the side-by-side NDK version from AGP.
-            ndkVersion = "21.4.7075529"
+            ndkVersion = "23.2.8568313"
         }
     }
     repositories {

--- a/Apps/PackageTest/0.69.0/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.69.0/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/Playground/0.64/android/app/build.gradle
+++ b/Apps/Playground/0.64/android/app/build.gradle
@@ -121,9 +121,9 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    ndkVersion rootProject.ext.ndkVersion
 
-    ndkVersion = rootProject.ext.ndkVersion
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -161,6 +161,10 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
+
+            // Caution! In production, you probably don't want it to be debuggable.
+            debuggable true
+
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
@@ -179,6 +183,13 @@ android {
             }
 
         }
+    }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 }
 

--- a/Apps/Playground/0.64/android/build.gradle
+++ b/Apps/Playground/0.64/android/build.gradle
@@ -2,18 +2,18 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.3"
-        minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
-        ndkVersion = "21.3.6528147"
+        buildToolsVersion = "30.0.2"
+        minSdkVersion = 23
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        ndkVersion = "23.2.8568313"
     }
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.0")
+        classpath("com.android.tools.build:gradle:4.2.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/Playground/0.64/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/Playground/0.64/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/Playground/0.65/android/app/build.gradle
+++ b/Apps/Playground/0.65/android/app/build.gradle
@@ -156,6 +156,10 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
+
+            // Caution! In production, you probably don't want it to be debuggable.
+            debuggable true
+
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
@@ -175,6 +179,13 @@ android {
             }
 
         }
+    }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 }
 

--- a/Apps/Playground/0.65/android/build.gradle
+++ b/Apps/Playground/0.65/android/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
     ext {
         buildToolsVersion = "30.0.2"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 30
         targetSdkVersion = 30
-        ndkVersion = "20.1.5948944"
+        ndkVersion = "23.2.8568313"
     }
     repositories {
         google()

--- a/Apps/Playground/0.69/android/app/build.gradle
+++ b/Apps/Playground/0.69/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
     ndkVersion rootProject.ext.ndkVersion
 
     compileSdkVersion rootProject.ext.compileSdkVersion
-	
+
     defaultConfig {
         applicationId "com.playground"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -233,6 +233,10 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
+
+            // Caution! In production, you probably don't want it to be debuggable.
+            debuggable true
+
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
@@ -252,6 +256,13 @@ android {
             }
 
         }
+    }
+
+    packagingOptions {
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 }
 

--- a/Apps/Playground/0.69/android/build.gradle
+++ b/Apps/Playground/0.69/android/build.gradle
@@ -5,15 +5,14 @@ import org.apache.tools.ant.taskdefs.condition.Os
 buildscript {
     ext {
         buildToolsVersion = "30.0.2"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 31
         targetSdkVersion = 31
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"
         } else {
-            // Otherwise we default to the side-by-side NDK version from AGP.
-            ndkVersion = "21.4.7075529"
+            ndkVersion = "23.2.8568313"
         }
     }
     repositories {

--- a/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
+++ b/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
@@ -10,11 +10,11 @@
 //   original location:
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_MIN_SDK_VERSION = 21
-def DEFAULT_TARGET_SDK_VERSION = 28
-def DEFAULT_NDK_VERSION = '21.3.6528147'
+def DEFAULT_COMPILE_SDK_VERSION = 30
+def DEFAULT_BUILD_TOOLS_VERSION = '30.0.2'
+def DEFAULT_MIN_SDK_VERSION = 23
+def DEFAULT_TARGET_SDK_VERSION = 30
+def DEFAULT_NDK_VERSION = '23.2.8568313'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -62,7 +62,7 @@ android {
         externalNativeBuild {
             cmake {
                 abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
-                arguments '-DANDROID_STL=c++_static',
+                arguments "-DANDROID_STL=c++_shared",
                         "-DGRAPHICS_API=${graphics_api}",
                         "-DARCORE_LIBPATH=${extractedLibDir}/jni",
                         "-DFBJNI_INCPATH=${extractedLibDir}/fbjni/",
@@ -116,11 +116,11 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'com.google.ar:core:1.22.0'
 
-    api("com.facebook.fbjni:fbjni-java-only:0.0.3")
+    api("com.facebook.fbjni:fbjni-java-only:0.3.0")
 
     natives 'com.google.ar:core:1.22.0'
-    fbjniHeaders 'com.facebook.fbjni:fbjni:0.0.2:headers'
-    fbjniLibs 'com.facebook.fbjni:fbjni:0.0.2'
+    fbjniHeaders 'com.facebook.fbjni:fbjni:0.3.0:headers'
+    fbjniLibs 'com.facebook.fbjni:fbjni:0.3.0'
 }
 
 def configureReactNativePom(def pom) {

--- a/Package/Android/build.gradle
+++ b/Package/Android/build.gradle
@@ -10,10 +10,10 @@
 //   original location:
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_MIN_SDK_VERSION = 18
-def DEFAULT_TARGET_SDK_VERSION = 28
+def DEFAULT_COMPILE_SDK_VERSION = 30
+def DEFAULT_BUILD_TOOLS_VERSION = '30.0.2'
+def DEFAULT_MIN_SDK_VERSION = 23
+def DEFAULT_TARGET_SDK_VERSION = 30
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback


### PR DESCRIPTION
**Describe the change**

- Bump versions (minSdkVersion 23 and ndkVersion 23.2.8568313)
- Use libc++_shared for ANDROID_STL
- Make Playground release builds debuggable

**Documentation**

TODO: maybe should add/update requirements

**Testing**

TODO