### PR TITLE
Troubleshooting infos + react-native up for 0.69

### DIFF
--- a/Apps/Playground/0.69/package-lock.json
+++ b/Apps/Playground/0.69/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@babylonjs/core": "5.35.1",
-        "@babylonjs/loaders": "5.35.1",
+        "@babylonjs/core": "^6.14.0",
+        "@babylonjs/loaders": "6.14.0",
         "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
         "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
         "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",
         "@react-native-community/slider": "^4.0.0-rc.3",
         "react": "18.0.0",
-        "react-native": "0.69.3",
+        "react-native": "0.69.9",
         "react-native-permissions": "^3.0.0",
-        "react-native-windows": "0.69.3"
+        "react-native-windows": "0.69."
       },
       "devDependencies": {
         "@babel/core": "^7.12.9",
@@ -50,7 +50,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.35.1",
+        "@babylonjs/core": "6.14.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -67,10 +67,9 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@babylonjs/core": "5.35.1",
+        "@babylonjs/core": "^6.14.0",
         "react": ">=16.13.1",
-        "react-native": ">=0.63.1",
-        "react-native-permissions": "^3.0.0"
+        "react-native": ">=0.63.1"
       }
     },
     "../../../Modules/@babylonjs/react-native-iosandroid": {
@@ -102,7 +101,7 @@
       "devDependencies": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.35.1",
+        "@babylonjs/core": "6.14.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -120,7 +119,7 @@
         "typescript": "^3.8.3"
       },
       "peerDependencies": {
-        "@babylonjs/core": "5.35.1",
+        "@babylonjs/core": "^6.14.0",
         "@babylonjs/react-native": "version",
         "react": ">=17.0.1",
         "react-native": ">=0.64.0",
@@ -132,8 +131,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@babylonjs/core": "5.35.1",
-        "@babylonjs/loaders": "5.35.1",
+        "@babylonjs/core": "6.14.0",
+        "@babylonjs/loaders": "6.14.0",
         "@babylonjs/playground-shared": "file:../playground-shared",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
         "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
@@ -2161,17 +2160,17 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.35.1.tgz",
-      "integrity": "sha512-CJ61GcMFYN9mjgkKzM+fokM7/TRPc3LW4eAesENRSdX6nEngtn1B9FodqKMD1hnb6T30Cm907Lmse1AAHXzFvw=="
+      "version": "6.21.4",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-6.21.4.tgz",
+      "integrity": "sha512-RqzMwrEiZXBk/WuF0+NVECRhwh5jW1EQBPN6b276x8ANY9r5SDSbGRL0YK8HZtadymwwXjKsK6xKZ9D0xCmvig=="
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.35.1.tgz",
-      "integrity": "sha512-sC/oMwLG5cLO/Bmq5nFBX3sy4jwwbo9EodwbCVk4pfOTi4zRM5ZghgGu4xpEmFTd8PpWfbfzCTCV0HY7gDaO0A==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-6.14.0.tgz",
+      "integrity": "sha512-rGDMuyHEphpOHBO4JtY0vNIri2VMAmwUw3UmDJ+C00erQpiQDXyzG3IkJpXDHt7mWOJZNASRJjC76bPDu9zarg==",
       "peerDependencies": {
-        "@babylonjs/core": "^5.22.0",
-        "babylonjs-gltf2interface": "^5.22.0"
+        "@babylonjs/core": "^6.0.0",
+        "babylonjs-gltf2interface": "^6.0.0"
       }
     },
     "node_modules/@babylonjs/playground-shared": {
@@ -4916,9 +4915,9 @@
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.27.0.tgz",
-      "integrity": "sha512-9K1AFWVbIjvfWgZZ7cgWgzqSm+YHR2Z55zvj4pGYgA4dKZledNi4+ft4M9iRGjGYQviCIwf45acq2hHFdMOU3Q==",
+      "version": "6.21.4",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.21.4.tgz",
+      "integrity": "sha512-adeQTh6mkdQ3z52CMf5LjBncnyynMhtPu1hO9rD14FI4XsVxD50OG4brk/hoHVjLtFCyrEzeCGiOSo2z8TNj4A==",
       "peer": true
     },
     "node_modules/balanced-match": {
@@ -7178,19 +7177,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -11529,10 +11515,9 @@
       }
     },
     "node_modules/promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
