### PR TITLE
Make versions consistent and bump fbjni to 0.3.0

### DIFF
--- a/.github/workflows/bn_master_commit.yml
+++ b/.github/workflows/bn_master_commit.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Gulp (Android)
         run: npx gulp buildAndroid
         working-directory: ./Package
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_11_X64 }}
 
   build-iOS:
     name: Build iOS - BabylonNative ${{ github.event.client_payload.sha }}

--- a/.github/workflows/ios_android.yml
+++ b/.github/workflows/ios_android.yml
@@ -9,10 +9,6 @@ on:
       release-version:
         required: true
         type: string
-      java-version:
-        required: false
-        type: string
-        default: '8'
 
 jobs:
   Build:
@@ -26,11 +22,6 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.8
         with:
           cmake-version: '3.19.6' # See https://gitlab.kitware.com/cmake/cmake/-/issues/22021
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: ${{ inputs.java-version }}        
       - name: Setup Ninja
         run: brew install ninja
       - name: NPM Install (Playground)
@@ -45,6 +36,8 @@ jobs:
       - name: Gulp
         run: npx gulp --reactNative ${{ inputs.react-native-version }} --releaseVersion ${{ inputs.release-version }}
         working-directory: ./Package
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_11_X64 }}
       - name: Upload Assembled iOS Android Folder
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,6 +80,8 @@ jobs:
       - name: Gulp
         run: npx gulp
         working-directory: ./Package
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_11_X64 }}
 
   build-windows:
     runs-on: windows-2019

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Gulp (Android)
         run: npx gulp buildAndroid
         working-directory: ./Package
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_11_X64 }}
 
   build-iOS:
     runs-on: macos-latest
@@ -125,14 +127,12 @@ jobs:
   build-android-ios-065:
     uses: ./.github/workflows/ios_android.yml
     with:
-      java-version: '8'
       react-native-version: 0.65
       release-version: 0.0.${GITHUB_SHA::8}
 
   build-android-ios-069:
     uses: ./.github/workflows/ios_android.yml
     with:
-      java-version: '11'
       react-native-version: 0.69
       release-version: 0.0.${GITHUB_SHA::8}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,21 +7,18 @@ jobs:
   build-android-ios-064:
     uses: ./.github/workflows/ios_android.yml
     with:
