### PR TITLE
fix(NativeEngineHook): avoid deprecated warning

### DIFF
--- a/Modules/@babylonjs/react-native/NativeEngineHook.ts
+++ b/Modules/@babylonjs/react-native/NativeEngineHook.ts
@@ -34,11 +34,16 @@ function useAppState(): string {
             setAppState(appState);
         };
 
-        AppState.addEventListener("change", onAppStateChanged);
+        const appStateListener = AppState.addEventListener("change", onAppStateChanged);
 
         return () => {
-            AppState.removeEventListener("change", onAppStateChanged);
-        }
+            if (!!appStateListener?.remove) {
+                appStateListener.remove();
+            }
+            else {
+                AppState.removeEventListener("change", onAppStateChanged);
+            }
+        };
     }, []);
 
     return appState;


### PR DESCRIPTION
Fixed useAppState hook causing "removeEventListener" deprecated warning on newer react native versions

**Describe the change**

- Checks if the return of AppState.addEventListener has a remove method
- If the remove method exists it will be called
- if the remove method doesn't exist, the event listener will be removed with the deprecated removeEventListener method

**Documentation**

*N/A*

**Testing**

Tested on Android and iOS