-      "license": "MIT",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "dependencies": {
         "asap": "~2.0.6"
       }
@@ -11652,15 +11637,15 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.69.3",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.3.tgz",
-      "integrity": "sha512-SyGkcoEUa/BkO+wKVnv4OsnLSNfUM5zLNXS3iT/3eXjKX91/FKBH/nfR9BE1c60X5LQe/P5QYqr6WPX3TRSQkA==",
-      "license": "MIT",
+      "version": "0.69.9",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.9.tgz",
+      "integrity": "sha512-I1xqIn47RWxBToO4E6yqyIPSaK9mZnMiscMfrFpWjQr3Gdkicr9y+twmtrRszxaLdQLjHzh/M3y4qOqc3hZnpg==",
+      "deprecated": "Issues and pull requests filed against this version are not supported. See the React Native release support policy to learn more: https://github.com/reactwg/react-native-releases#releases-support-policy",
       "dependencies": {
         "@jest/create-cache-key-function": "^27.0.1",
-        "@react-native-community/cli": "^8.0.3",
-        "@react-native-community/cli-platform-android": "^8.0.2",
-        "@react-native-community/cli-platform-ios": "^8.0.2",
+        "@react-native-community/cli": "^8.0.4",
+        "@react-native-community/cli-platform-android": "^8.0.4",
+        "@react-native-community/cli-platform-ios": "^8.0.4",
         "@react-native/assets": "1.0.0",
         "@react-native/normalize-color": "2.0.0",
         "@react-native/polyfills": "2.0.0",
@@ -11678,9 +11663,9 @@
         "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
-        "promise": "^8.0.3",
+        "promise": "^8.2.0",
         "react-devtools-core": "4.24.0",
-        "react-native-codegen": "^0.69.1",
+        "react-native-codegen": "^0.69.2",
         "react-native-gradle-plugin": "^0.0.7",
         "react-refresh": "^0.4.0",
         "react-shallow-renderer": "16.15.0",
@@ -11702,10 +11687,9 @@
       }
     },
     "node_modules/react-native-codegen": {
-      "version": "0.69.1",
-      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.69.1.tgz",
-      "integrity": "sha512-TOZEqBarczcyYN3iZE3VpKkooOevaAzBq9n7lU0h9mQUvtRhLVyolc+a5K6cWI0e4v4K69I0MqzjPcPeFKo32Q==",
-      "license": "MIT",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.69.2.tgz",
+      "integrity": "sha512-yPcgMHD4mqLbckqnWjFBaxomDnBREfRjDi2G/WxNyPBQLD+PXUEmZTkDx6QoOXN+Bl2SkpnNOSsLE2+/RUHoPw==",
       "dependencies": {
         "@babel/parser": "^7.14.0",
         "flow-parser": "^0.121.0",
@@ -15652,21 +15636,21 @@
       }
     },
     "@babylonjs/core": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.35.1.tgz",
