### PR TITLE
Agnostic toolset for VS project + std link issue with MSVC 17.2+

### DIFF
--- a/Modules/@babylonjs/react-native-windows/README.md
+++ b/Modules/@babylonjs/react-native-windows/README.md
@@ -10,3 +10,11 @@ This package has several **peer dependencies**. If these dependencies are unmet,
 
 This package will not work without installing the `@babylonjs/react-native` peer dependency.
 The `react-native-permissions` dependency is required for XR capabilities of Babylon.js.
+
+### Toolset
+
+Default toolset is v142. It's possible to change it using project variable named `BabylonReactNativeToolset`.
+There are multiple ways to specify it:
+- environment variable
+- msbuild property (`msbuild /p:BabylonReactNativeToolset=v143` for example)
+- customize the build by folder (https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022)

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonModule.cpp
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonModule.cpp
@@ -2,6 +2,12 @@
 #include "BabylonModule.h"
 #include "JSI/JsiApiContext.h"
 
+// see https://developercommunity.visualstudio.com/t/-imp-std-init-once-complete-unresolved-external-sy/1684365
+#if _MSC_VER >= 1932 // Visual Studio 2022 version 17.2+
+#    pragma comment(linker, "/alternatename:__imp___std_init_once_complete=__imp_InitOnceComplete")
+#    pragma comment(linker, "/alternatename:__imp___std_init_once_begin_initialize=__imp_InitOnceBeginInitialize")
+#endif
+
 using namespace winrt::BabylonReactNative::implementation;
 
 REACT_INIT(Initialize);

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -76,6 +76,8 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset Condition="'$(BabylonReactNativeToolSet)'!=''">$(BabylonReactNativeToolSet)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>

--- a/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
+++ b/Modules/@babylonjs/react-native-windows/windows/BabylonReactNative/BabylonReactNative.vcxproj
@@ -76,9 +76,6 @@
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>


### PR DESCRIPTION
Default toolset is v142. it can be overriden with `BabylonReactNativeToolset` property