### PR TITLE
Fix Xcode 26 build: suppress deprecated-declarations + BABYLON_USE_SYSTEM_CMAKE env var

### DIFF
--- a/Modules/@babylonjs/react-native/README.md
+++ b/Modules/@babylonjs/react-native/README.md
@@ -61,7 +61,7 @@ Babylon.js minimal version:
 
 |BabylonReactNative version | Babylon.js version | BabylonNative commit |
 | ----------- | ------------------------ | --- |
-|2.0.2 | 9.0.0 | 887a044
+|2.0.2 | 9.0.0 | ce2edf0851e0c8483559832a4f8eb9d39c6b2f53
 |2.0.0 | 8.3.0 | 6c25966e8f8c0f3a0c13fdf77064f1bde790391f
 
 

--- a/Modules/@babylonjs/react-native/README.md
+++ b/Modules/@babylonjs/react-native/README.md
@@ -34,6 +34,11 @@ To disable post install CMake generation, set this variable before running `npm 
 export BABYLON_NO_CMAKE_POSTINSTALL=1
 ```
 
+To use the system cmake (e.g. a Homebrew or system install) instead of the cmake bundled in the npm package, set this variable before running `npm install`:
+```
+export BABYLON_USE_SYSTEM_CMAKE=1
+```
+
 ### Plugins selection
 
 Plugins can be disabled at build time. They are all enabled by default and disabling is done with environment variables:
@@ -56,6 +61,7 @@ Babylon.js minimal version:
 
 |BabylonReactNative version | Babylon.js version | BabylonNative commit |
 | ----------- | ------------------------ | --- |
+|2.0.2 | 9.0.0 | 887a044
 |2.0.0 | 8.3.0 | 6c25966e8f8c0f3a0c13fdf77064f1bde790391f
 
 

--- a/Modules/@babylonjs/react-native/ios/CMakeLists.txt
+++ b/Modules/@babylonjs/react-native/ios/CMakeLists.txt
@@ -19,6 +19,12 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x objective-c++")
 
+# wstring_convert and codecvt_utf8_utf16 are deprecated in C++17; prevent this from
+# being treated as a hard error so the build succeeds on Xcode 26+ / Clang 20+.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    add_compile_options(-Wno-deprecated-declarations)
+endif()
+
 set(BABYLON_NATIVE_PLUGIN_NATIVEXR 1)
 if(DEFINED ENV{BABYLON_NATIVE_PLUGIN_NATIVEXR})
     set(BABYLON_NATIVE_PLUGIN_NATIVEXR $ENV{BABYLON_NATIVE_PLUGIN_NATIVEXR})

--- a/Modules/@babylonjs/react-native/postinstall.js
+++ b/Modules/@babylonjs/react-native/postinstall.js
@@ -2,6 +2,11 @@ const os = require("os");
 const path = require("path");
 
 function getCmakeExecutable() {
+  // When BABYLON_USE_SYSTEM_CMAKE=1, skip the npm cmake package and use whatever
+  // cmake is found on PATH (e.g. a Homebrew or system install).
+  if (process.env.BABYLON_USE_SYSTEM_CMAKE === '1') {
+    return 'cmake';
+  }
   try {
     // cmake-runtime ships the cmake binary; resolve it directly to avoid
     // relying on npx or PATH.

--- a/Package/gulpfile.js
+++ b/Package/gulpfile.js
@@ -230,7 +230,7 @@ const createPackage = async () => {
   exec('npm pack', 'Assembled');
 };
 
-const COMMIT_ID = '887a0446c2ce5d379d931d802071cf6f9e008c6a';
+const COMMIT_ID = 'ce2edf0851e0c8483559832a4f8eb9d39c6b2f53';
 const ZIP_URL = `https://github.com/BabylonJS/BabylonNative/archive/${COMMIT_ID}.zip`;
 const TARGET_DIR = path.resolve(__dirname, '../Modules/@babylonjs/react-native/shared/BabylonNative');
 const ZIP_PATH = path.join(TARGET_DIR, `${COMMIT_ID}.zip`);


### PR DESCRIPTION
## Summary

This PR addresses two issues when building BabylonReactNative with Xcode 26 (Clang 20) and adds a quality-of-life improvement for cmake usage.

### Fix: Xcode 26 `-Wdeprecated-declarations` build failure

Xcode 26 / Clang 20 promotes `wstring_convert<std::codecvt_utf8_utf16<char16_t>>` deprecation warnings to hard errors under `-Werror` (set by BabylonNative’s `warnings_as_errors()` in `cmakeextensions`). The `#pragma GCC diagnostic ignored` suppression in `napi-inl.h` is not sufficient in this context.

**Fix:** Add `-Wno-deprecated-declarations` to the iOS CMake target compile options, guarded by a Clang/AppleClang compiler check.

**Files changed:**
- `Modules/@babylonjs/react-native/ios/CMakeLists.txt`

### Feature: `BABYLON_USE_SYSTEM_CMAKE` environment variable

The `postinstall.js` script previously always tried to resolve `cmake` from the npm `cmake-runtime` package, falling back to PATH only on error. Some environments (CI, Homebrew, custom toolchains) have a preferred `cmake` on PATH that should take precedence.

**Fix:** Add `BABYLON_USE_SYSTEM_CMAKE=1` env variable: when set, `getCmakeExecutable()` immediately returns `cmake` (from PATH) without attempting to resolve the npm package.

**Files changed:**
- `Modules/@babylonjs/react-native/postinstall.js`
- `Modules/@babylonjs/react-native/README.md` — documents the new variable and adds 2.0.2 row to the Platform Native Packages version table
- `Package/gulpfile.js` — update BabylonNative to latest master commit (`ce2edf08`)

### Usage
```sh
export BABYLON_USE_SYSTEM_CMAKE=1
npm install
```