### PR TITLE
Swap start/finish order for rendering

### DIFF
--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -103,8 +103,11 @@ namespace BabylonNative
             }
             else
             {
-                g_update->Finish();
-                g_graphicsDevice->FinishRenderingCurrentFrame();
+                if (m_isRenderingEnabled)
+                {
+                    g_update->Finish();
+                    g_graphicsDevice->FinishRenderingCurrentFrame();
+                }
 
                 g_graphicsDevice->UpdateWindow(m_graphicsConfig.Window);
                 g_graphicsDevice->UpdateSize(m_graphicsConfig.Width, m_graphicsConfig.Height);
@@ -181,6 +184,8 @@ namespace BabylonNative
         {
             if (g_graphicsDevice)
             {
+                g_update->Finish();
+                g_graphicsDevice->FinishRenderingCurrentFrame();
                 g_nativeCanvas->FlushGraphicResources();
                 g_graphicsDevice->DisableRendering();
             }

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -73,6 +73,12 @@ namespace BabylonNative
 
         ~ReactNativeModule() override
         {
+            if (g_graphicsDevice)
+            {
+                g_update->Finish();
+                g_graphicsDevice->FinishRenderingCurrentFrame();
+            }
+
             *m_isRunning = false;
             Napi::Detach(m_env);
         }
@@ -91,11 +97,20 @@ namespace BabylonNative
             {
                 g_graphicsDevice.emplace(m_graphicsConfig);
                 g_update.emplace(g_graphicsDevice->GetUpdate("update"));
+
+                g_graphicsDevice->StartRenderingCurrentFrame();
+                g_update->Start();
             }
             else
             {
+                g_update->Finish();
+                g_graphicsDevice->FinishRenderingCurrentFrame();
+
                 g_graphicsDevice->UpdateWindow(m_graphicsConfig.Window);
                 g_graphicsDevice->UpdateSize(m_graphicsConfig.Width, m_graphicsConfig.Height);
+
+                g_graphicsDevice->StartRenderingCurrentFrame();
+                g_update->Start();
             }
             g_graphicsDevice->UpdateMSAA(mMSAAValue);
             g_graphicsDevice->UpdateAlphaPremultiplied(mAlphaPremultiplied);
@@ -150,10 +165,10 @@ namespace BabylonNative
             // Otherwise rendering can be implicitly enabled, which may not be desirable (e.g. after the engine is disposed).
             if (g_graphicsDevice && m_isRenderingEnabled)
             {
-                g_graphicsDevice->StartRenderingCurrentFrame();
-                g_update->Start();
                 g_update->Finish();
                 g_graphicsDevice->FinishRenderingCurrentFrame();
+                g_graphicsDevice->StartRenderingCurrentFrame();
+                g_update->Start();
             }
         }
 

--- a/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
+++ b/Modules/@babylonjs/react-native/shared/BabylonNative.cpp
@@ -97,9 +97,6 @@ namespace BabylonNative
             {
                 g_graphicsDevice.emplace(m_graphicsConfig);
                 g_update.emplace(g_graphicsDevice->GetUpdate("update"));
-
-                g_graphicsDevice->StartRenderingCurrentFrame();
-                g_update->Start();
             }
             else
             {
@@ -111,14 +108,12 @@ namespace BabylonNative
 
                 g_graphicsDevice->UpdateWindow(m_graphicsConfig.Window);
                 g_graphicsDevice->UpdateSize(m_graphicsConfig.Width, m_graphicsConfig.Height);
-
-                g_graphicsDevice->StartRenderingCurrentFrame();
-                g_update->Start();
             }
             g_graphicsDevice->UpdateMSAA(mMSAAValue);
             g_graphicsDevice->UpdateAlphaPremultiplied(mAlphaPremultiplied);
 
-            g_graphicsDevice->EnableRendering();
+            g_graphicsDevice->StartRenderingCurrentFrame();
+            g_update->Start();
 
             std::call_once(m_isGraphicsInitialized, [this]()
             {


### PR DESCRIPTION
In this change, the order of start/finish for rendering (`Graphics::Device` and `Graphics::DeviceUpdate`) is swapped (similar to what was already done in the BN Playground app). This is more efficient as it results in less blocked time on the main thread, and should also allow the JS thread to start its per-frame work earlier. Without these changes, there can be more "fighting" for CPU time between BN and platform UI. I tested these changes by adding a large React Native `FlatList` into the main screen of the Playground app, and testing how scrolling the `FlatList` while interacting with the scene affected performance. Just looking at the frame rate, it seems like I get about a 10% improvement in performance (both Android and iOS). I expect we'd get better gains on Android with future work moving the rendering off the main thread entirely.

**Testing**
I tested pretty thoroughly with the Playground app on Android and iOS. I wasn't able to get a Windows build working (haven't tried in a long time), so I haven't tested on Windows (could use some help here 🙏🏻).
