### PR TITLE
Revoke rendering when SCP is unloaded

### DIFF
--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.cpp
@@ -19,6 +19,13 @@ namespace winrt::BabylonReactNative::implementation {
 
         _revokerData.SizeChangedRevoker = SizeChanged(winrt::auto_revoke, { this, &EngineView::OnSizeChanged });
 
+        // Stop rendering when SwapChainPanel is unloaded
+        _revokerData.UnloadedEventToken = Unloaded(winrt::auto_revoke, [ref = get_weak()](auto const&, auto const&) {
+            if (auto self = ref.get()) {
+                self->_revokerData.RenderingRevoker.revoke();
+            }
+        });
+
         WorkItemHandler workItemHandler([weakThis{ this->get_weak() }](IAsyncAction const& /* action */)
         {
             if (auto trueThis = weakThis.get())

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -27,6 +27,7 @@ namespace winrt::BabylonReactNative::implementation {
         struct RevokerData
         {
             winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker SizeChangedRevoker{};
+            winrt::Windows::UI::Xaml::FrameworkElement::Unloaded_revoker UnloadedEventToken{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerPressed_revoker PointerPressedRevoker{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerMoved_revoker PointerMovedRevoker{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerReleased_revoker PointerReleasedRevoker{};


### PR DESCRIPTION
When the view is unloaded, rendering keeps going and initialization promise created by resetview call is resolve almost immediately. Initialization is not done for a second view and no rendering is visible.