### PR TITLE
fix: add support for merged so libraries

### DIFF
--- a/Modules/@babylonjs/react-native-iosandroid/android/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native-iosandroid/android/CMakeLists.txt
@@ -56,8 +56,11 @@ else()
     set(ADDITIONAL_LIBRARIES NativeXr NativeCamera)
 endif()
 
-set(TURBOMODULE_DIR "${REACTNATIVE_DIR_CMAKE}/ReactAndroid/src/main/jni/react/turbomodule/")
-if (EXISTS "${TURBOMODULE_DIR}/CMakeLists.txt")
+# Prefab packages from React Native
+find_package(ReactAndroid REQUIRED CONFIG)
+find_package(fbjni REQUIRED CONFIG)
+
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 71)
    # >= React Native 0.71 with prefabs
    include(${REACTNATIVE_DIR_CMAKE}/ReactAndroid/cmake-utils/folly-flags.cmake)
 
@@ -84,77 +87,80 @@ if (EXISTS "${TURBOMODULE_DIR}/CMakeLists.txt")
         ${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni)
 
     target_compile_options(BabylonNative PRIVATE -Wall -Werror -fexceptions -frtti -std=c++17 -DWITH_INSPECTOR=1 -DLOG_TAG=\"ReactNative\")
-
-    # Prefab packages from React Native
-    find_package(ReactAndroid REQUIRED CONFIG)
-    add_library(react_render_debug ALIAS ReactAndroid::react_render_debug)
-    add_library(turbomodulejsijni ALIAS ReactAndroid::turbomodulejsijni)
-    add_library(runtimeexecutor ALIAS ReactAndroid::runtimeexecutor)
-    add_library(react_codegen_rncore ALIAS ReactAndroid::react_codegen_rncore)
-    add_library(react_debug ALIAS ReactAndroid::react_debug)
-    add_library(react_render_componentregistry ALIAS ReactAndroid::react_render_componentregistry)
-    add_library(react_newarchdefaults ALIAS ReactAndroid::react_newarchdefaults)
-    add_library(react_render_core ALIAS ReactAndroid::react_render_core)
-    add_library(react_render_graphics ALIAS ReactAndroid::react_render_graphics)
-    add_library(rrc_view ALIAS ReactAndroid::rrc_view)
-    add_library(jsi ALIAS ReactAndroid::jsi)
-    add_library(glog ALIAS ReactAndroid::glog)
-    add_library(fabricjni ALIAS ReactAndroid::fabricjni)
-    add_library(react_render_mapbuffer ALIAS ReactAndroid::react_render_mapbuffer)
-    add_library(yoga ALIAS ReactAndroid::yoga)
-    add_library(folly_runtime ALIAS ReactAndroid::folly_runtime)
-    add_library(react_nativemodule_core ALIAS ReactAndroid::react_nativemodule_core)
-    add_library(react_render_imagemanager ALIAS ReactAndroid::react_render_imagemanager)
-    add_library(rrc_image ALIAS ReactAndroid::rrc_image)
-
-    find_package(fbjni REQUIRED CONFIG)
     add_library(fbjni ALIAS fbjni::fbjni)
 
-    target_link_libraries(BabylonNative
-        GLESv3
-        android
-        EGL
-        log
-        -lz
-        arcana
-        fabricjni                           # prefab ready
-        fbjni                               # via 3rd party prefab
-        folly_runtime                       # prefab ready
-        glog                                # prefab ready
-        jsi                                 # prefab ready
-        react_codegen_rncore                # prefab ready
-        react_debug                         # prefab ready
-        react_nativemodule_core             # prefab ready
-        react_newarchdefaults               # prefab ready
-        react_render_componentregistry      # prefab ready
-        react_render_core                   # prefab ready
-        react_render_debug                  # prefab ready
-        react_render_graphics               # prefab ready
-        react_render_imagemanager           # prefab ready
-        react_render_mapbuffer              # prefab ready
-        rrc_image                           # prefab ready
-        rrc_view                            # prefab ready
-        runtimeexecutor                     # prefab ready
-        turbomodulejsijni                   # prefab ready
-        yoga                                # prefab ready
-        AndroidExtensions
-        GraphicsDevice
-        JsRuntime
-        NativeCapture
-        NativeEngine
-        NativeInput
-        NativeOptimizations
-        NativeTracing
-        Window
-        XMLHttpRequest
-        Canvas
-        ${ADDITIONAL_LIBRARIES})
+    # React Native introduced merged .so libraries in 0.76.0
+    # https://github.com/react-native-community/discussions-and-proposals/discussions/816
+    if (REACTNATIVE_MERGED_SO OR ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+        target_link_libraries(BabylonNative
+            GLESv3
+            android
+            EGL
+            log
+            -lz
+            arcana
+            ReactAndroid::reactnative
+            ReactAndroid::jsi
+            fbjni
+            AndroidExtensions
+            GraphicsDevice
+            JsRuntime
+            NativeCapture
+            NativeEngine
+            NativeInput
+            NativeOptimizations
+            NativeTracing
+            Window
+            XMLHttpRequest
+            Canvas
+            ${ADDITIONAL_LIBRARIES})
+    else()
+        target_link_libraries(BabylonNative
+            GLESv3
+            android
+            EGL
+            log
+            -lz
+            arcana
+            ReactAndroid::fabricjni                           # prefab ready
+            fbjni::fbjni                                      # via 3rd party prefab
+            ReactAndroid::folly_runtime                       # prefab ready
+            ReactAndroid::glog                                # prefab ready
+            ReactAndroid::jsi                                 # prefab ready
+            ReactAndroid::react_codegen_rncore                # prefab ready
+            ReactAndroid::react_debug                         # prefab ready
+            ReactAndroid::react_nativemodule_core             # prefab ready
+            ReactAndroid::react_newarchdefaults               # prefab ready
+            ReactAndroid::react_render_componentregistry      # prefab ready
+            ReactAndroid::react_render_core                   # prefab ready
+            ReactAndroid::react_render_debug                  # prefab ready
+            ReactAndroid::react_render_graphics               # prefab ready
+            ReactAndroid::react_render_imagemanager           # prefab ready
+            ReactAndroid::react_render_mapbuffer              # prefab ready
+            ReactAndroid::rrc_image                           # prefab ready
+            ReactAndroid::rrc_view                            # prefab ready
+            ReactAndroid::runtimeexecutor                     # prefab ready
+            ReactAndroid::turbomodulejsijni                   # prefab ready
+            ReactAndroid::yoga                                # prefab ready
+            AndroidExtensions
+            GraphicsDevice
+            JsRuntime
+            NativeCapture
+            NativeEngine
+            NativeInput
+            NativeOptimizations
+            NativeTracing
+            Window
+            XMLHttpRequest
+            Canvas
+            ${ADDITIONAL_LIBRARIES})
 
-    # We use an interface target to propagate flags to all the generated targets
-    # such as the folly flags or others.
-    add_library(common_flags INTERFACE)
-    target_compile_options(common_flags INTERFACE ${folly_FLAGS})
-    target_link_libraries(ReactAndroid::react_codegen_rncore INTERFACE common_flags)
+        # We use an interface target to propagate flags to all the generated targets
+        # such as the folly flags or others.
+       add_library(common_flags INTERFACE)
+       target_compile_options(common_flags INTERFACE ${folly_FLAGS})
+       target_link_libraries(ReactAndroid::react_codegen_rncore INTERFACE common_flags)
+    endif()
 
     # If project is on RN CLI v9, then we can use the following lines to link against the autolinked 3rd party libraries.
     if(EXISTS ${PROJECT_BUILD_DIR}/generated/rncli/src/main/jni/Android-rncli.cmake)

--- a/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
+++ b/Modules/@babylonjs/react-native-iosandroid/android/build.gradle
@@ -62,9 +62,6 @@ buildscript {
 }
 
 def graphics_api = safeExtGet('GRAPHICS_API', "OpenGL")
-
-apply plugin: 'com.android.library'
-
 configurations {
     extractHeaders
     extractLibs


### PR DESCRIPTION
**Describe the change**

This PR adds support for React Native 0.76 merged .so libraries, reference: https://github.com/react-native-community/discussions-and-proposals/discussions/816

**Documentation**

N/A

**Testing**

Try to build the app for 0.76

The app is built properly but Im getting corrupted stack issues, both on 0.75 (without merged so) and 0.76 (with merged so) but this is mostly build-related change so verifying if the library builds properly is the most important step. I'm looking into the corrupted stack issues
