### PR TITLE
RN Windows/extra rendering frame bug

### DIFF
--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/EngineView.h
@@ -27,6 +27,8 @@ namespace winrt::BabylonReactNative::implementation {
         struct RevokerData
         {
             winrt::Windows::UI::Xaml::FrameworkElement::SizeChanged_revoker SizeChangedRevoker{};
+            winrt::Windows::UI::Xaml::FrameworkElement::Unloaded_revoker UnloadedEventToken{};
+            winrt::Windows::UI::Xaml::FrameworkElement::Loaded_revoker LoadedEventToken{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerPressed_revoker PointerPressedRevoker{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerMoved_revoker PointerMovedRevoker{};
             winrt::Windows::UI::Core::CoreIndependentInputSource::PointerReleased_revoker PointerReleasedRevoker{};

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -115,7 +115,7 @@ namespace BabylonNative
                 });
             }
             m_isRenderingEnabled = true;
-            m_pendingReset = false;
+            m_newEngine = false;
         }
 
         void UpdateMSAA(uint8_t value)
@@ -138,12 +138,7 @@ namespace BabylonNative
 
         void RenderView()
         {
-            // m_pendingReset becomes true when a resetView call has been performed and no UpdateView has been performed.
-            // This happens with a fast refresh when the view is not unmounted and it's still available for rendering.
-            // UpdateView will set back m_pendingReset to false in case the view is unmounted/mounted with Engine.Dispose for example.
-            // With fast refresh, we have to do that work on the UI/render thread, and UpdateView is not called in that case, 
-            // so RenderView is pretty much the only option. Specifically, it must be done on the UI/render thread and so RenderView is the only hook we have.
-            if (m_pendingReset)
+            if (m_newEngine)
             {
                 UpdateGraphicsConfiguration();
             }
@@ -158,13 +153,17 @@ namespace BabylonNative
             }
         }
 
+        void newEngine()
+        {
+            m_newEngine = true;
+        }
+
         void ResetView()
         {
             if (g_graphics)
             {
                 g_nativeCanvas->FlushGraphicResources();
                 g_graphics->DisableRendering();
-                m_pendingReset = true;
             }
 
             m_isRenderingEnabled = false;
@@ -266,11 +265,11 @@ namespace BabylonNative
         std::optional<Babylon::Plugins::NativeXr> m_nativeXr{};
 
         Babylon::Graphics::WindowConfiguration m_windowConfig{};
-        bool m_pendingReset{};
 
         std::shared_ptr<bool> m_isXRActive{};
         uint8_t mMSAAValue{};
         bool mAlphaPremultiplied{};
+        bool m_newEngine{};
     };
 
     namespace
@@ -286,6 +285,10 @@ namespace BabylonNative
             auto nativeModule{ std::make_shared<ReactNativeModule>(jsiRuntime, jsDispatcher) };
             jsiRuntime.global().setProperty(jsiRuntime, JS_INSTANCE_NAME, jsi::Object::createFromHostObject(jsiRuntime, nativeModule));
             g_nativeModule = nativeModule;
+        }
+        if (auto nativeModule{ g_nativeModule.lock() })
+        {
+            nativeModule->newEngine();
         }
     }
 

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -153,7 +153,7 @@ namespace BabylonNative
             }
         }
 
-        void newEngine()
+        void Initialize()
         {
             m_newEngine = true;
         }
@@ -288,7 +288,7 @@ namespace BabylonNative
         }
         if (auto nativeModule{ g_nativeModule.lock() })
         {
-            nativeModule->newEngine();
+            nativeModule->Initialize();
         }
     }
 


### PR DESCRIPTION
With RN Windows, when the view was unmounted, rendering calls keep being performed and view is not destroyed.
Added mount/unmount event to handle rendering.
With this fix in place, because of async, an extra frame rendering might happen after the resetView. As this resolves the initialization promise, its creation is done when a new engine is being created.