-      "integrity": "sha512-CJ61GcMFYN9mjgkKzM+fokM7/TRPc3LW4eAesENRSdX6nEngtn1B9FodqKMD1hnb6T30Cm907Lmse1AAHXzFvw=="
+      "version": "6.21.4",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-6.21.4.tgz",
+      "integrity": "sha512-RqzMwrEiZXBk/WuF0+NVECRhwh5jW1EQBPN6b276x8ANY9r5SDSbGRL0YK8HZtadymwwXjKsK6xKZ9D0xCmvig=="
     },
     "@babylonjs/loaders": {
-      "version": "5.35.1",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.35.1.tgz",
-      "integrity": "sha512-sC/oMwLG5cLO/Bmq5nFBX3sy4jwwbo9EodwbCVk4pfOTi4zRM5ZghgGu4xpEmFTd8PpWfbfzCTCV0HY7gDaO0A==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-6.14.0.tgz",
+      "integrity": "sha512-rGDMuyHEphpOHBO4JtY0vNIri2VMAmwUw3UmDJ+C00erQpiQDXyzG3IkJpXDHt7mWOJZNASRJjC76bPDu9zarg==",
       "requires": {}
     },
     "@babylonjs/playground-shared": {
       "version": "file:../playground-shared",
       "requires": {
-        "@babylonjs/core": "5.35.1",
-        "@babylonjs/loaders": "5.35.1",
+        "@babylonjs/core": "6.14.0",
+        "@babylonjs/loaders": "6.14.0",
         "@babylonjs/playground-shared": "file:",
         "@babylonjs/react-native": "file:../../../Modules/@babylonjs/react-native",
         "@babylonjs/react-native-iosandroid": "file:../../../Modules/@babylonjs/react-native-iosandroid",
@@ -15683,7 +15667,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.35.1",
+        "@babylonjs/core": "6.14.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -15721,7 +15705,7 @@
       "requires": {
         "@babel/core": "^7.8.4",
         "@babel/runtime": "^7.8.4",
-        "@babylonjs/core": "5.35.1",
+        "@babylonjs/core": "6.14.0",
         "@rnw-scripts/eslint-config": "0.1.6",
         "@rnw-scripts/ts-config": "0.1.0",
         "@types/base-64": "^0.1.3",
@@ -17694,9 +17678,9 @@
       }
     },
     "babylonjs-gltf2interface": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.27.0.tgz",
-      "integrity": "sha512-9K1AFWVbIjvfWgZZ7cgWgzqSm+YHR2Z55zvj4pGYgA4dKZledNi4+ft4M9iRGjGYQviCIwf45acq2hHFdMOU3Q==",
+      "version": "6.21.4",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-6.21.4.tgz",
+      "integrity": "sha512-adeQTh6mkdQ3z52CMf5LjBncnyynMhtPu1hO9rD14FI4XsVxD50OG4brk/hoHVjLtFCyrEzeCGiOSo2z8TNj4A==",
       "peer": true
     },
     "balanced-match": {
@@ -19276,12 +19260,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -22351,9 +22329,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "requires": {
         "asap": "~2.0.6"
       }
@@ -22438,14 +22416,14 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "react-native": {
-      "version": "0.69.3",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.3.tgz",
-      "integrity": "sha512-SyGkcoEUa/BkO+wKVnv4OsnLSNfUM5zLNXS3iT/3eXjKX91/FKBH/nfR9BE1c60X5LQe/P5QYqr6WPX3TRSQkA==",
+      "version": "0.69.9",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.69.9.tgz",
+      "integrity": "sha512-I1xqIn47RWxBToO4E6yqyIPSaK9mZnMiscMfrFpWjQr3Gdkicr9y+twmtrRszxaLdQLjHzh/M3y4qOqc3hZnpg==",
       "requires": {
         "@jest/create-cache-key-function": "^27.0.1",
-        "@react-native-community/cli": "^8.0.3",
-        "@react-native-community/cli-platform-android": "^8.0.2",
-        "@react-native-community/cli-platform-ios": "^8.0.2",
+        "@react-native-community/cli": "^8.0.4",
+        "@react-native-community/cli-platform-android": "^8.0.4",
+        "@react-native-community/cli-platform-ios": "^8.0.4",
         "@react-native/assets": "1.0.0",
         "@react-native/normalize-color": "2.0.0",
         "@react-native/polyfills": "2.0.0",
@@ -22463,9 +22441,9 @@
         "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^26.5.2",
-        "promise": "^8.0.3",
+        "promise": "^8.2.0",
         "react-devtools-core": "4.24.0",
-        "react-native-codegen": "^0.69.1",
+        "react-native-codegen": "^0.69.2",
         "react-native-gradle-plugin": "^0.0.7",
         "react-refresh": "^0.4.0",
         "react-shallow-renderer": "16.15.0",
@@ -22488,9 +22466,9 @@
       }
     },
     "react-native-codegen": {
-      "version": "0.69.1",
-      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.69.1.tgz",
-      "integrity": "sha512-TOZEqBarczcyYN3iZE3VpKkooOevaAzBq9n7lU0h9mQUvtRhLVyolc+a5K6cWI0e4v4K69I0MqzjPcPeFKo32Q==",
+      "version": "0.69.2",
+      "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.69.2.tgz",
+      "integrity": "sha512-yPcgMHD4mqLbckqnWjFBaxomDnBREfRjDi2G/WxNyPBQLD+PXUEmZTkDx6QoOXN+Bl2SkpnNOSsLE2+/RUHoPw==",
       "requires": {
         "@babel/parser": "^7.14.0",
         "flow-parser": "^0.121.0",

--- a/Apps/Playground/0.69/package.json
+++ b/Apps/Playground/0.69/package.json
@@ -21,7 +21,7 @@
     "@babylonjs/react-native-windows": "file:../../../Modules/@babylonjs/react-native-windows",
     "@react-native-community/slider": "^4.0.0-rc.3",
     "react": "18.0.0",
-    "react-native": "0.69.3",
+    "react-native": "0.69.9",
     "react-native-permissions": "^3.0.0",
     "react-native-windows": "0.69.3"
   },

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 - Android Studio is the tool of choice for downloading the various versions of NDK.
 - If something goes wrong with the build `npm run android --verbose` can give some hints.
 - If the emulator is not launched by the build, you can run `~/Android/Sdk/emulator/emulator @name_of_your_image`.
+- If `ld: library not found for -lBabylonNative` appears when building for iOS, this is because of CMake 3.26+. use 3.24 or remove `CONFIGURATION_BUILD_DIR`entries for every ReactNativeBabylon projects.
 - For other emulator issues, follow the [instructions](https://github.com/BabylonJS/BabylonNative/blob/master/Documentation/AndroidEmulator.md) from Babylon Native documentation.
 - Refer to the [Babylon Native documentation](https://github.com/BabylonJS/BabylonNative/tree/master/Documentation#babylon-native-documention) for additional information that may help troubleshoot issues.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 - Android Studio is the tool of choice for downloading the various versions of NDK.
 - If something goes wrong with the build `npm run android --verbose` can give some hints.
 - If the emulator is not launched by the build, you can run `~/Android/Sdk/emulator/emulator @name_of_your_image`.
-- If `ld: library not found for -lBabylonNative` appears when building for iOS, this is because of CMake 3.26+. use 3.24 or remove `CONFIGURATION_BUILD_DIR`entries for every ReactNativeBabylon projects.
+- If `ld: library not found for -lBabylonNative` appears when building for iOS, this is because of CMake 3.26+. use 3.24 or remove `CONFIGURATION_BUILD_DIR`entries for every `.pbxproj` file.
 - For other emulator issues, follow the [instructions](https://github.com/BabylonJS/BabylonNative/blob/master/Documentation/AndroidEmulator.md) from Babylon Native documentation.
 - Refer to the [Babylon Native documentation](https://github.com/BabylonJS/BabylonNative/tree/master/Documentation#babylon-native-documention) for additional information that may help troubleshoot issues.
 


### PR DESCRIPTION
Small fixes while testing PG 0.69 targeting iOS.
- react-native is upgraded to 0.69.9 because of an deployment issue with `React-Codegen` with 0.69.3
- Added troubleshooting info because of cmake 3.26 and link folders issue
