### PR TITLE
fix podspec include path for BabylonInterop

### DIFF
--- a/Modules/@babylonjs/react-native-iosandroid/ios/BabylonNativeInterop.mm
+++ b/Modules/@babylonjs/react-native-iosandroid/ios/BabylonNativeInterop.mm
@@ -1,5 +1,5 @@
 #import "BabylonNativeInterop.h"
-#import "../../react-native/shared/BabylonNative.h"
+#import "BabylonNative.h"
 
 #import <React/RCTBridge+Private.h>
 #import <jsi/jsi.h>

--- a/Modules/@babylonjs/react-native-iosandroid/react-native-babylon.podspec
+++ b/Modules/@babylonjs/react-native-iosandroid/react-native-babylon.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/*.{h,m,mm}"
   s.requires_arc = true
+  s.xcconfig     = { 'USER_HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_TARGET_SRCROOT}/shared ${PODS_TARGET_SRCROOT}/..react-native/shared' }
 
   s.libraries = 'astc-encoder',
                 'etc1',

--- a/Package/BaseKit/react-native-babylon.podspec
+++ b/Package/BaseKit/react-native-babylon.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm}"
   s.requires_arc = true
+  s.xcconfig     = { 'USER_HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_TARGET_SRCROOT}/shared ${PODS_TARGET_SRCROOT}/..react-native/shared' }
 
   s.vendored_libraries = 'ios/libs/libastc-encoder.a',
     'ios/libs/libBabylonNative.a',

--- a/Package/react-native-babylon.podspec
+++ b/Package/react-native-babylon.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm}"
   s.requires_arc = true
+  s.xcconfig     = { 'USER_HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_TARGET_SRCROOT}/shared ${PODS_TARGET_SRCROOT}/..react-native/shared' }
 
   s.vendored_libraries = 'ios/libs/*.a'
 


### PR DESCRIPTION
add include path in podspec so including BabylonNative works with 'Legacy' BRN package or with https://github.com/BabylonJS/BabylonReactNative/pull/615