### PR TITLE
Use abort controller to prevent async setState after unmount.

### DIFF
--- a/Modules/@babylonjs/react-native/NativeEngineHook.ts
+++ b/Modules/@babylonjs/react-native/NativeEngineHook.ts
@@ -9,9 +9,18 @@ export function useModuleInitializer(): boolean | undefined {
     const [initialized, setInitialized] = useState<boolean>();
 
     useEffect(() => {
+        const abortController = new AbortController();
         (async () => {
-            setInitialized(await ensureInitialized());
+            const isInitialized = await ensureInitialized();
+
+            if (!abortController.signal.aborted) {
+                setInitialized(isInitialized);
+            }
         })();
+
+        return () => {
+            abortController.abort();
+        }
     }, []);
 
     return initialized;


### PR DESCRIPTION
**Describe the change**

Only calls setState if not unmounted. useModuleInitializer was trying to set state in an async fashion, and this must always be accompanied by some cancellation or aborting mechanism in React, otherwise it is possible for a state update to happen on an unmounted component, causing memory leaks and warnings.

**Screenshots**

N/A

**Documentation**

N/A

**Testing**

*I need help testing on [Android|iOS|Windows]*
