### PR TITLE
fix permissions after basekit changes

### DIFF
--- a/Modules/@babylonjs/react-native/package.json
+++ b/Modules/@babylonjs/react-native/package.json
@@ -30,7 +30,8 @@
   "peerDependencies": {
     "@babylonjs/core": "^6.14.0",
     "react": ">=16.13.1",
-    "react-native": ">=0.63.1"
+    "react-native": ">=0.63.1",
+	"react-native-permissions": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",


### PR DESCRIPTION
Fix the regressions appearing after https://github.com/BabylonJS/BabylonReactNative/pull/598
An error with RNPermissionsModule not found.
I've reverted the change in the json and everything is fine again. 
Why is dependency needed in react-native package as it's already present in other packages like https://github.com/BabylonJS/BabylonReactNative/blob/313ee5c48003f0be1b4e6231a0cfea8aafec9155/Modules/%40babylonjs/react-native-iosandroid/package.json#L34 ?
Can this be an issue for basekit package ? @nima-ap 