-      java-version: '8'
       react-native-version: 0.64
       release-version: ${GITHUB_REF/refs\/tags\//}
 
   build-android-ios-065:
     uses: ./.github/workflows/ios_android.yml
     with:
-      java-version: '8'
       react-native-version: 0.65
       release-version: ${GITHUB_REF/refs\/tags\//}
       
   build-android-ios-069:
     uses: ./.github/workflows/ios_android.yml
     with:
-      java-version: '11'
       react-native-version: 0.69
       release-version: ${GITHUB_REF/refs\/tags\//}
 

--- a/.github/workflows/publish_preview.yml
+++ b/.github/workflows/publish_preview.yml
@@ -17,21 +17,18 @@ jobs:
   build-android-ios-064:
     uses: ./.github/workflows/ios_android.yml
     with:
-      java-version: '8'
       react-native-version: 0.64
       release-version: ${{ github.event.inputs.release_version }}
 
   build-android-ios-065:
     uses: ./.github/workflows/ios_android.yml
     with:
-      java-version: '8'
       react-native-version: 0.65
       release-version: ${{ github.event.inputs.release_version }}
 
   build-android-ios-069:
     uses: ./.github/workflows/ios_android.yml
     with:
-      java-version: '11'
       react-native-version: 0.69
       release-version: ${{ github.event.inputs.release_version }}
 

--- a/Apps/PackageTest/0.63.1/android/app/build.gradle
+++ b/Apps/PackageTest/0.63.1/android/app/build.gradle
@@ -121,6 +121,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    ndkVersion rootProject.ext.ndkVersion
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {

--- a/Apps/PackageTest/0.63.1/android/app/build.gradle
+++ b/Apps/PackageTest/0.63.1/android/app/build.gradle
@@ -213,7 +213,7 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 

--- a/Apps/PackageTest/0.63.1/android/app/src/debug/AndroidManifest.xml
+++ b/Apps/PackageTest/0.63.1/android/app/src/debug/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
 </manifest>

--- a/Apps/PackageTest/0.63.1/android/app/src/main/AndroidManifest.xml
+++ b/Apps/PackageTest/0.63.1/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/Apps/PackageTest/0.63.1/android/build.gradle
+++ b/Apps/PackageTest/0.63.1/android/build.gradle
@@ -2,17 +2,18 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
-        minSdkVersion = 18
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        buildToolsVersion = "30.0.2"
+        minSdkVersion = 21
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.4")
+        classpath("com.android.tools.build:gradle:4.2.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/PackageTest/0.63.1/android/build.gradle
+++ b/Apps/PackageTest/0.63.1/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         ndkVersion = "21.4.7075529"
     }
     repositories {
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.1")
+        classpath("com.android.tools.build:gradle:7.2.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/PackageTest/0.63.1/android/build.gradle
+++ b/Apps/PackageTest/0.63.1/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.2")

--- a/Apps/PackageTest/0.63.1/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.63.1/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/PackageTest/0.63.1/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.63.1/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/PackageTest/0.64.0/android/app/build.gradle
+++ b/Apps/PackageTest/0.64.0/android/app/build.gradle
@@ -121,6 +121,8 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
+    ndkVersion rootProject.ext.ndkVersion
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {

--- a/Apps/PackageTest/0.64.0/android/app/build.gradle
+++ b/Apps/PackageTest/0.64.0/android/app/build.gradle
@@ -213,7 +213,7 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 

--- a/Apps/PackageTest/0.64.0/android/app/src/debug/AndroidManifest.xml
+++ b/Apps/PackageTest/0.64.0/android/app/src/debug/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
 </manifest>

--- a/Apps/PackageTest/0.64.0/android/app/src/main/AndroidManifest.xml
+++ b/Apps/PackageTest/0.64.0/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/Apps/PackageTest/0.64.0/android/build.gradle
+++ b/Apps/PackageTest/0.64.0/android/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()

--- a/Apps/PackageTest/0.64.0/android/build.gradle
+++ b/Apps/PackageTest/0.64.0/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         ndkVersion = "21.4.7075529"
     }
     repositories {
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.4")
+        classpath("com.android.tools.build:gradle:7.2.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/PackageTest/0.64.0/android/build.gradle
+++ b/Apps/PackageTest/0.64.0/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.2")

--- a/Apps/PackageTest/0.64.0/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.64.0/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/PackageTest/0.64.0/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.64.0/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/PackageTest/0.65.0/android/app/build.gradle
+++ b/Apps/PackageTest/0.65.0/android/app/build.gradle
@@ -210,7 +210,7 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 

--- a/Apps/PackageTest/0.65.0/android/app/src/debug/AndroidManifest.xml
+++ b/Apps/PackageTest/0.65.0/android/app/src/debug/AndroidManifest.xml
@@ -2,12 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
+        <activity android:name="com.playground.MainActivity" android:exported="true" />
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 </manifest>

--- a/Apps/PackageTest/0.65.0/android/app/src/main/AndroidManifest.xml
+++ b/Apps/PackageTest/0.65.0/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/Apps/PackageTest/0.65.0/android/build.gradle
+++ b/Apps/PackageTest/0.65.0/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30
-        ndkVersion = "20.1.5948944"
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()

--- a/Apps/PackageTest/0.65.0/android/build.gradle
+++ b/Apps/PackageTest/0.65.0/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         ndkVersion = "21.4.7075529"
     }
     repositories {
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.1")
+        classpath("com.android.tools.build:gradle:7.2.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/PackageTest/0.65.0/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.65.0/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/PackageTest/0.69.0/android/app/src/debug/AndroidManifest.xml
+++ b/Apps/PackageTest/0.69.0/android/app/src/debug/AndroidManifest.xml
@@ -2,12 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false" />
+        <activity android:name="com.playground.MainActivity" android:exported="true" />
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 </manifest>

--- a/Apps/PackageTest/0.69.0/android/build.gradle
+++ b/Apps/PackageTest/0.69.0/android/build.gradle
@@ -4,10 +4,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"
@@ -21,7 +21,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.0")
+        classpath("com.android.tools.build:gradle:7.2.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/PackageTest/0.69.0/android/build.gradle
+++ b/Apps/PackageTest/0.69.0/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     ext {
         buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 30
+        targetSdkVersion = 30
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"

--- a/Apps/PackageTest/0.69.0/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.69.0/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/PackageTest/0.69.0/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/PackageTest/0.69.0/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/Playground/0.64/android/app/build.gradle
+++ b/Apps/Playground/0.64/android/app/build.gradle
@@ -121,9 +121,9 @@ def jscFlavor = 'org.webkit:android-jsc:+'
 def enableHermes = project.ext.react.get("enableHermes", false);
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    ndkVersion rootProject.ext.ndkVersion
 
-    ndkVersion = rootProject.ext.ndkVersion
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/Apps/Playground/0.64/android/app/build.gradle
+++ b/Apps/Playground/0.64/android/app/build.gradle
@@ -213,7 +213,7 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 

--- a/Apps/Playground/0.64/android/app/src/debug/AndroidManifest.xml
+++ b/Apps/Playground/0.64/android/app/src/debug/AndroidManifest.xml
@@ -2,12 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
+        <activity android:name="com.playground.MainActivity" android:exported="true" />
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 </manifest>

--- a/Apps/Playground/0.64/android/app/src/main/AndroidManifest.xml
+++ b/Apps/Playground/0.64/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/Apps/Playground/0.64/android/build.gradle
+++ b/Apps/Playground/0.64/android/build.gradle
@@ -2,18 +2,18 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.3"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
-        ndkVersion = "21.3.6528147"
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.0")
+        classpath("com.android.tools.build:gradle:4.2.1")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/Playground/0.64/android/build.gradle
+++ b/Apps/Playground/0.64/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         ndkVersion = "21.4.7075529"
     }
     repositories {
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.1")
+        classpath("com.android.tools.build:gradle:7.2.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/Playground/0.64/android/build.gradle
+++ b/Apps/Playground/0.64/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.2")

--- a/Apps/Playground/0.64/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/Playground/0.64/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/Playground/0.64/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/Playground/0.64/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/Playground/0.65/android/app/build.gradle
+++ b/Apps/Playground/0.65/android/app/build.gradle
@@ -210,7 +210,7 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }
 

--- a/Apps/Playground/0.65/android/app/src/debug/AndroidManifest.xml
+++ b/Apps/Playground/0.65/android/app/src/debug/AndroidManifest.xml
@@ -2,12 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
+        <activity android:name="com.playground.MainActivity" android:exported="true" />
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 </manifest>

--- a/Apps/Playground/0.65/android/app/src/debug/java/com/playground/ReactNativeFlipper.java
+++ b/Apps/Playground/0.65/android/app/src/debug/java/com/playground/ReactNativeFlipper.java
@@ -17,7 +17,6 @@ import com.facebook.flipper.plugins.inspector.DescriptorMapping;
 import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin;
 import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor;
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin;
-import com.facebook.flipper.plugins.react.ReactFlipperPlugin;
 import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.ReactContext;
@@ -30,7 +29,6 @@ public class ReactNativeFlipper {
       final FlipperClient client = AndroidFlipperClient.getInstance(context);
 
       client.addPlugin(new InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()));
-      client.addPlugin(new ReactFlipperPlugin());
       client.addPlugin(new DatabasesFlipperPlugin(context));
       client.addPlugin(new SharedPreferencesFlipperPlugin(context));
       client.addPlugin(CrashReporterPlugin.getInstance());

--- a/Apps/Playground/0.65/android/app/src/main/AndroidManifest.xml
+++ b/Apps/Playground/0.65/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/Apps/Playground/0.65/android/build.gradle
+++ b/Apps/Playground/0.65/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30
-        ndkVersion = "20.1.5948944"
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()

--- a/Apps/Playground/0.65/android/build.gradle
+++ b/Apps/Playground/0.65/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         ndkVersion = "21.4.7075529"
     }
     repositories {
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.1")
+        classpath("com.android.tools.build:gradle:7.2.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/Playground/0.65/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/Playground/0.65/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Apps/Playground/0.69/android/app/build.gradle
+++ b/Apps/Playground/0.69/android/app/build.gradle
@@ -133,7 +133,7 @@ android {
     ndkVersion rootProject.ext.ndkVersion
 
     compileSdkVersion rootProject.ext.compileSdkVersion
-	
+
     defaultConfig {
         applicationId "com.playground"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/Apps/Playground/0.69/android/app/src/debug/AndroidManifest.xml
+++ b/Apps/Playground/0.69/android/app/src/debug/AndroidManifest.xml
@@ -2,12 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false" />
+        <activity android:name="com.playground.MainActivity" android:exported="true" />
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 </manifest>

--- a/Apps/Playground/0.69/android/build.gradle
+++ b/Apps/Playground/0.69/android/build.gradle
@@ -4,7 +4,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31
@@ -21,7 +21,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.1")
+        classpath("com.android.tools.build:gradle:7.2.2")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/Apps/Playground/0.69/android/gradle/wrapper/gradle-wrapper.properties
+++ b/Apps/Playground/0.69/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Modules/@babylonjs/react-native-iosandroid/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native-iosandroid/android/CMakeLists.txt
@@ -68,7 +68,6 @@ target_link_libraries(BabylonNative
     log
     -lz
     arcana
-    fbjni
     jsi
     turbomodulejsijni
     AndroidExtensions

--- a/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
+++ b/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
@@ -32,10 +32,10 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath 'com.android.tools.build:gradle:7.2.2'
         }
     }
 }
@@ -44,10 +44,9 @@ def graphics_api = safeExtGet('GRAPHICS_API', "OpenGL")
 
 apply plugin: 'com.android.library'
 
-configurations { 
-    natives
-    fbjniHeaders
-    fbjniLibs
+configurations {
+    extractHeaders
+    extractLibs
 }
 
 android {
@@ -64,9 +63,9 @@ android {
                 abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
                 arguments '-DANDROID_STL=c++_static',
                         "-DGRAPHICS_API=${graphics_api}",
-                        "-DARCORE_LIBPATH=${extractedLibDir}/jni",
-                        "-DFBJNI_INCPATH=${extractedLibDir}/fbjni/",
-                        "-DFBJNI_LIBPATH=${extractedLibDir}/jni",
+                        "-DARCORE_LIBPATH=${extractedLibDir}/core-1.22.0.aar/jni",
+                        "-DFBJNI_INCPATH=${extractedLibDir}/fbjni-0.3.0-headers.jar/",
+                        "-DFBJNI_LIBPATH=${extractedLibDir}/fbjni-0.3.0.aar/jni",
                         "-DREACTNATIVE_DIR=${rootDir}/../node_modules/react-native/"
             }
         }
@@ -107,6 +106,7 @@ android {
 
 repositories {
     google()
+    mavenCentral()
 }
 
 dependencies {
@@ -115,11 +115,8 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'com.google.ar:core:1.22.0'
 
-    api("com.facebook.fbjni:fbjni-java-only:0.3.0")
-
-    natives 'com.google.ar:core:1.22.0'
-    fbjniHeaders 'com.facebook.fbjni:fbjni:0.3.0:headers'
-    fbjniLibs 'com.facebook.fbjni:fbjni:0.3.0'
+    extractHeaders 'com.facebook.fbjni:fbjni:0.3.0:headers'
+    extractLibs 'com.facebook.fbjni:fbjni:0.3.0', 'com.google.ar:core:1.22.0'
 }
 
 def configureReactNativePom(def pom) {
@@ -150,40 +147,24 @@ def configureReactNativePom(def pom) {
     }
 }
 
-// Extracts the shared libraries from aars in the natives configuration.
-// This is done so that NDK builds can access these libraries.
-task extractNativeLibraries() {
-    // Always extract, this insures the native libs are updated if the version changes.
-    outputs.upToDateWhen { false }
-    doFirst {
-        configurations.natives.files.each { f ->
-            copy {
-                from zipTree(f)
-                into extractedLibDir
-                include "jni/**/*"
-            }
-        }
-    }
-}
-
-task extractFBJNIHeaders {
+task extractHeaders {
     doLast {
-        configurations.fbjniHeaders.files.each { f ->
+        configurations.extractLibs.files.each { file ->
             copy {
-                from zipTree(f)
-                into "$extractedLibDir/fbjni"
+                from zipTree(file)
+                into "$extractedLibDir/" + file.name
                 include "**/*.h"
             }
         }
     }
 }
 
-task extractFBJNILibs {
+task extractLibs {
     doLast {
-        configurations.fbjniLibs.files.each { f ->
+        configurations.extractLibs.files.each { file ->
             copy {
-                from zipTree(f)
-                into extractedLibDir
+                from zipTree(file)
+                into "$extractedLibDir/" + file.name
                 include "jni/**/*"
             }
         }
@@ -191,10 +172,9 @@ task extractFBJNILibs {
 }
 
 tasks.whenTaskAdded { task ->
-    if (task.name.contains("external") && !task.name.contains("Clean")) {
-        task.dependsOn(extractNativeLibraries)
-        task.dependsOn(extractFBJNIHeaders)
-        task.dependsOn(extractFBJNILibs)
+    if (task.name.contains("configureCMake")) {
+        task.dependsOn(extractHeaders)
+        task.dependsOn(extractLibs)
     }
 }
 

--- a/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
+++ b/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
@@ -107,7 +107,6 @@ android {
 
 repositories {
     google()
-    jcenter()
 }
 
 dependencies {

--- a/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
+++ b/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
@@ -10,11 +10,11 @@
 //   original location:
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
+def DEFAULT_COMPILE_SDK_VERSION = 30
+def DEFAULT_BUILD_TOOLS_VERSION = '30.0.2'
 def DEFAULT_MIN_SDK_VERSION = 21
-def DEFAULT_TARGET_SDK_VERSION = 28
-def DEFAULT_NDK_VERSION = '21.3.6528147'
+def DEFAULT_TARGET_SDK_VERSION = 30
+def DEFAULT_NDK_VERSION = '21.4.7075529'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -116,11 +116,11 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'com.google.ar:core:1.22.0'
 
-    api("com.facebook.fbjni:fbjni-java-only:0.0.3")
+    api("com.facebook.fbjni:fbjni-java-only:0.3.0")
 
     natives 'com.google.ar:core:1.22.0'
-    fbjniHeaders 'com.facebook.fbjni:fbjni:0.0.2:headers'
-    fbjniLibs 'com.facebook.fbjni:fbjni:0.0.2'
+    fbjniHeaders 'com.facebook.fbjni:fbjni:0.3.0:headers'
+    fbjniLibs 'com.facebook.fbjni:fbjni:0.3.0'
 }
 
 def configureReactNativePom(def pom) {

--- a/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
+++ b/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
@@ -149,7 +149,7 @@ def configureReactNativePom(def pom) {
 
 task extractHeaders {
     doLast {
-        configurations.extractLibs.files.each { file ->
+        configurations.extractHeaders.files.each { file ->
             copy {
                 from zipTree(file)
                 into "$extractedLibDir/" + file.name

--- a/Package/Android/build.gradle
+++ b/Package/Android/build.gradle
@@ -10,10 +10,10 @@
 //   original location:
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_MIN_SDK_VERSION = 18
-def DEFAULT_TARGET_SDK_VERSION = 28
+def DEFAULT_COMPILE_SDK_VERSION = 30
+def DEFAULT_BUILD_TOOLS_VERSION = '30.0.2'
+def DEFAULT_MIN_SDK_VERSION = 21
+def DEFAULT_TARGET_SDK_VERSION = 30
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/Package/Android/build.gradle
+++ b/Package/Android/build.gradle
@@ -33,10 +33,9 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.4.1'
+            classpath 'com.android.tools.build:gradle:7.2.2'
         }
     }
 }
@@ -71,7 +70,7 @@ if (REACT_VERSION >= 64) {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After merging upstream changes in the future, you will need to either run `npm i
 
 ### **Configuring a Mac Dev Environment**
 
-**Required Tools:** [Android Studio](https://developer.android.com/studio/) (including NDK 21.3.6528147), [CMake](https://cmake.org/), [Ninja](https://ninja-build.org/), [JDK 13](https://www.oracle.com/java/technologies/javase-jdk13-downloads.html)
+**Required Tools:** [Android Studio](https://developer.android.com/studio/) (including NDK 21.4.7075529), [CMake](https://cmake.org/), [Ninja](https://ninja-build.org/), [JDK 13](https://www.oracle.com/java/technologies/javase-jdk13-downloads.html)
 
 - The `PATH` environment variable must include the path to adb (typically ~/Library/Android/sdk/platform-tools/).
 - The `PATH` environment variable must include the path to Ninja, or Ninja must be [installed via a package manager](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages).
@@ -86,7 +86,7 @@ export JAVA_HOME=$(/usr/libexec/java_home -v 13)
 
 ### **Configuring a Windows Dev Environment**
 
-**Required Tools:** [Android Studio](https://developer.android.com/studio/) (including NDK 21.3.6528147), [CMake](https://cmake.org/), [Ninja](https://ninja-build.org/), [Visual Studio 2019](https://visualstudio.microsoft.com/vs/)
+**Required Tools:** [Android Studio](https://developer.android.com/studio/) (including NDK 21.4.7075529), [CMake](https://cmake.org/), [Ninja](https://ninja-build.org/), [Visual Studio 2019](https://visualstudio.microsoft.com/vs/)
 
 - The `PATH` environment variable must include the path to adb (typically %LOCALAPPDATA%/Android/sdk/platform-tools/).
 - The `PATH` environment variable must include the path to Ninja, or Ninja must be [installed via a package manager](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages).  
@@ -95,7 +95,7 @@ export JAVA_HOME=$(/usr/libexec/java_home -v 13)
 
 ### **Configuring a Linux Dev Environment**
 
-**Required Tools:** [Android Studio](https://developer.android.com/studio/) (including NDK 21.3.6528147)
+**Required Tools:** [Android Studio](https://developer.android.com/studio/) (including NDK 21.4.7075529)
 
 With Ubuntu, you can install needed packages by this command:
 


### PR DESCRIPTION
This change fixes a runtime problem when integrating Babylon React Native with an NDK greater than r21b. The symptom for this change is that some devices will crash with the following error:
> java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "_Unwind_Resume" referenced by "/data/app/<app id>/base.apk!/lib/x86/libBabylonNative.so"...

**Main Change**
- Update fbjni to 0.3.0.

**Consistency Changes**
- Update minSdkVersion to 21. Most are already at 21.
- Update NDK version to 21.4.7075529. Ideally, we should update to the latest NDK, but we can't as it will conflict with the API24 camera hack.
- Update to latest versions for:
  - buildToolsVersion (33.0.0)
  - compileSdkVersion (33)
  - targetSdkVersion (33)
  - gradle maven dependency (7.2.2)
  - gradle distribution (7.3.3)

**Additional Details**

It all started from the following NDK change: https://github.com/android/ndk/wiki/Changelog-r21#r21b
> [Issue 1166](https://github.com/android/ndk/issues/1166): Rehid unwinder symbols all architectures.

Early version of NDK r21, the unwinder symbols were exposed, but was later fixed in r21b. This make it such that any `.so` libraries compiled with r21 be incompatible with libraries compiled with r21b or greater. See [this](https://github.com/android/ndk/issues/1247).

This also includes any `.so` dependencies that uses the NDK, which seems obvious now, but it wasn't when we were investigating. This means that our only dependency that also must be updated is `fbjni`, which is the main fix for this change. I also updated version numbers to be consistent across the different cases because it was confusing what version we are actively using in the code base.

**Documentation**

- [x] Update README to reflect required NDK version

**Testing**

- [x] Locally with Android
- [x] 0.65 Android output against partner projects
- [ ] Locally with iOS

**Other**
Just for completeness, here are some documentation links (thanks to @bbowman) that were useful while investigating this issue:
- https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#unwinding
- https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md