### PR TITLE
Markdown to HTML in gulp script

### DIFF
--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -8,12 +8,35 @@ const shelljs = require('shelljs');
 const rename = require('gulp-rename');
 const glob = require('glob');
 const chalk = require('chalk');
+const marked = require('marked');
 
 let assemblediOSAndroidDir = 'Assembled-iOSAndroid';
 let assembledWindowsDir = 'Assembled-Windows';
 let basekitBuild = false;
 let cmakeBasekitBuildDefinition = '';
 let basekitPackagePath = '';
+
+
+const makeHTMLNotice = async () => {
+  fs.readFile('../README.md', 'utf8', (err, data) => {
+    if (err) {
+      console.error('Error reading file:', err);
+      return;
+    }
+
+    // Convert Markdown to HTML
+    const html = marked.parse(data);
+
+    // Write the HTML to a file
+    fs.writeFile('../NOTICE.html', html, 'utf8', err => {
+      if (err) {
+        console.error('Error writing file:', err);
+        return;
+      }
+      console.log('NOTICE Conversion complete!');
+    });
+});
+};
 
 function exec(command, workingDirectory = '.', logCommand = true) {
   if (logCommand) {
@@ -615,6 +638,8 @@ const buildIOSAndroid = gulp.series(patchPackageVersion, buildIOS, buildAndroid,
 const build = gulp.series(buildIOSAndroid, switchToBaseKit, buildIOSAndroid);
 const rebuild = gulp.series(clean, build);
 const pack = gulp.series(rebuild, createPackage);
+
+exports.buildNotice = makeHTMLNotice;
 
 exports.validateAssembled = validateAssembled;
 exports.validateAssemblediOSAndroid = validateAssemblediOSAndroid;

--- a/Package/package-lock.json
+++ b/Package/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "marked": "^4.3.0"
+      },
       "devDependencies": {
         "chalk": "^4.1.1",
         "fancy-log": "^1.3.3",
@@ -2359,6 +2362,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/matchdep": {
@@ -6101,6 +6115,11 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "matchdep": {
       "version": "2.0.0",

--- a/Package/package.json
+++ b/Package/package.json
@@ -7,5 +7,8 @@
     "gulp": "^4.0.2",
     "gulp-rename": "2.0.0",
     "shelljs": "^0.8.4"
+  },
+  "dependencies": {
+    "marked": "^4.3.0"
   }
 }


### PR DESCRIPTION
gulp script that converts a .MD file to Notice.html that can then be packaged with the npm.
As a test, this script converts the readme file.

Result:

![image](https://github.com/BabylonJS/BabylonReactNative/assets/1312968/151c886a-d0c6-4a8c-b2bc-a38649bca611)

TODO:
- get the notice.md file
- add the buildNotice step into the build/package process